### PR TITLE
Revamp color scheme with post-apocalyptic palette

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -6,6 +6,16 @@
     display: none;
 }
 
+@layer base {
+    body {
+        @apply bg-charcoal text-dust;
+    }
+
+    a {
+        @apply text-rust hover:text-rust-light;
+    }
+}
+
 /* Vereinslogo als Asset referenzieren */
 .logo {
     background-image: url('../images/omxfc-logo.png');

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,3 +1,3 @@
-<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 transition ease-in-out duration-150']) }}>
+<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-rust text-dust border border-transparent rounded-md font-semibold text-xs uppercase tracking-widest hover:bg-rust-light focus:bg-rust-light active:bg-rust focus:outline-none focus:ring-2 focus:ring-rust focus:ring-offset-2 disabled:opacity-50 transition ease-in-out duration-150']) }}>
     {{ $slot }}
 </button>

--- a/resources/views/components/checkbox.blade.php
+++ b/resources/views/components/checkbox.blade.php
@@ -1,1 +1,1 @@
-<input type="checkbox" {!! $attributes->merge(['class' => 'rounded dark:bg-gray-900 border-gray-300 dark:border-gray-700 text-indigo-600 shadow-sm focus:ring-indigo-500 dark:focus:ring-indigo-600 dark:focus:ring-offset-gray-800']) !!}>
+<input type="checkbox" {!! $attributes->merge(['class' => 'rounded bg-charcoal border-rust text-rust shadow-sm focus:ring-rust focus:ring-offset-charcoal']) !!}>

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,4 +1,4 @@
-<footer class="bg-gray-900 text-white py-4">
+<footer class="bg-charcoal text-dust border-t border-rust py-4">
     <div class="container mx-auto px-4 text-center">
         <a href="{{ route('impressum') }}">Impressum</a> |
         <a href="{{ route('datenschutz') }}">Datenschutz</a>

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -1,3 +1,3 @@
 @props(['disabled' => false])
 
-<input {{ $disabled ? 'disabled' : '' }} {!! $attributes->merge(['class' => 'border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm']) !!}>
+<input {{ $disabled ? 'disabled' : '' }} {!! $attributes->merge(['class' => 'border-rust bg-charcoal text-dust focus:border-rust focus:ring-rust rounded-md shadow-sm']) !!}>

--- a/resources/views/components/nav-link.blade.php
+++ b/resources/views/components/nav-link.blade.php
@@ -2,8 +2,8 @@
 
 @php
 $classes = ($active ?? false)
-            ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 dark:border-indigo-600 text-sm font-medium leading-5 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-indigo-700 transition duration-150 ease-in-out'
-            : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-700 focus:outline-none focus:text-gray-700 dark:focus:text-gray-300 focus:border-gray-300 dark:focus:border-gray-700 transition duration-150 ease-in-out';
+            ? 'inline-flex items-center px-1 pt-1 border-b-2 border-rust text-sm font-medium leading-5 text-dust focus:outline-none focus:border-rust transition duration-150 ease-in-out'
+            : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-dust hover:text-rust hover:border-rust focus:outline-none focus:text-rust focus:border-rust transition duration-150 ease-in-out';
 @endphp
 
 <a {{ $attributes->merge(['class' => $classes]) }}>

--- a/resources/views/components/responsive-nav-link.blade.php
+++ b/resources/views/components/responsive-nav-link.blade.php
@@ -2,8 +2,8 @@
 
 @php
 $classes = ($active ?? false)
-            ? 'block w-full ps-3 pe-4 py-2 border-l-4 border-indigo-400 dark:border-indigo-600 text-start text-base font-medium text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/50 focus:outline-none focus:text-indigo-800 dark:focus:text-indigo-200 focus:bg-indigo-100 dark:focus:bg-indigo-900 focus:border-indigo-700 dark:focus:border-indigo-300 transition duration-150 ease-in-out'
-            : 'block w-full ps-3 pe-4 py-2 border-l-4 border-transparent text-start text-base font-medium text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-300 dark:hover:border-gray-600 focus:outline-none focus:text-gray-800 dark:focus:text-gray-200 focus:bg-gray-50 dark:focus:bg-gray-700 focus:border-gray-300 dark:focus:border-gray-600 transition duration-150 ease-in-out';
+            ? 'block w-full ps-3 pe-4 py-2 border-l-4 border-rust text-start text-base font-medium text-rust bg-ash focus:outline-none focus:text-rust focus:bg-charcoal focus:border-rust transition duration-150 ease-in-out'
+            : 'block w-full ps-3 pe-4 py-2 border-l-4 border-transparent text-start text-base font-medium text-dust hover:text-rust hover:bg-ash hover:border-rust focus:outline-none focus:text-rust focus:bg-ash focus:border-rust transition duration-150 ease-in-out';
 @endphp
 
 <a {{ $attributes->merge(['class' => $classes]) }}>

--- a/resources/views/components/secondary-button.blade.php
+++ b/resources/views/components/secondary-button.blade.php
@@ -1,3 +1,3 @@
-<button {{ $attributes->merge(['type' => 'button', 'class' => 'inline-flex items-center px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-500 rounded-md font-semibold text-xs text-gray-700 dark:text-gray-300 uppercase tracking-widest shadow-sm hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-25 transition ease-in-out duration-150']) }}>
+<button {{ $attributes->merge(['type' => 'button', 'class' => 'inline-flex items-center px-4 py-2 bg-ash border border-rust rounded-md font-semibold text-xs text-dust uppercase tracking-widest shadow-sm hover:bg-charcoal focus:outline-none focus:ring-2 focus:ring-rust focus:ring-offset-2 disabled:opacity-25 transition ease-in-out duration-150']) }}>
     {{ $slot }}
 </button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,8 +11,8 @@
     <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('favicon/favicon-16x16.png') }}">
     <link rel="manifest" href="{{ asset('favicon/site.webmanifest') }}">
     <link rel="shortcut icon" href="{{ asset('favicon/favicon.ico') }}">
