### PR TITLE
Add apocalypse color theme

### DIFF
--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-md mx-auto px-6 py-12 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md">
-        <h2 class="text-2xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6 text-center">
+    <div class="max-w-md mx-auto px-6 py-12 bg-apocalypse-dark text-gray-100 rounded-lg shadow-md">
+        <h2 class="text-2xl font-bold text-apocalypse-accent mb-6 text-center">
             {{ __('Passwort vergessen') }}
         </h2>
 

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-md mx-auto px-6 py-12 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md">
-        <h2 class="text-2xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6 text-center">
+    <div class="max-w-md mx-auto px-6 py-12 bg-apocalypse-dark text-gray-100 rounded-lg shadow-md">
+        <h2 class="text-2xl font-bold text-apocalypse-accent mb-6 text-center">
             {{ __('Login') }}
         </h2>
         <x-validation-errors class="mb-4" />

--- a/resources/views/components/authentication-card.blade.php
+++ b/resources/views/components/authentication-card.blade.php
@@ -1,4 +1,4 @@
-<div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100 dark:bg-gray-900">
+<div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-apocalypse-dark text-gray-100">
     <div>
         {{ $logo }}
     </div>

--- a/resources/views/components/confirmation-modal.blade.php
+++ b/resources/views/components/confirmation-modal.blade.php
@@ -21,7 +21,7 @@
         </div>
     </div>
 
-    <div class="flex flex-row justify-end px-6 py-4 bg-gray-100 dark:bg-gray-800 text-end">
+    <div class="flex flex-row justify-end px-6 py-4 bg-apocalypse-dark text-gray-100 text-end">
         {{ $footer }}
     </div>
 </x-modal>

--- a/resources/views/components/dialog-modal.blade.php
+++ b/resources/views/components/dialog-modal.blade.php
@@ -11,7 +11,7 @@
         </div>
     </div>
 
-    <div class="flex flex-row justify-end px-6 py-4 bg-gray-100 dark:bg-gray-800 text-end">
+    <div class="flex flex-row justify-end px-6 py-4 bg-apocalypse-dark text-gray-100 text-end">
         {{ $footer }}
     </div>
 </x-modal>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -11,49 +11,49 @@
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
                 <!-- Mitgliederzahl Card -->
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Aktuelle Mitgliederzahl</h2>
+                    <h2 class="text-lg font-semibold text-apocalypse-accent mb-2">Aktuelle Mitgliederzahl</h2>
                     <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
                         {{ $memberCount }}
                     </div>
                 </div>
                 <!-- Offene Aufgaben Card -->
                 <a href="{{ route('todos.index') }}" class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Offene Challenges</h2>
+                    <h2 class="text-lg font-semibold text-apocalypse-accent mb-2">Offene Challenges</h2>
                     <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
                         {{ $openTodos }}
                     </div>
                 </a>
                 <!-- Baxx Card -->
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Meine Baxx</h2>
+                    <h2 class="text-lg font-semibold text-apocalypse-accent mb-2">Meine Baxx</h2>
                     <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
                         {{ $userPoints }}
                     </div>
                 </div>
                 <!-- Erledigte Aufgaben Card -->
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Abgeschlossene Challenges</h2>
+                    <h2 class="text-lg font-semibold text-apocalypse-accent mb-2">Abgeschlossene Challenges</h2>
                     <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
                         {{ $completedTodos }}
                     </div>
                 </div>
                 <!-- Gesamtanzahl Rezensionen Card -->
                 <a href="{{ route('reviews.index') }}" class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Alle Rezensionen</h2>
+                    <h2 class="text-lg font-semibold text-apocalypse-accent mb-2">Alle Rezensionen</h2>
                     <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
                         {{ $allReviews }}
                     </div>
                 </a>
                 <!-- Meine Rezensionen Card -->
                 <a href="{{ route('reviews.index') }}" class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Meine Rezensionen</h2>
+                    <h2 class="text-lg font-semibold text-apocalypse-accent mb-2">Meine Rezensionen</h2>
                     <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
                         {{ $myReviews }}
                     </div>
                 </a>
                 <!-- Meine Kommentare Card -->
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Meine Kommentare</h2>
+                    <h2 class="text-lg font-semibold text-apocalypse-accent mb-2">Meine Kommentare</h2>
                     <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
                         {{ $myReviewComments }}
                     </div>
@@ -61,7 +61,7 @@
             </div>
             <!-- Aktivitäten Card -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-8">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-4">Aktivitäten</h2>
+                <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">Aktivitäten</h2>
                 <ul class="divide-y divide-gray-200 dark:divide-gray-700">
                     @forelse($activities as $activity)
                         <li class="py-2 flex justify-between">
@@ -93,7 +93,7 @@
             </div>
             <!-- TOP 3 Mitglieder -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-8">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-6">TOP 3 Baxx-Sammler</h2>
+                <h2 class="text-xl font-semibold text-apocalypse-accent mb-6">TOP 3 Baxx-Sammler</h2>
                 
                 @if(count($topUsers) > 0)
                     <div class="flex flex-col md:flex-row items-center md:items-start justify-center gap-6 md:gap-10">
@@ -125,8 +125,8 @@
                                     </div>
                                 @endif
                                 
-                                <h3 class="text-lg font-semibold text-gray-800 dark:text-white mt-2 group-hover:text-[#8B0116] dark:group-hover:text-[#FCA5A5] transition-colors">{{ $topUser['name'] }}</h3>
-                                <p class="font-bold text-xl text-[#8B0116] dark:text-[#FCA5A5]">{{ $topUser['points'] }}</p>
+                                <h3 class="text-lg font-semibold text-gray-800 dark:text-white mt-2 group-hover:text-apocalypse-accent dark:group-hover:text-[#FCA5A5] transition-colors">{{ $topUser['name'] }}</h3>
+                                <p class="font-bold text-xl text-apocalypse-accent">{{ $topUser['points'] }}</p>
                                 <p class="text-xs text-gray-500 dark:text-gray-400">Baxx</p>
                             </a>
                         @endforeach
@@ -139,11 +139,11 @@
             @if(in_array($userRole, $allowedRoles) && $pendingVerification > 0)
                 <a href="{{ route('todos.index') }}?filter=pending" class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-8 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
                     <div>
-                        <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-1">Auf Verifizierung wartende Challenges</h2>
+                        <h2 class="text-lg font-semibold text-apocalypse-accent mb-1">Auf Verifizierung wartende Challenges</h2>
                         <p class="text-gray-600 dark:text-gray-400 text-sm">Es gibt {{ $pendingVerification }} Challenge(s), die auf Bestätigung warten</p>
                     </div>
                     <div class="flex items-center">
