### PR TITLE
Add rating charts for all Maddrax cycles

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -110,6 +110,46 @@ class StatistikController extends Controller
         $eureeLabels = $eureeCycle->pluck('nummer');
         $eureeValues = $eureeCycle->pluck('bewertung');
 
+        // ── Card 9 – Bewertungen des Meeraka-Zyklus ──────────────────────
+        $meerakaCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 25 && ($r['nummer'] ?? 0) <= 49)
+            ->sortBy('nummer');
+
+        $meerakaLabels = $meerakaCycle->pluck('nummer');
+        $meerakaValues = $meerakaCycle->pluck('bewertung');
+
+        // ── Card 10 – Bewertungen des Expeditions-Zyklus ─────────────────
+        $expeditionCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 50 && ($r['nummer'] ?? 0) <= 74)
+            ->sortBy('nummer');
+
+        $expeditionLabels = $expeditionCycle->pluck('nummer');
+        $expeditionValues = $expeditionCycle->pluck('bewertung');
+
+        // ── Card 11 – Bewertungen des Kratersee-Zyklus ───────────────────
+        $kraterseeCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 75 && ($r['nummer'] ?? 0) <= 99)
+            ->sortBy('nummer');
+
+        $kraterseeLabels = $kraterseeCycle->pluck('nummer');
+        $kraterseeValues = $kraterseeCycle->pluck('bewertung');
+
+        // ── Card 12 – Bewertungen des Daa'muren-Zyklus ──────────────────
+        $daaMurenCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 100 && ($r['nummer'] ?? 0) <= 124)
+            ->sortBy('nummer');
+
+        $daaMurenLabels = $daaMurenCycle->pluck('nummer');
+        $daaMurenValues = $daaMurenCycle->pluck('bewertung');
+
+        // ── Card 13 – Bewertungen des Wandler-Zyklus ─────────────────────
+        $wandlerCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 125 && ($r['nummer'] ?? 0) <= 149)
+            ->sortBy('nummer');
+
+        $wandlerLabels = $wandlerCycle->pluck('nummer');
+        $wandlerValues = $wandlerCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -197,6 +237,16 @@ class StatistikController extends Controller
             'romaneTable' => $romaneTable,
             'eureeLabels' => $eureeLabels,
             'eureeValues' => $eureeValues,
