### PR TITLE
feat: add post-apocalyptic color palette

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -6,6 +6,55 @@
     display: none;
 }
 
+/* Post-apocalyptic color palette */
+:root {
+    --background: #FED17E; /* scorched earth */
+    --surface: #f4c76e;    /* lighter panels */
+    --text: #000000;       /* dark text */
+    --accent: #900316;     /* blood red */
+}
+
+.dark {
+    --background: #0f0f0f; /* wasteland night */
+    --surface: #1a0f0f;
+    --text: #FED17E;
+    --accent: #900316;
+}
+
+body {
+    background-color: var(--background);
+    color: var(--text);
+}
+
+a {
+    color: var(--accent);
+}
+
+a:hover {
+    color: #63010e;
+}
+
+/* Override Tailwind utility colors to use palette */
+.bg-white, .bg-gray-100 {
+    background-color: var(--surface) !important;
+}
+
+.text-gray-900 {
+    color: var(--text) !important;
+}
+
+.dark .bg-gray-800 {
+    background-color: var(--surface) !important;
+}
+
+.dark .bg-gray-900 {
+    background-color: var(--background) !important;
+}
+
+.dark .text-gray-100 {
+    color: var(--text) !important;
+}
+
 /* Vereinslogo als Asset referenzieren */
 .logo {
     background-image: url('../images/omxfc-logo.png');

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,8 +11,8 @@
     <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicon/favicon-16x16.png') }}">
     <link rel="manifest" href="{{ asset('favicon/site.webmanifest') }}">
     <link rel="shortcut icon" href="{{ asset('favicon/favicon.ico') }}">
-    <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="msapplication-TileColor" content="#FED17E">
+    <meta name="theme-color" content="#FED17E">
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
@@ -21,7 +21,7 @@
     @livewireStyles
 </head>
 
-<body class="font-sans antialiased">
+<body class="font-sans antialiased bg-[var(--background)] text-[var(--text)]">
     <!-- Livewire Scripts -->
     <script src="/livewire/livewire.min.js" 
         data-csrf="{{ csrf_token() }}" 
@@ -30,18 +30,18 @@
     </script>
 
     <x-banner />
-    <div class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 xl:pt-16">
+    <div class="min-h-screen xl:pt-16">
         @livewire('navigation-menu')
         <!-- Page Heading -->
         @if (isset($header))
-            <header class="bg-white dark:bg-gray-800 shadow">
+            <header class="shadow bg-[var(--surface)] text-[var(--text)]">
                 <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
                     {{ $header }}
                 </div>
             </header>
         @endif
         <!-- Page Content -->
-        <main class="text-gray-900 dark:text-gray-100">
+        <main>
             {{ $slot }}
         </main>
     </div>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -4,6 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
+        <meta name="theme-color" content="#FED17E">
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 
@@ -17,8 +18,8 @@
         <!-- Styles -->
         @livewireStyles
     </head>
-    <body>
-        <div class="font-sans text-gray-900 dark:text-gray-100 antialiased">
+    <body class="bg-[var(--background)] text-[var(--text)]">
+        <div class="font-sans antialiased">
             {{ $slot }}
         </div>
 


### PR DESCRIPTION
This pull request introduces a post-apocalyptic color palette to the application, replacing the default colors with a custom theme. The changes include defining new CSS variables, updating HTML templates to use the new palette, and overriding Tailwind utility classes to align with the theme.

### Theme Implementation:

* [`resources/css/app.css`](diffhunk://#diff-a1c9ab048f9b74906be677a45a60d9e91ec88bce4de1bc6c0456820b9f9b0998R9-R57): Added CSS variables for the post-apocalyptic color palette (`--background`, `--surface`, `--text`, `--accent`) and applied them to body, links, and Tailwind utility classes. A dark mode variant was also defined.

### Template Updates:

* [`resources/views/layouts/app.blade.php`](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7L24-R24): Updated the `<body>` and `<div>` elements to use the new color variables for background and text. Removed redundant Tailwind classes for colors and replaced them with the custom palette. [[1]](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7L24-R24) [[2]](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7L33-R44)
* [`resources/views/layouts/app.blade.php`](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7L14-R15): Changed the `meta` tags for `msapplication-TileColor` and `theme-color` to use the new `--background` color.

* [`resources/views/layouts/guest.blade.php`](diffhunk://#diff-05ed95a005677b19cdca1e1e1371e90fca89f16d7284070225931eee6ddc2f41R7): Applied the new theme variables for background and text to the `<body>` and removed unnecessary Tailwind classes. Added a `theme-color` meta tag for consistency. [[1]](diffhunk://#diff-05ed95a005677b19cdca1e1e1371e90fca89f16d7284070225931eee6ddc2f41R7) [[2]](diffhunk://#diff-05ed95a005677b19cdca1e1e1371e90fca89f16d7284070225931eee6ddc2f41L20-R22)