-                        <div class="text-3xl font-bold text-[#8B0116] dark:text-[#FCA5A5] mr-4">{{ $pendingVerification }}</div>
+                        <div class="text-3xl font-bold text-apocalypse-accent mr-4">{{ $pendingVerification }}</div>
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-500 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                         </svg>
@@ -153,7 +153,7 @@
             <!-- Anwärter-Liste für Kassenwart, Vorstand und Admin -->
             @if($anwaerter->isNotEmpty())
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-4">Mitgliedsanträge</h2>
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">Mitgliedsanträge</h2>
                     <!-- Desktop-Ansicht (versteckt auf Mobilgeräten) -->
                     <div class="hidden md:block overflow-auto">
                         <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,11 +1,11 @@
 <x-app-layout>
     <div class="container mx-auto py-12 text-center">
-        <h1 class="text-5xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6">403</h1>
+        <h1 class="text-5xl font-bold text-apocalypse-accent mb-6">403</h1>
         <img src="{{ asset('images/errors/403.png') }}" alt="Verbotene Zone" class="mx-auto w-64 h-auto mb-6">
         <p class="text-xl text-gray-700 dark:text-gray-300 mb-8">
             {{ __('Der Zugriff auf diese Seite ist dir nicht gestattet. Solltest du versuchen, trotzdem an diese Inhalte zu kommen, wird dich ein Rudel Taratze holen und Orguudoo bringen!') }}
         </p>
-        <a href="{{ url('/') }}" class="text-[#8B0116] dark:text-[#ff4b63] underline">
+        <a href="{{ url('/') }}" class="text-apocalypse-accent underline">
             {{ __('Zur Startseite') }}
         </a>
     </div>

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,11 +1,11 @@
 <x-app-layout>
     <div class="container mx-auto py-12 text-center">
-        <h1 class="text-5xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6">404</h1>
+        <h1 class="text-5xl font-bold text-apocalypse-accent mb-6">404</h1>
         <img src="{{ asset('images/errors/404.png') }}" alt="Seite verschollen" class="mx-auto w-64 h-auto mb-6">
         <p class="text-xl text-gray-700 dark:text-gray-300 mb-8">
             {{ __('Wir haben Archivar Zuul losgeschickt um diese Seite zu finden, aber er wurde nicht mal in seiner BagBox fündig. Bitte prüfe die eingegebene URL auf Fehlertaratzen!') }}
         </p>
-        <a href="{{ url('/') }}" class="text-[#8B0116] dark:text-[#ff4b63] underline">
+        <a href="{{ url('/') }}" class="text-apocalypse-accent underline">
             {{ __('Zur Startseite') }}
         </a>
     </div>

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,11 +1,11 @@
 <x-app-layout>
     <div class="container mx-auto py-12 text-center">
-        <h1 class="text-5xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6">500</h1>
+        <h1 class="text-5xl font-bold text-apocalypse-accent mb-6">500</h1>
         <img src="{{ asset('images/errors/500.png') }}" alt="Server zerstört" class="mx-auto w-64 h-auto mb-6">
         <p class="text-xl text-gray-700 dark:text-gray-300 mb-8">
             {{ __('Entweder ist ein Komet eingeschlagen oder der Server ist überlastet. Bitte versuche es später aus deinem Bunker erneut.') }}
         </p>
-        <a href="{{ url('/') }}" class="text-[#8B0116] dark:text-[#ff4b63] underline">
+        <a href="{{ url('/') }}" class="text-apocalypse-accent underline">
             {{ __('Zur Startseite') }}
         </a>
     </div>

--- a/resources/views/kassenbuch/index.blade.php
+++ b/resources/views/kassenbuch/index.blade.php
@@ -13,7 +13,7 @@
             </div>
             @endif
             
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-red-400 mb-6">Kassenbuch</h1>
+            <h1 class="text-2xl font-semibold text-apocalypse-accent dark:text-red-400 mb-6">Kassenbuch</h1>
             
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <!-- Card 1: Mitgliedsbeitrag Status (Für alle Rollen) -->
@@ -362,11 +362,11 @@
                                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Typ</label>
                                 <div class="flex space-x-4">
                                     <label class="inline-flex items-center">
-                                        <input type="radio" name="typ" value="einnahme" checked class="form-radio h-4 w-4 text-[#8B0116] focus:ring-[#8B0116] border-gray-300 dark:border-gray-700">
+                                        <input type="radio" name="typ" value="einnahme" checked class="form-radio h-4 w-4 text-apocalypse-accent focus:ring-[#8B0116] border-gray-300 dark:border-gray-700">
                                         <span class="ml-2 text-gray-700 dark:text-gray-300">Einnahme</span>
                                     </label>
                                     <label class="inline-flex items-center">
-                                        <input type="radio" name="typ" value="ausgabe" class="form-radio h-4 w-4 text-[#8B0116] focus:ring-[#8B0116] border-gray-300 dark:border-gray-700">
+                                        <input type="radio" name="typ" value="ausgabe" class="form-radio h-4 w-4 text-apocalypse-accent focus:ring-[#8B0116] border-gray-300 dark:border-gray-700">
                                         <span class="ml-2 text-gray-700 dark:text-gray-300">Ausgabe</span>
                                     </label>
                                 </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -30,7 +30,7 @@
     </script>
 
     <x-banner />
-    <div class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 xl:pt-16">
+    <div class="min-h-screen bg-apocalypse-dark text-gray-100 xl:pt-16">
         @livewire('navigation-menu')
         <!-- Page Heading -->
         @if (isset($header))

--- a/resources/views/mitglieder/index.blade.php
+++ b/resources/views/mitglieder/index.blade.php
@@ -14,7 +14,7 @@
     @endif
     
     <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-    <h2 class="text-2xl font-semibold text-[#8B0116] dark:text-red-400 mb-6">Mitgliederliste</h2>
+    <h2 class="text-2xl font-semibold text-apocalypse-accent dark:text-red-400 mb-6">Mitgliederliste</h2>
     
     <!-- Export-Funktionen für berechtigte Benutzer -->
     @if($canViewDetails)
@@ -67,19 +67,19 @@
                         <h4 class="font-medium text-gray-700 dark:text-gray-300 mb-2">Zu exportierende Daten auswählen:</h4>
                         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
                             <label class="inline-flex items-center">
-                                <input type="checkbox" name="export_fields[]" value="name" class="rounded border-gray-300 text-[#8B0116] shadow-sm focus:border-red-300 focus:ring focus:ring-red-200 focus:ring-opacity-50" checked>
+                                <input type="checkbox" name="export_fields[]" value="name" class="rounded border-gray-300 text-apocalypse-accent shadow-sm focus:border-red-300 focus:ring focus:ring-red-200 focus:ring-opacity-50" checked>
                                 <span class="ml-2 text-gray-700 dark:text-gray-300">Name (Vor-/Nachname)</span>
                             </label>
                             <label class="inline-flex items-center">