+            'meerakaLabels' => $meerakaLabels,
+            'meerakaValues' => $meerakaValues,
+            'expeditionLabels' => $expeditionLabels,
+            'expeditionValues' => $expeditionValues,
+            'kraterseeLabels' => $kraterseeLabels,
+            'kraterseeValues' => $kraterseeValues,
+            'daaMurenLabels' => $daaMurenLabels,
+            'daaMurenValues' => $daaMurenValues,
+            'wandlerLabels' => $wandlerLabels,
+            'wandlerValues' => $wandlerValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -64,7 +64,32 @@ return [
     [
         'title' => 'Statistik - Bewertungen des Euree-Zyklus',
         'description' => 'Zeigt Bewertungen des Euree-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
-        'points' => 12,
+        'points' => 13,
+    ],
+    [
+        'title' => 'Statistik - Bewertungen des Meeraka-Zyklus',
+        'description' => 'Zeigt Bewertungen des Meeraka-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 14,
+    ],
+    [
+        'title' => 'Statistik - Bewertungen des Expeditions-Zyklus',
+        'description' => 'Zeigt Bewertungen des Expeditions-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 15,
+    ],
+    [
+        'title' => 'Statistik - Bewertungen des Kratersee-Zyklus',
+        'description' => 'Zeigt Bewertungen des Kratersee-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 16,
+    ],
+    [
+        'title' => 'Statistik - Bewertungen des Daa\'muren-Zyklus',
+        'description' => 'Zeigt Bewertungen des Daa\'muren-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 17,
+    ],
+    [
+        'title' => 'Statistik - Bewertungen des Wandler-Zyklus',
+        'description' => 'Zeigt Bewertungen des Wandler-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 18,
     ],
     [
         'title' => 'Kompendium-Suche',

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -30,10 +30,10 @@ function drawAuthorChart(canvasId, labels, data) {
 }
 
 /**
- * Rendert das Liniendiagramm „Bewertungen des Euree-Zyklus“,
+ * Rendert ein Liniendiagramm für die Zyklus-Bewertungen,
  * wenn das Canvas existiert.
  */
-function drawEureeChart(canvasId, labels, data) {
+function drawCycleChart(canvasId, labels, data) {
     const canvas = document.getElementById(canvasId);
     if (!canvas) return;
 
@@ -78,11 +78,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const labels = window.authorChartLabels ?? [];
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
-    const eureeLabels = window.eureeChartLabels ?? [];
-    const eureeValues = window.eureeChartValues ?? [];
-    drawEureeChart('eureeChart', eureeLabels, eureeValues);
+
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler'];
+    cycles.forEach((cycle) => {
+        const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
+        const cycleValues = window[`${cycle}ChartValues`] ?? [];
+        drawCycleChart(`${cycle}Chart`, cycleLabels, cycleValues);
+    });
+
     initRomaneTable();
 });
 
 /* ── optionale Named-Exports (falls du die Funktionen woanders brauchst) */
-export { drawAuthorChart, drawEureeChart, initRomaneTable };
+export { drawAuthorChart, drawCycleChart, initRomaneTable };

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -271,6 +271,82 @@
                     window.eureeChartValues = @json($eureeValues);
                 </script>
             @endif
+
+            {{-- Card 9 – Bewertungen des Meeraka-Zyklus (≥ 14 Baxx) --}}
+            @if ($userPoints >= 14)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Meeraka-Zyklus
+                    </h2>
+                    <canvas id="meerakaChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.meerakaChartLabels = @json($meerakaLabels);
+                    window.meerakaChartValues = @json($meerakaValues);
+                </script>
+            @endif
+
+            {{-- Card 10 – Bewertungen des Expeditions-Zyklus (≥ 15 Baxx) --}}
+            @if ($userPoints >= 15)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Expeditions-Zyklus
+                    </h2>
+                    <canvas id="expeditionChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.expeditionChartLabels = @json($expeditionLabels);
+                    window.expeditionChartValues = @json($expeditionValues);
+                </script>
+            @endif
+
+            {{-- Card 11 – Bewertungen des Kratersee-Zyklus (≥ 16 Baxx) --}}
+            @if ($userPoints >= 16)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Kratersee-Zyklus
+                    </h2>
+                    <canvas id="kraterseeChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.kraterseeChartLabels = @json($kraterseeLabels);
+                    window.kraterseeChartValues = @json($kraterseeValues);
+                </script>
+            @endif
+
+            {{-- Card 12 – Bewertungen des Daa'muren-Zyklus (≥ 17 Baxx) --}}
+            @if ($userPoints >= 17)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Daa'muren-Zyklus
+                    </h2>
+                    <canvas id="daaMurenChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.daaMurenChartLabels = @json($daaMurenLabels);
+                    window.daaMurenChartValues = @json($daaMurenValues);
+                </script>
+            @endif
+
+            {{-- Card 13 – Bewertungen des Wandler-Zyklus (≥ 18 Baxx) --}}
+            @if ($userPoints >= 18)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Wandler-Zyklus
+                    </h2>
+                    <canvas id="wandlerChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.wandlerChartLabels = @json($wandlerLabels);
+                    window.wandlerChartValues = @json($wandlerValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif


### PR DESCRIPTION
This pull request introduces support for displaying and managing data for additional cycles in the statistics feature. It includes updates to the backend logic, frontend rendering, and configuration to handle these new cycles dynamically. The most important changes are grouped below:

### Backend Enhancements
* Added logic in `StatistikController.php` to filter and process data for five new cycles: Meeraka, Expedition, Kratersee, Daa'muren, and Wandler. Each cycle has its own labels and values for rendering charts.
* Updated the `index` method in `StatistikController.php` to pass the new cycle data (`meerakaLabels`, `expeditionLabels`, etc.) to the view.

### Frontend Updates
* Refactored the JavaScript function `drawEureeChart` to a more generic `drawCycleChart` for rendering charts dynamically based on cycle data. Updated the DOMContentLoaded event to iterate over all cycles and render their respective charts. [[1]](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L33-R36) [[2]](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L81-R93)
* Added new cards to `index.blade.php` for each cycle, displaying charts conditionally based on user points. Each card includes a canvas element and associated script for chart data.

### Configuration Changes
* Updated `config/rewards.php` to include new rewards for each cycle, specifying titles, descriptions, and point requirements.