-    <meta name="msapplication-TileColor" content="#ffffff">
-    <meta name="theme-color" content="#ffffff">
+    <meta name="msapplication-TileColor" content="#1b1b1b">
+    <meta name="theme-color" content="#1b1b1b">
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
@@ -30,18 +30,18 @@
     </script>
 
     <x-banner />
-    <div class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 xl:pt-16">
+    <div class="min-h-screen bg-charcoal text-dust xl:pt-16">
         @livewire('navigation-menu')
         <!-- Page Heading -->
         @if (isset($header))
-            <header class="bg-white dark:bg-gray-800 shadow">
+            <header class="bg-ash border-b border-rust shadow">
                 <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
                     {{ $header }}
                 </div>
             </header>
         @endif
         <!-- Page Content -->
-        <main class="text-gray-900 dark:text-gray-100">
+        <main class="text-dust">
             {{ $slot }}
         </main>
     </div>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -1,4 +1,4 @@
-<nav x-data="{ open: false, openMenu: null }" class="bg-white dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700 xl:fixed xl:top-0 xl:left-0 xl:right-0 xl:z-50">
+<nav x-data="{ open: false, openMenu: null }" class="bg-ash border-b border-rust xl:fixed xl:top-0 xl:left-0 xl:right-0 xl:z-50">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
             <!-- Linker Bereich: Logo + Hauptmenü -->
@@ -14,10 +14,10 @@
                         <x-nav-link href="{{ route('dashboard') }}">Dashboard</x-nav-link>
                         <!-- Dropdown Verein -->
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
-                            <button id="verein-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="verein-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                            <button id="verein-button" type="button" class="px-3 py-2 text-sm font-medium text-dust hover:text-rust focus:outline-none focus-visible:ring-2 focus-visible:ring-rust transition" :aria-expanded="open" aria-controls="verein-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
                                 Verein
                             </button>
-                            <div id="verein-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
+                            <div id="verein-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-charcoal border border-rust rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
                                 <x-dropdown-link href="{{ route('mitglieder.index') }}">Mitgliederliste</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('mitglieder.karte') }}">Mitgliederkarte</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('protokolle') }}">Protokolle</x-dropdown-link>