-                                <input type="checkbox" name="export_fields[]" value="email" class="rounded border-gray-300 text-[#8B0116] shadow-sm focus:border-red-300 focus:ring focus:ring-red-200 focus:ring-opacity-50" checked>
+                                <input type="checkbox" name="export_fields[]" value="email" class="rounded border-gray-300 text-apocalypse-accent shadow-sm focus:border-red-300 focus:ring focus:ring-red-200 focus:ring-opacity-50" checked>
                                 <span class="ml-2 text-gray-700 dark:text-gray-300">E-Mail-Adresse</span>
                             </label>
                             <label class="inline-flex items-center">
-                                <input type="checkbox" name="export_fields[]" value="adresse" class="rounded border-gray-300 text-[#8B0116] shadow-sm focus:border-red-300 focus:ring focus:ring-red-200 focus:ring-opacity-50">
+                                <input type="checkbox" name="export_fields[]" value="adresse" class="rounded border-gray-300 text-apocalypse-accent shadow-sm focus:border-red-300 focus:ring focus:ring-red-200 focus:ring-opacity-50">
                                 <span class="ml-2 text-gray-700 dark:text-gray-300">Postadresse</span>
                             </label>
                             <label class="inline-flex items-center">
-                                <input type="checkbox" name="export_fields[]" value="bezahlt_bis" class="rounded border-gray-300 text-[#8B0116] shadow-sm focus:border-red-300 focus:ring focus:ring-red-200 focus:ring-opacity-50">
+                                <input type="checkbox" name="export_fields[]" value="bezahlt_bis" class="rounded border-gray-300 text-apocalypse-accent shadow-sm focus:border-red-300 focus:ring focus:ring-red-200 focus:ring-opacity-50">
                                 <span class="ml-2 text-gray-700 dark:text-gray-300">Bezahlt bis</span>
                             </label>
                         </div>
@@ -113,7 +113,7 @@
     <tr>
     <th class="px-4 py-2 text-left">
     <a href="{{ route('mitglieder.index', ['sort' => 'name', 'dir' => ($sortBy === 'name' && $sortDir === 'asc') ? 'desc' : 'asc']) }}"
