### PR TITLE
feat: apply post-apocalyptic color palette

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -6,6 +6,55 @@
     display: none;
 }
 
+/* Post-apocalyptic color palette */
+:root {
+    --background: #FED17E; /* scorched earth */
+    --surface: #f4c76e;    /* lighter panels */
+    --text: #000000;       /* dark text */
+    --accent: #900316;     /* blood red */
+}
+
+.dark {
+    --background: #0f0f0f; /* wasteland night */
+    --surface: #1a0f0f;
+    --text: #FED17E;
+    --accent: #900316;
+}
+
+body {
+    background-color: var(--background);
+    color: var(--text);
+}
+
+a {
+    color: var(--accent);
+}
+
+a:hover {
+    color: #63010e;
+}
+
+/* Override Tailwind utility colors to use palette */
+.bg-white, .bg-gray-100 {
+    background-color: var(--surface) !important;
+}
+
+.text-gray-900 {
+    color: var(--text) !important;
+}
+
+.dark .bg-gray-800 {
+    background-color: var(--surface) !important;
+}
+
+.dark .bg-gray-900 {
+    background-color: var(--background) !important;
+}
+
+.dark .text-gray-100 {
+    color: var(--text) !important;
+}
+
 /* Vereinslogo als Asset referenzieren */
 .logo {
     background-image: url('../images/omxfc-logo.png');

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,8 +11,8 @@
     <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicon/favicon-16x16.png') }}">
     <link rel="manifest" href="{{ asset('favicon/site.webmanifest') }}">
     <link rel="shortcut icon" href="{{ asset('favicon/favicon.ico') }}">
-    <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="msapplication-TileColor" content="#FED17E">
+    <meta name="theme-color" content="#FED17E">
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
@@ -21,7 +21,7 @@
     @livewireStyles
 </head>
 
-<body class="font-sans antialiased">
+<body class="font-sans antialiased bg-[var(--background)] text-[var(--text)]">
     <!-- Livewire Scripts -->
     <script src="/livewire/livewire.min.js" 
         data-csrf="{{ csrf_token() }}" 
@@ -30,18 +30,18 @@
     </script>
 
     <x-banner />
-    <div class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 xl:pt-16">
+    <div class="min-h-screen xl:pt-16">
         @livewire('navigation-menu')
         <!-- Page Heading -->
         @if (isset($header))
-            <header class="bg-white dark:bg-gray-800 shadow">
+            <header class="shadow bg-[var(--surface)] text-[var(--text)]">
                 <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
                     {{ $header }}
                 </div>
             </header>
         @endif
         <!-- Page Content -->
-        <main class="text-gray-900 dark:text-gray-100">
+        <main>
             {{ $slot }}
         </main>
     </div>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
+        <meta name="theme-color" content="#FED17E">
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 
@@ -17,8 +18,8 @@
         <!-- Styles -->
         @livewireStyles
     </head>
-    <body>
-        <div class="font-sans text-gray-900 dark:text-gray-100 antialiased">
+    <body class="bg-[var(--background)] text-[var(--text)]">
+        <div class="font-sans antialiased">
             {{ $slot }}
         </div>
 


### PR DESCRIPTION
## Summary
- add CSS variables for Maddrax-themed palette
- apply dystopian colors across layouts
- override default Tailwind grays for new scheme

## Testing
- `npm run build`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_688cebc3e208832e95582053da7b4197