@@ -28,29 +28,29 @@
                         </div>
                         <!-- Dropdown Veranstaltungen -->
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
-                            <button id="veranstaltungen-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="veranstaltungen-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                            <button id="veranstaltungen-button" type="button" class="px-3 py-2 text-sm font-medium text-dust hover:text-rust focus:outline-none focus-visible:ring-2 focus-visible:ring-rust transition" :aria-expanded="open" aria-controls="veranstaltungen-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
                                 Veranstaltungen
                             </button>
-                            <div id="veranstaltungen-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
+                            <div id="veranstaltungen-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-charcoal border border-rust rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
                                 <x-dropdown-link href="{{ route('fotogalerie') }}">Fotos</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('meetings') }}">Meetings</x-dropdown-link>
                             </div>
                         </div>
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
-                            <button id="baxx-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="baxx-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                            <button id="baxx-button" type="button" class="px-3 py-2 text-sm font-medium text-dust hover:text-rust focus:outline-none focus-visible:ring-2 focus-visible:ring-rust transition" :aria-expanded="open" aria-controls="baxx-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
                                 Baxx
                             </button>
-                            <div id="baxx-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
+                            <div id="baxx-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-charcoal border border-rust rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
                                 <x-dropdown-link href="{{ route('todos.index') }}">Challenges</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('rewards.index') }}">Belohnungen</x-dropdown-link>
                             </div>
                         </div>
                         <!-- Dropdown Veranstaltungen -->
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
-                            <button id="belohnungen-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="belohnungen-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                            <button id="belohnungen-button" type="button" class="px-3 py-2 text-sm font-medium text-dust hover:text-rust focus:outline-none focus-visible:ring-2 focus-visible:ring-rust transition" :aria-expanded="open" aria-controls="belohnungen-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
                                 Belohnungen
                             </button>
-                            <div id="belohnungen-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
+                            <div id="belohnungen-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-charcoal border border-rust rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
                                 <x-dropdown-link href="{{ route('maddraxiversum.index') }}">Maddraxiversum</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('downloads') }}">Downloads</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('kompendium.index') }}">Kompendium</x-dropdown-link>
@@ -98,7 +98,7 @@
 
             <!-- Hamburger (Mobile) -->
             <div class="-mr-2 flex items-center sm:hidden">
-                <button @click="open = !open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700">
+                <button @click="open = !open" class="inline-flex items-center justify-center p-2 rounded-md text-dust hover:bg-ash">
                     <svg class="h-6 w-6" stroke="currentColor" fill="none">
                         <path :class="{'hidden': open, 'inline-flex': !open}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
                         <path :class="{'hidden': !open, 'inline-flex': open}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
@@ -112,7 +112,7 @@
     <div :class="{'block': open, 'hidden': !open}" class="hidden sm:hidden">
         @auth
             <x-responsive-nav-link href="{{ route('dashboard') }}">Dashboard</x-responsive-nav-link>
-            <button id="verein-mobile-button" type="button" @click="openMenu = (openMenu === 'verein' ? null : 'verein')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'verein' }" :aria-expanded="openMenu === 'verein'" aria-controls="verein-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'verein' ? null : 'verein')" @keydown.space.prevent="openMenu = (openMenu === 'verein' ? null : 'verein')">
+            <button id="verein-mobile-button" type="button" @click="openMenu = (openMenu === 'verein' ? null : 'verein')" class="w-full text-left px-4 py-2 font-bold text-dust focus:outline-none focus-visible:ring-2 focus-visible:ring-rust" :class="{ 'bg-ash': openMenu === 'verein' }" :aria-expanded="openMenu === 'verein'" aria-controls="verein-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'verein' ? null : 'verein')" @keydown.space.prevent="openMenu = (openMenu === 'verein' ? null : 'verein')">
             Verein</button>
             <div id="verein-mobile-menu" x-show="openMenu === 'verein'" x-cloak class="italic">
                 <x-responsive-nav-link href="{{ route('mitglieder.index') }}">Mitgliederliste</x-responsive-nav-link>
@@ -123,20 +123,20 @@
                 <x-responsive-nav-link href="{{ route('romantausch.index') }}">Tauschbörse</x-responsive-nav-link>
             </div>
 