-    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-[#8B0116] dark:hover:text-red-400">
+    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-apocalypse-accent dark:hover:text-red-400">
     Name
     @if($sortBy === 'name')
     <span class="ml-1">
@@ -133,7 +133,7 @@
     
     <th class="px-4 py-2 text-left">
     <a href="{{ route('mitglieder.index', ['sort' => 'mitglied_seit', 'dir' => ($sortBy === 'mitglied_seit' && $sortDir === 'asc') ? 'desc' : 'asc']) }}"
-    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-[#8B0116] dark:hover:text-red-400">
+    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-apocalypse-accent dark:hover:text-red-400">
     Mitglied seit
     @if($sortBy === 'mitglied_seit')
     <span class="ml-1">
@@ -153,7 +153,7 @@
     
     <th class="px-4 py-2 text-left">
     <a href="{{ route('mitglieder.index', ['sort' => 'role', 'dir' => ($sortBy === 'role' && $sortDir === 'asc') ? 'desc' : 'asc']) }}"
-    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-[#8B0116] dark:hover:text-red-400">
+    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-apocalypse-accent dark:hover:text-red-400">
     Rolle
     @if($sortBy === 'role')
     <span class="ml-1">
@@ -174,7 +174,7 @@
     @if($canViewDetails)
     <th class="px-4 py-2 text-left">
     <a href="{{ route('mitglieder.index', ['sort' => 'bezahlt_bis', 'dir' => ($sortBy === 'bezahlt_bis' && $sortDir === 'asc') ? 'desc' : 'asc']) }}"
-    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-[#8B0116] dark:hover:text-red-400">
+    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-apocalypse-accent dark:hover:text-red-400">
     Bezahlt bis
     @if($sortBy === 'bezahlt_bis')
     <span class="ml-1">
@@ -194,7 +194,7 @@
     
     <th class="px-4 py-2 text-left">
     <a href="{{ route('mitglieder.index', ['sort' => 'mitgliedsbeitrag', 'dir' => ($sortBy === 'mitgliedsbeitrag' && $sortDir === 'asc') ? 'desc' : 'asc']) }}"
-    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-[#8B0116] dark:hover:text-red-400">
+    class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-apocalypse-accent dark:hover:text-red-400">
     Beitrag
     @if($sortBy === 'mitgliedsbeitrag')
     <span class="ml-1">

--- a/resources/views/mitglieder/karte-locked.blade.php
+++ b/resources/views/mitglieder/karte-locked.blade.php
@@ -2,7 +2,7 @@
     <div class="py-8">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                <h2 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-6">Mitgliederkarte</h2>
+                <h2 class="text-2xl font-semibold text-apocalypse-accent mb-6">Mitgliederkarte</h2>
                 
                 <div class="bg-yellow-50 dark:bg-yellow-900 border border-yellow-200 dark:border-yellow-800 rounded-lg p-6 text-center">
                     <div class="flex flex-col items-center">

--- a/resources/views/mitglieder/karte.blade.php
+++ b/resources/views/mitglieder/karte.blade.php
@@ -2,7 +2,7 @@
     <div class="py-8">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white shadow-xl sm:rounded-lg p-6">
-                <h2 class="text-2xl font-semibold text-[#8B0116] mb-6">Mitgliederkarte</h2>
+                <h2 class="text-2xl font-semibold text-apocalypse-accent mb-6">Mitgliederkarte</h2>
                 
                 <div class="mb-4 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
                     <p class="text-sm text-yellow-800">

--- a/resources/views/pages/arbeitsgruppen.blade.php
+++ b/resources/views/pages/arbeitsgruppen.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800">
-        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Arbeitsgruppen des OMXFC e.V.</h1>
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100">
+        <h1 class="text-2xl sm:text-3xl font-bold text-apocalypse-accent mb-4 sm:mb-8">Arbeitsgruppen des OMXFC e.V.</h1>
 
         <!-- AG Maddraxikon -->
         <section class="mb-12">

--- a/resources/views/pages/changelog.blade.php
+++ b/resources/views/pages/changelog.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800">
-        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Changelog</h1>
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100">
+        <h1 class="text-2xl sm:text-3xl font-bold text-apocalypse-accent mb-4 sm:mb-8">Changelog</h1>
         <p class="mb-6">Auf dieser Seite werden sämtliche Änderungen an der Vereinswebseite des Offiziellen Maddrax
             Fanclub e. V. dokumentiert.</p>
         <section class="mb-6">

--- a/resources/views/pages/chronik.blade.php
+++ b/resources/views/pages/chronik.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
-        <h1 class="text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-8">Chronik des Offiziellen MADDRAX Fanclub e. V.</h1>
+        <h1 class="text-3xl font-bold text-apocalypse-accent mb-8">Chronik des Offiziellen MADDRAX Fanclub e. V.</h1>
         <div class="relative border-l-4 border-[#8B0116] dark:border-[#ff4b63] pl-8 space-y-8">
             <div class="relative">
                 <div class="absolute -left-[25px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>

--- a/resources/views/pages/datenschutz.blade.php
+++ b/resources/views/pages/datenschutz.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800">
-        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Datenschutzerklärung</h1>
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100">
+        <h1 class="text-2xl sm:text-3xl font-bold text-apocalypse-accent mb-4 sm:mb-8">Datenschutzerklärung</h1>
 
         <section class="mb-6">
             <h2 class="text-xl font-semibold mb-2">Verantwortlicher</h2>

--- a/resources/views/pages/downloads.blade.php
+++ b/resources/views/pages/downloads.blade.php
@@ -2,7 +2,7 @@
     <div class="py-8">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-6">
+                <h1 class="text-2xl font-semibold text-apocalypse-accent mb-6">
                     Downloads
                 </h1>
 

--- a/resources/views/pages/ehrenmitglieder.blade.php
+++ b/resources/views/pages/ehrenmitglieder.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-sm">
-        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Ehrenmitglieder</h1>
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100 rounded-lg shadow-sm">
+        <h1 class="text-2xl sm:text-3xl font-bold text-apocalypse-accent mb-4 sm:mb-8">Ehrenmitglieder</h1>
         <p class="mb-8 text-gray-700 dark:text-gray-300">
             Wir sind stolz darauf, herausragende Autoren der Maddrax-Serie zu unseren Ehrenmitgliedern zählen zu dürfen.
             Diese talentierten Schriftsteller haben maßgeblich zum Erfolg und zur Entwicklung des Maddraxiversums
@@ -16,7 +16,7 @@
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
-                    <h2 class="text-xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-2">Michael Edelbrock</h2>
+                    <h2 class="text-xl font-bold text-apocalypse-accent mb-2">Michael Edelbrock</h2>
                     <p class="text-gray-700 dark:text-gray-300 text-sm mb-3">
                         Michael Edelbrock wurde 1980 geboren und beschäftigt sich am liebsten mit dicken Schmökern oder
                         langen Sagen, sowohl in der klassischen Phantastik als auch in der Science-Fiction.
@@ -46,7 +46,7 @@
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
-                    <h2 class="text-xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-2">Lucy Guth</h2>
+                    <h2 class="text-xl font-bold text-apocalypse-accent mb-2">Lucy Guth</h2>
                     <p class="text-gray-700 dark:text-gray-300 text-sm mb-3">
                         Lucy Guth (Tanja Monique Bruske-Guth) wurde 1978 geboren und ist seit 2014 als Maddrax-Autorin
                         dabei und hat dementsprechend schon viel Gut(h)es beigetragen. In ihrem Hauptberuf arbeitet sie als
@@ -72,7 +72,7 @@
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
-                    <h2 class="text-xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-2">Ian Rolf Hill</h2>
+                    <h2 class="text-xl font-bold text-apocalypse-accent mb-2">Ian Rolf Hill</h2>
                     <p class="text-gray-700 dark:text-gray-300 text-sm mb-3">
                         Ian Rolf Hill (Florian Hilleberg) wurde 1980 geboren und ist seit 2016 für Maddrax aktiv. Für
                         die Serie hat er eine Vielzahl an Romanen geschrieben und interessante Charaktere entwickelt,
@@ -97,7 +97,7 @@
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
-                    <h2 class="text-xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-2">Oliver Müller</h2>
+                    <h2 class="text-xl font-bold text-apocalypse-accent mb-2">Oliver Müller</h2>
                     <p class="text-gray-700 dark:text-gray-300 text-sm mb-3">
                         Oliver Müller wurde 1983 geboren und gab seinen Einstand bei Maddrax im Jahr 2014 mit <em>Ein
                             Käfig aus Zeit</em> (MX 365). Neben seinem Hauptberuf veröffentlicht er viele
@@ -121,7 +121,7 @@
                         alt="Michael Schönenbröcher" class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
-                    <h2 class="text-xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-2">Michael Schönenbröcher</h2>
+                    <h2 class="text-xl font-bold text-apocalypse-accent mb-2">Michael Schönenbröcher</h2>
                     <p class="text-gray-700 dark:text-gray-300 text-sm mb-3">
                         Michael Schönenbröcher (Mad Mike) wurde 1961 geboren, ist seit 1979 Lektor beim Bastei Verlag
                         und seit 2000 alleiniger Betreuer von Maddrax. Die Serie, die in Zusammenarbeit mit den Autoren
@@ -147,7 +147,7 @@
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
-                    <h2 class="text-xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-2">Jo Zybell</h2>
+                    <h2 class="text-xl font-bold text-apocalypse-accent mb-2">Jo Zybell</h2>
                     <p class="text-gray-700 dark:text-gray-300 text-sm mb-3">
                         Jo Zybell (Thomas Ziebula) wurde 1954 geboren und hat die Serie als Autor seit 2000 aktiv
                         mitgestaltet. Von ihm wurde eine Vielzahl an Heftromanen und ergänzenden Hardcover-Bücher

--- a/resources/views/pages/fotogalerie.blade.php
+++ b/resources/views/pages/fotogalerie.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-sm">
-        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Fotogalerie</h1>
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100 rounded-lg shadow-sm">
+        <h1 class="text-2xl sm:text-3xl font-bold text-apocalypse-accent mb-4 sm:mb-8">Fotogalerie</h1>
 
         <p class="mb-8 text-gray-700 dark:text-gray-300">
             Hier findest du Fotos von unseren Veranstaltungen aus den letzten Jahren.
@@ -13,7 +13,7 @@
                     @foreach($years as $year)
                         <button 
                             class="jahr-tab py-4 px-1 border-b-2 font-medium text-sm whitespace-nowrap
-                            {{ $year === $activeYear ? 'border-[#8B0116] dark:border-[#ff4b63] text-[#8B0116] dark:text-[#ff4b63]' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300 dark:hover:border-gray-300' }}"
+                            {{ $year === $activeYear ? 'border-[#8B0116] dark:border-[#ff4b63] text-apocalypse-accent' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 dark:text-gray-400 dark:hover:text-gray-300 dark:hover:border-gray-300' }}"
                             data-year="{{ $year }}"
                         >
                             Fotos {{ $year }}
@@ -77,13 +77,13 @@
                 
                 // Alle Tabs zurücksetzen
                 jahresTabs.forEach(t => {
-                    t.classList.remove('border-[#8B0116]', 'dark:border-[#ff4b63]', 'text-[#8B0116]', 'dark:text-[#ff4b63]');
+                    t.classList.remove('border-[#8B0116]', 'dark:border-[#ff4b63]', 'text-apocalypse-accent', 'dark:text-[#ff4b63]');
                     t.classList.add('border-transparent', 'text-gray-500');
                 });
                 
                 // Aktiven Tab setzen
                 this.classList.remove('border-transparent', 'text-gray-500');
-                this.classList.add('border-[#8B0116]', 'dark:border-[#ff4b63]', 'text-[#8B0116]', 'dark:text-[#ff4b63]');
+                this.classList.add('border-[#8B0116]', 'dark:border-[#ff4b63]', 'text-apocalypse-accent', 'dark:text-[#ff4b63]');
                 
                 // Galerien anzeigen/verstecken
                 document.querySelectorAll('.gallery-container').forEach(gallery => {

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-sm">
-        <h1 class="text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-8 text-center">Willkommen beim Offiziellen MADDRAX Fanclub e. V.!</h1>
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100 rounded-lg shadow-sm">
+        <h1 class="text-3xl font-bold text-apocalypse-accent mb-8 text-center">Willkommen beim Offiziellen MADDRAX Fanclub e. V.!</h1>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             {{-- Fotogalerie --}}
@@ -14,19 +14,19 @@
             </div>
             {{-- Wer wir sind --}}
             <div class="bg-white dark:bg-gray-700 rounded-lg shadow-md p-6">
-                <h2 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-4">Wer wir sind</h2>
+                <h2 class="text-2xl font-semibold text-apocalypse-accent mb-4">Wer wir sind</h2>
                 <p class="text-gray-700 dark:text-gray-300">{{ $whoWeAre }}</p>
             </div>
 
             {{-- Was wir machen --}}
             <div class="bg-white dark:bg-gray-700 rounded-lg shadow-md p-6">
-                <h2 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-4">Was wir machen</h2>
+                <h2 class="text-2xl font-semibold text-apocalypse-accent mb-4">Was wir machen</h2>
                 <p class="text-gray-700 dark:text-gray-300">{{ $whatWeDo }}</p>
             </div>
 
             {{-- Aktuelle Projekte --}}
             <div class="md:col-span-2 bg-white dark:bg-gray-700 rounded-lg shadow-md p-6">
-                <h2 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-4">Aktuelle Projekte</h2>
+                <h2 class="text-2xl font-semibold text-apocalypse-accent mb-4">Aktuelle Projekte</h2>
                 <ul class="list-disc ml-5 text-gray-700 dark:text-gray-300 space-y-2">
                     @foreach($currentProjects as $project)
                     <li><strong>{{ $project['title'] }}</strong>: {{ $project['description'] }}</li>
@@ -36,7 +36,7 @@
 
             {{-- Vorteile einer Mitgliedschaft --}}
             <div class="bg-white dark:bg-gray-700 rounded-lg shadow-md p-6">
-                <h2 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-4">Vorteile einer Mitgliedschaft
+                <h2 class="text-2xl font-semibold text-apocalypse-accent mb-4">Vorteile einer Mitgliedschaft
                 </h2>
                 <ul class="list-disc ml-5 text-gray-700 dark:text-gray-300">
                     @foreach($membershipBenefits as $benefit)
@@ -47,7 +47,7 @@
 
             {{-- Anzahl Mitglieder --}}
             <div class="bg-white dark:bg-gray-700 rounded-lg shadow-md p-6 flex flex-col justify-center items-center">
-                <h2 class="text-4xl font-bold text-[#8B0116] dark:text-[#ff4b63]">{{ $memberCount }}</h2>
+                <h2 class="text-4xl font-bold text-apocalypse-accent">{{ $memberCount }}</h2>
                 <span class="text-gray-700 dark:text-gray-300">aktive Mitglieder</span>
             </div>
         </div>

--- a/resources/views/pages/impressum.blade.php
+++ b/resources/views/pages/impressum.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800">
-        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Impressum</h1>
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100">
+        <h1 class="text-2xl sm:text-3xl font-bold text-apocalypse-accent mb-4 sm:mb-8">Impressum</h1>
 
         <p class="mb-6">Dieses Impressum gilt für alle Angebote unter der Domain <strong>maddrax-fanclub.de</strong>
             inklusive aller Subdomains (Unterseiten).</p>

--- a/resources/views/pages/kompendium.blade.php
+++ b/resources/views/pages/kompendium.blade.php
@@ -3,7 +3,7 @@
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
                 {{-- Überschrift ------------------------------------------------ --}}
-                <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-6">
+                <h1 class="text-2xl font-semibold text-apocalypse-accent mb-6">
                     Maddrax-Kompendium
                 </h1>
 
@@ -72,7 +72,7 @@
                 // HTML-Template pro Roman
                 const tpl = (roman) => `
                     <div class="border border-gray-200 dark:border-gray-700 rounded p-4">
-                        <h2 class="font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-2">
+                        <h2 class="font-semibold text-apocalypse-accent mb-2">
                             ${roman.cycle} – ${roman.romanNr}: ${roman.title}
                         </h2>
                         ${roman.snippets.map(s => `<p class="mb-2 text-sm leading-relaxed">${s}</p>`).join('')}

--- a/resources/views/pages/meetings.blade.php
+++ b/resources/views/pages/meetings.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <div class="py-8 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-6">Meetings</h1>
+            <h1 class="text-2xl font-semibold text-apocalypse-accent mb-6">Meetings</h1>
 
             <ul class="space-y-6">
                 @foreach($meetings as $meeting)

--- a/resources/views/pages/mitglied_werden.blade.php
+++ b/resources/views/pages/mitglied_werden.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-sm">
-        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Mitglied werden</h1>
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100 rounded-lg shadow-sm">
+        <h1 class="text-2xl sm:text-3xl font-bold text-apocalypse-accent mb-4 sm:mb-8">Mitglied werden</h1>
         <!-- Erfolg-/Fehlermeldungen -->
         <div id="form-messages" class="mb-4 hidden"></div>
         <form id="mitgliedschaft-form" class="w-full">
@@ -123,12 +123,12 @@
                 disabled>Antrag absenden</button>
             <!-- Lade-Indikator -->
             <div id="loading-indicator" class="mt-4 hidden flex items-center justify-center">
-                <svg class="animate-spin h-8 w-8 text-[#8B0116]" xmlns="http://www.w3.org/2000/svg" fill="none"
+                <svg class="animate-spin h-8 w-8 text-apocalypse-accent" xmlns="http://www.w3.org/2000/svg" fill="none"
                     viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v2.5A5.5 5.5 0 006.5 12H4z"></path>
                 </svg>
-                <span class="ml-2 font-medium text-[#8B0116]">Dein Antrag wird gesendet, bitte warten...</span>
+                <span class="ml-2 font-medium text-apocalypse-accent">Dein Antrag wird gesendet, bitte warten...</span>
             </div>
         </form>
     </div>

--- a/resources/views/pages/mitglied_werden_bestaetigt.blade.php
+++ b/resources/views/pages/mitglied_werden_bestaetigt.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <div class="py-12">
         <div class="max-w-2xl mx-auto px-6 lg:px-8 bg-white dark:bg-gray-800 p-8 rounded shadow">
-            <h1 class="text-2xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4">Vielen Dank für deine Bestätigung!</h1>
+            <h1 class="text-2xl font-bold text-apocalypse-accent mb-4">Vielen Dank für deine Bestätigung!</h1>
             <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
                 Dein Mitgliedschaftsantrag wurde erfolgreich an den Vorstand übermittelt. Er wird nun geprüft.
                 Dies geschieht manuell. Lass uns etwas Zeit, um deinen Antrag zu prüfen.

--- a/resources/views/pages/mitglied_werden_erfolgreich.blade.php
+++ b/resources/views/pages/mitglied_werden_erfolgreich.blade.php
@@ -1,5 +1,5 @@
 <x-app-layout>
-    <div class="max-w-3xl mx-auto px-6 py-10 text-center bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md">
+    <div class="max-w-3xl mx-auto px-6 py-10 text-center bg-apocalypse-dark text-gray-100 rounded-lg shadow-md">
         <h2 class="text-2xl font-bold text-green-700 dark:text-green-400 mb-4">🎉 Antrag erfolgreich eingereicht!</h2>
         <p class="text-gray-700 dark:text-gray-300 mb-4">
             Wir haben dir eine E-Mail zur Bestätigung deiner Mailadresse geschickt.

--- a/resources/views/pages/protokolle.blade.php
+++ b/resources/views/pages/protokolle.blade.php
@@ -2,7 +2,7 @@
     <div class="py-8">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-6">Protokolle</h1>
+                <h1 class="text-2xl font-semibold text-apocalypse-accent mb-6">Protokolle</h1>
 
                 <div id="accordion">
                     @foreach($protokolle as $jahr => $dokumente)

--- a/resources/views/pages/satzung.blade.php
+++ b/resources/views/pages/satzung.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800">
-        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Satzung des Offiziellen MADDRAX Fanclub e.V.</h1>
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100">
+        <h1 class="text-2xl sm:text-3xl font-bold text-apocalypse-accent mb-4 sm:mb-8">Satzung des Offiziellen MADDRAX Fanclub e.V.</h1>
         <section class="mb-6">
             <h2 class="text-xl font-semibold mb-2">§1 Name, Sitz des Vereins, Rechtsform und Geschäftsjahr</h2>
             <p>Der Verein führt den Namen „Offizieller MADDRAX-Fanclub“ und hat seinen Sitz in Potsdam, Brandenburg. Das Geschäftsjahr ist das Kalenderjahr.</p>

--- a/resources/views/pages/termine.blade.php
+++ b/resources/views/pages/termine.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
-    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-sm">
-        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Termine</h1>
+    <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-apocalypse-dark text-gray-100 rounded-lg shadow-sm">
+        <h1 class="text-2xl sm:text-3xl font-bold text-apocalypse-accent mb-4 sm:mb-8">Termine</h1>
         <!-- Desktop: Monatsansicht -->
         <div
             class="hidden md:block aspect-video rounded-lg overflow-hidden shadow-md border border-gray-200 dark:border-gray-600">
@@ -16,7 +16,7 @@
         <p class="mt-4 text-sm sm:text-base text-gray-700 dark:text-gray-300">
             Hier findest du alle aktuellen Termine des Vereins. Den Kalender kannst du auch direkt bei
             <a href="{{ $calendarLink }}" target="_blank"
-                class="text-[#8B0116] dark:text-[#ff4b63] underline hover:text-[#6a0110] dark:hover:text-[#d63c4e]">
+                class="text-apocalypse-accent underline hover:text-[#6a0110] dark:hover:text-[#d63c4e]">
                 Google Kalender
             </a>
             öffnen.

--- a/resources/views/policy.blade.php
+++ b/resources/views/policy.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <div class="pt-4 bg-gray-100 dark:bg-gray-900">
+    <div class="pt-4 bg-apocalypse-dark text-gray-100">
         <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
             <div>
                 <x-authentication-card-logo />

--- a/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/resources/views/profile/two-factor-authentication-form.blade.php
@@ -68,7 +68,7 @@
                     </p>
                 </div>
 
-                <div class="grid gap-1 max-w-xl mt-4 px-4 py-4 font-mono text-sm bg-gray-100 dark:bg-gray-900 dark:text-gray-100 rounded-lg">
+                <div class="grid gap-1 max-w-xl mt-4 px-4 py-4 font-mono text-sm bg-apocalypse-dark text-gray-100 dark:text-gray-100 rounded-lg">
                     @foreach (json_decode(decrypt($this->user->two_factor_recovery_codes), true) as $code)
                         <div>{{ $code }}</div>
                     @endforeach

--- a/resources/views/profile/view.blade.php
+++ b/resources/views/profile/view.blade.php
@@ -109,7 +109,7 @@
                     <div class="col-span-2 mt-8 md:mt-0">
                         <!-- Vereinsaktivität -->
                         <div class="mb-8">
-                            <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 flex items-center">
+                            <h2 class="text-xl font-semibold text-apocalypse-accent mb-4 flex items-center">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 mr-2" fill="none"
                                     viewBox="0 0 24 24" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -124,7 +124,7 @@
                                         class="text-center sm:text-left mb-6 sm:mb-0 bg-white dark:bg-gray-800 p-4 rounded-lg shadow-sm flex-1 mr-0 sm:mr-4">
                                         <h3 class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">
                                             Baxx</h3>
-                                        <p class="text-4xl font-bold text-[#8B0116] dark:text-[#FF6B81]">
+                                        <p class="text-4xl font-bold text-apocalypse-accent">
                                             {{ $userPoints }}
                                         </p>
                                         <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Baxx</p>
@@ -144,7 +144,7 @@
 
                         <!-- Maddrax-Leidenschaft -->
                         <div>
-                            <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 flex items-center">
+                            <h2 class="text-xl font-semibold text-apocalypse-accent mb-4 flex items-center">
                                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 mr-2" fill="none"
                                     viewBox="0 0 24 24" stroke="currentColor">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/resources/views/reviews/create.blade.php
+++ b/resources/views/reviews/create.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <div class="py-8">
         <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-6">
+            <h1 class="text-2xl font-semibold text-apocalypse-accent mb-6">
                 Neue Rezension zu „{{ $book->title }}“ (Nr. {{ $book->roman_number }})
             </h1>
 

--- a/resources/views/reviews/edit.blade.php
+++ b/resources/views/reviews/edit.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <div class="py-8">
         <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-6">
+            <h1 class="text-2xl font-semibold text-apocalypse-accent mb-6">
                 Rezension zu „{{ $review->book->title }}“ bearbeiten
             </h1>
 

--- a/resources/views/reviews/index.blade.php
+++ b/resources/views/reviews/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <div class="py-8">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-4">Rezensionen</h1>
+            <h1 class="text-2xl font-semibold text-apocalypse-accent mb-4">Rezensionen</h1>
             <p class="mb-6 text-sm text-gray-600 dark:text-gray-400">
                 Für jede <strong>zehnte</strong> verfasste Rezension erhältst du automatisch
                 <strong>1 Baxx</strong>.
@@ -59,7 +59,7 @@
                                     @foreach($cycleBooks->sortByDesc('roman_number') as $book)
                                         <tr>
                                             <td class="px-4 py-2">
-                                                <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline">
+                                                <a href="{{ route('reviews.show', $book) }}" class="text-apocalypse-accent hover:underline">
                                                     {{ $book->roman_number }}
                                                 </a>
                                             </td>
@@ -81,7 +81,7 @@
                                                 @endif
                                             </td>
                                             <td class="px-4 py-2">
-                                                <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline">
+                                                <a href="{{ route('reviews.show', $book) }}" class="text-apocalypse-accent hover:underline">
                                                     {{ $book->reviews_count }} {{ $book->reviews_count === 1 ? 'Rezension' : 'Rezensionen' }}
                                                 </a>
                                             </td>

--- a/resources/views/reviews/show.blade.php
+++ b/resources/views/reviews/show.blade.php
@@ -7,7 +7,7 @@
                 </div>
             @endif
 
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-6">
+            <h1 class="text-2xl font-semibold text-apocalypse-accent mb-6">
                 Rezensionen zu „{{ $book->title }}“ (Nr. {{ $book->roman_number }})
             </h1>
 
@@ -49,7 +49,7 @@
                 <p class="text-gray-600 dark:text-gray-400">Noch keine Rezensionen vorhanden.</p>
             @endforelse
 
-            <a href="{{ route('reviews.index') }}" class="text-[#8B0116] hover:underline">← Zurück zur Übersicht</a>
+            <a href="{{ route('reviews.index') }}" class="text-apocalypse-accent hover:underline">← Zurück zur Übersicht</a>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/rewards/index.blade.php
+++ b/resources/views/rewards/index.blade.php
@@ -2,7 +2,7 @@
     <div class="py-8">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-6">Belohnungen</h1>
+                <h1 class="text-2xl font-semibold text-apocalypse-accent mb-6">Belohnungen</h1>
                 <p class="mb-4 text-sm text-gray-600 dark:text-gray-400">
                     Dein aktuelles Baxx-Guthaben: <span class="font-semibold">{{ $userPoints }}</span>
                 </p>
@@ -12,7 +12,7 @@
                             $unlocked = $userPoints >= $reward['points'];
                         @endphp
                         <div class="p-4 rounded-lg shadow {{ $unlocked ? 'bg-white dark:bg-gray-700' : 'bg-gray-100 dark:bg-gray-700 opacity-50' }}">
-                            <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-1">{{ $reward['title'] }}</h2>
+                            <h2 class="text-lg font-semibold text-apocalypse-accent mb-1">{{ $reward['title'] }}</h2>
                             <p class="text-gray-700 dark:text-gray-300">{{ $reward['description'] }}</p>
                             <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Erforderliche Baxx: {{ $reward['points'] }}</p>
                             @if(isset($reward['percentage']))

--- a/resources/views/romantausch/create_offer.blade.php
+++ b/resources/views/romantausch/create_offer.blade.php
@@ -2,7 +2,7 @@
     <div class="py-8">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                <h1 class="text-2xl font-bold text-[#8B0116] dark:text-[#FF6B81] mb-6">Neues Angebot erstellen</h1>
+                <h1 class="text-2xl font-bold text-apocalypse-accent mb-6">Neues Angebot erstellen</h1>
 
                 <form action="{{ route('romantausch.store-offer') }}" method="POST">
                     @csrf

--- a/resources/views/romantausch/create_request.blade.php
+++ b/resources/views/romantausch/create_request.blade.php
@@ -2,7 +2,7 @@
     <div class="py-8">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                <h1 class="text-2xl font-bold text-[#8B0116] dark:text-[#FF6B81] mb-6">Neues Gesuch erstellen</h1>
+                <h1 class="text-2xl font-bold text-apocalypse-accent mb-6">Neues Gesuch erstellen</h1>
 
                 <form action="{{ route('romantausch.store-request') }}" method="POST">
                     @csrf

--- a/resources/views/romantausch/index.blade.php
+++ b/resources/views/romantausch/index.blade.php
@@ -8,7 +8,7 @@
             @endif
             <!-- Kopfzeile mit Buttons -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
-                <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">Romantauschbörse</h1>
+                <h1 class="text-2xl font-semibold text-apocalypse-accent">Romantauschbörse</h1>
                 <div class="flex gap-2">
                     <a href="{{ route('romantausch.create-offer') }}"
                        class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D]">
@@ -27,7 +27,7 @@
             </p>
             @if($activeSwaps->isNotEmpty())
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-2">Deine Matches</h2>
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-2">Deine Matches</h2>
                     <p class="mb-4 text-gray-600 dark:text-gray-400">Kontaktiert euch gegenseitig über die angezeigten Mailadressen und klickt anschließend auf „Tausch abgeschlossen“. Für jeden abgeschlossenen Tausch gibt es <strong>2 Baxx</strong>!</p>
                     <ul class="space-y-4">
                         @foreach($activeSwaps as $swap)
@@ -52,7 +52,7 @@
             @endif
             <!-- Angebote -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">Aktuelle Angebote</h2>
+                <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">Aktuelle Angebote</h2>
                 @if($offers->isEmpty())
                     <p class="text-gray-600 dark:text-gray-400">Keine Angebote vorhanden.</p>
                 @else
@@ -68,7 +68,7 @@
             </div>
             <!-- Gesuche -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">Aktuelle Gesuche</h2>
+                <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">Aktuelle Gesuche</h2>
                 @if($requests->isEmpty())
                     <p class="text-gray-600 dark:text-gray-400">Keine Gesuche vorhanden.</p>
                 @else
@@ -84,7 +84,7 @@
             </div>
             <!-- Abgeschlossene Tauschaktionen -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">Erfolgreiche Tauschaktionen</h2>
+                <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">Erfolgreiche Tauschaktionen</h2>
                 @if($completedSwaps->isEmpty())
                     <p class="text-gray-600 dark:text-gray-400">Bisher wurden noch keine Tauschaktionen abgeschlossen.</p>
                 @else

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -5,14 +5,14 @@
             {{-- Kopfzeile --}}
             <div
                 class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
-                <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                <h1 class="text-2xl font-semibold text-apocalypse-accent">
                     Statistik
                 </h1>
             </div>
             {{-- Card 1 – Balkendiagramm (≥ 2 Bakk) --}}
             @if ($userPoints >= 2)
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4 text-center">
                         Romane je Autor:in
                     </h2>
                     <canvas id="authorChart" height="140"></canvas>
@@ -27,7 +27,7 @@
             {{-- Card 2 – Teamplayer-Tabelle (≥ 4 Baxx) --}}
             @if ($userPoints >= 4)
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4 text-center">
                         Top Teamplayer
                     </h2>
 
@@ -56,7 +56,7 @@
             {{-- Card 3 – Romane-Tabelle (≥ 5 Baxx) --}}
             @if ($userPoints >= 5)
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4 text-center">
                         Alle Romane
                     </h2>
 
@@ -89,7 +89,7 @@
             {{-- Card 4 – Top-Autor:innen nach Ø‑Bewertung (≥ 7 Baxx) --}}
             @if ($userPoints >= 7)
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4 text-center">
                         Top 10 Autor:innen nach Ø-Bewertung
                     </h2>
 
@@ -116,7 +116,7 @@
                 </div>
             @else
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">
                         Top 10 Autor:innen nach Ø-Bewertung
                     </h2>
                     <p class="text-sm text-gray-600 dark:text-gray-400">
@@ -128,7 +128,7 @@
             {{-- Card 5 – Top-Charaktere nach Auftritten (≥ 10 Baxx) --}}
             @if ($userPoints >= 10)
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4 text-center">
                         Top 10 Charaktere nach Auftritten
                     </h2>
 
@@ -155,7 +155,7 @@
                 </div>
             @else
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4 text-center">
                         Top 10 Charaktere nach Auftritten
                     </h2>
                     <p class="text-sm text-gray-600 dark:text-gray-400">
@@ -167,7 +167,7 @@
             {{-- Card 6 – Bewertungen im Maddraxikon (≥ 11 Baxx) --}}
             @if ($userPoints >= 11)
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6 grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 col-span-1 md:col-span-3">
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4 col-span-1 md:col-span-3">
                         Bewertungen im Maddraxikon
                     </h2>
                     <div>

--- a/resources/views/terms.blade.php
+++ b/resources/views/terms.blade.php
@@ -1,5 +1,5 @@
 <x-guest-layout>
-    <div class="pt-4 bg-gray-100 dark:bg-gray-900">
+    <div class="pt-4 bg-apocalypse-dark text-gray-100">
         <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
             <div>
                 <x-authentication-card-logo />

--- a/resources/views/todos/create.blade.php
+++ b/resources/views/todos/create.blade.php
@@ -2,7 +2,7 @@
     <div class="py-8">
         <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-6">Neue Challenge erstellen</h2>
+                <h2 class="text-xl font-semibold text-apocalypse-accent mb-6">Neue Challenge erstellen</h2>
 
                 <form action="{{ route('todos.store') }}" method="POST">
                     @csrf

--- a/resources/views/todos/edit.blade.php
+++ b/resources/views/todos/edit.blade.php
@@ -2,7 +2,7 @@
     <div class="py-8">
         <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-6">Challenge bearbeiten</h2>
+                <h2 class="text-xl font-semibold text-apocalypse-accent mb-6">Challenge bearbeiten</h2>
 
                 <form action="{{ route('todos.update', $todo) }}" method="POST">
                     @csrf

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -17,7 +17,7 @@
             <div
                 class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
                 <div>
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-1">Deine Baxx</h2>
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-1">Deine Baxx</h2>
                     <div class="text-4xl font-bold text-gray-800 dark:text-gray-200">
                         {{ $userPoints }}
                     </div>
@@ -38,7 +38,7 @@
             </div>
             <!-- Deine Challenges -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">Deine Challenges</h2>
+                <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">Deine Challenges</h2>
                 @if($assignedTodos->isEmpty())
                     <p class="text-gray-600 dark:text-gray-400">Du hast aktuell keine übernommenen Challenges.</p>
                 @else
@@ -74,7 +74,7 @@
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->points }}</td>
                                         <td class="px-4 py-2 text-center">
                                             <a href="{{ route('todos.show', $todo) }}"
-                                                class="text-[#8B0116] dark:text-[#FF6B81] hover:underline">
+                                                class="text-apocalypse-accent hover:underline">
                                                 Details
                                             </a>
                                             @if($todo->created_by === Auth::id())
@@ -152,7 +152,7 @@
             </div>
             <!-- Offene Challenges -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">Offene Challenges</h2>
+                <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">Offene Challenges</h2>
                 @if($unassignedTodos->isEmpty())
                     <p class="text-gray-600 dark:text-gray-400">Es sind aktuell keine offenen Challenges verfügbar.</p>
                 @else
@@ -177,7 +177,7 @@
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->points }}</td>
                                         <td class="px-4 py-2 text-center">
                                             <a href="{{ route('todos.show', $todo) }}"
-                                                class="text-[#8B0116] dark:text-[#FF6B81] hover:underline mr-2">
+                                                class="text-apocalypse-accent hover:underline mr-2">
                                                 Details
                                             </a>
                                             @if($todo->created_by === Auth::id())
@@ -239,7 +239,7 @@
             <!-- Erledigte Challenges (nur wenn Verifizierungsrechte vorhanden) -->
             @if($canVerifyTodos && $completedTodos->where('status', 'completed')->isNotEmpty())
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">Zu verifizierende Challenges
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">Zu verifizierende Challenges
                     </h2>
                     <!-- Desktop-Ansicht (versteckt auf Mobilgeräten) -->
                     <div class="hidden md:block">
@@ -263,7 +263,7 @@
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->points }}</td>
                                         <td class="px-4 py-2 text-center">
                                             <a href="{{ route('todos.show', $todo) }}"
-                                                class="text-[#8B0116] dark:text-[#FF6B81] hover:underline mr-2">
+                                                class="text-apocalypse-accent hover:underline mr-2">
                                                 Details
                                             </a>
                                             @if($todo->created_by === Auth::id())
@@ -331,7 +331,7 @@
             @endphp
             @if($inProgressTodos->isNotEmpty())
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">In Bearbeitung befindliche Challenges</h2>
+                    <h2 class="text-xl font-semibold text-apocalypse-accent mb-4">In Bearbeitung befindliche Challenges</h2>
                     <!-- Desktop-Ansicht (versteckt auf Mobilgeräten) -->
                     <div class="hidden md:block">
                         <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
@@ -353,7 +353,7 @@
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->points }}</td>
                                         <td class="px-4 py-2 text-center">
                                             <a href="{{ route('todos.show', $todo) }}"
-                                                class="text-[#8B0116] dark:text-[#FF6B81] hover:underline">
+                                                class="text-apocalypse-accent hover:underline">
                                                 Details
                                             </a>
                                             @if($todo->created_by === Auth::id())

--- a/resources/views/todos/show.blade.php
+++ b/resources/views/todos/show.blade.php
@@ -19,7 +19,7 @@
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
                 <!-- Titel und Status -->
                 <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">{{ $todo->title }}</h2>
+                    <h2 class="text-xl font-semibold text-apocalypse-accent">{{ $todo->title }}</h2>
                     <div class="mt-2 md:mt-0">
                         @if($todo->status === 'open')
                             <span

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,10 @@ export default {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                'apocalypse-dark': '#1f2937',
+                'apocalypse-accent': '#ef4444',
+            },
         },
     },
 


### PR DESCRIPTION
## Summary
- extend Tailwind theme with `apocalypse-dark` and `apocalypse-accent`
- use new background and text utilities in layouts and views
- apply accent color to headings across templates

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688a55d11f98832e816aa464da5cb7c9