-            <button id="veranstaltungen-mobile-button" type="button" @click="openMenu = (openMenu === 'veranstaltungen' ? null : 'veranstaltungen')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'veranstaltungen' }" :aria-expanded="openMenu === 'veranstaltungen'" aria-controls="veranstaltungen-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'veranstaltungen' ? null : 'veranstaltungen')" @keydown.space.prevent="openMenu = (openMenu === 'veranstaltungen' ? null : 'veranstaltungen')">
+            <button id="veranstaltungen-mobile-button" type="button" @click="openMenu = (openMenu === 'veranstaltungen' ? null : 'veranstaltungen')" class="w-full text-left px-4 py-2 font-bold text-dust focus:outline-none focus-visible:ring-2 focus-visible:ring-rust" :class="{ 'bg-ash': openMenu === 'veranstaltungen' }" :aria-expanded="openMenu === 'veranstaltungen'" aria-controls="veranstaltungen-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'veranstaltungen' ? null : 'veranstaltungen')" @keydown.space.prevent="openMenu = (openMenu === 'veranstaltungen' ? null : 'veranstaltungen')">
             Veranstaltungen</button>
             <div id="veranstaltungen-mobile-menu" x-show="openMenu === 'veranstaltungen'" x-cloak class="italic">
                 <x-responsive-nav-link href="{{ route('fotogalerie') }}">Fotos</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('meetings') }}">Meetings</x-responsive-nav-link>
             </div>
 
-            <button id="baxx-mobile-button" type="button" @click="openMenu = (openMenu === 'baxx' ? null : 'baxx')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'baxx' }" :aria-expanded="openMenu === 'baxx'" aria-controls="baxx-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'baxx' ? null : 'baxx')" @keydown.space.prevent="openMenu = (openMenu === 'baxx' ? null : 'baxx')">
+            <button id="baxx-mobile-button" type="button" @click="openMenu = (openMenu === 'baxx' ? null : 'baxx')" class="w-full text-left px-4 py-2 font-bold text-dust focus:outline-none focus-visible:ring-2 focus-visible:ring-rust" :class="{ 'bg-ash': openMenu === 'baxx' }" :aria-expanded="openMenu === 'baxx'" aria-controls="baxx-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'baxx' ? null : 'baxx')" @keydown.space.prevent="openMenu = (openMenu === 'baxx' ? null : 'baxx')">
             Baxx</button>
             <div id="baxx-mobile-menu" x-show="openMenu === 'baxx'" x-cloak class="italic">
                 <x-responsive-nav-link href="{{ route('todos.index') }}">Challenges</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('rewards.index') }}">Belohnungen</x-responsive-nav-link>
             </div>
-            <button id="belohnungen-mobile-button" type="button" @click="openMenu = (openMenu === 'belohnungen' ? null : 'belohnungen')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'belohnungen' }" :aria-expanded="openMenu === 'belohnungen'" aria-controls="belohnungen-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'belohnungen' ? null : 'belohnungen')" @keydown.space.prevent="openMenu = (openMenu === 'belohnungen' ? null : 'belohnungen')">
+            <button id="belohnungen-mobile-button" type="button" @click="openMenu = (openMenu === 'belohnungen' ? null : 'belohnungen')" class="w-full text-left px-4 py-2 font-bold text-dust focus:outline-none focus-visible:ring-2 focus-visible:ring-rust" :class="{ 'bg-ash': openMenu === 'belohnungen' }" :aria-expanded="openMenu === 'belohnungen'" aria-controls="belohnungen-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'belohnungen' ? null : 'belohnungen')" @keydown.space.prevent="openMenu = (openMenu === 'belohnungen' ? null : 'belohnungen')">
             Belohnungen</button>
             <div id="belohnungen-mobile-menu" x-show="openMenu === 'belohnungen'" x-cloak class="italic">
                 <x-responsive-nav-link href="{{ route('maddraxiversum.index') }}">Maddraxiversum</x-responsive-nav-link>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,15 @@ export default {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                charcoal: '#1b1b1b',
+                ash: '#2a2a2a',
+                rust: {
+                    DEFAULT: '#b7410e',
+                    light: '#da7627',
+                },
+                dust: '#d6d3d1',
+            },
         },
     },
 


### PR DESCRIPTION
## Summary
- add charcoal, ash, rust and dust color palette
- apply post-apocalyptic styling to layout, navigation and UI components

## Testing
- `npm run build`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688d9b4e9ee0832e98f02784e553705d