### PR TITLE
Add Lieblingsthema profile field

### DIFF
--- a/app/Actions/Fortify/UpdateUserSeriendaten.php
+++ b/app/Actions/Fortify/UpdateUserSeriendaten.php
@@ -19,6 +19,7 @@ class UpdateUserSeriendaten
             'lieblingsschauplatz' => ['nullable', 'string', 'max:255'],
             'lieblingsautor' => ['nullable', 'string', 'max:255'],
             'lieblingszyklus' => ['nullable', 'string', 'max:255'],
+            'lieblingsthema' => ['nullable', 'string', 'max:255'],
         ])->validateWithBag('updateSeriendaten');
 
         $user->forceFill([
@@ -30,6 +31,7 @@ class UpdateUserSeriendaten
             'lieblingsschauplatz' => $input['lieblingsschauplatz'] ?? null,
             'lieblingsautor' => $input['lieblingsautor'] ?? null,
             'lieblingszyklus' => $input['lieblingszyklus'] ?? null,
+            'lieblingsthema' => $input['lieblingsthema'] ?? null,
         ])->save();
     }
 }

--- a/app/Livewire/Profile/UpdateSeriendatenForm.php
+++ b/app/Livewire/Profile/UpdateSeriendatenForm.php
@@ -15,6 +15,7 @@ class UpdateSeriendatenForm extends Component
     public array $romane = [];
     public array $figuren = [];
     public array $schauplaetze = [];
+    public array $schlagworte = [];
 
     public function mount()
     {
@@ -27,12 +28,14 @@ class UpdateSeriendatenForm extends Component
             'lieblingsschauplatz',
             'lieblingsautor',
             'lieblingszyklus',
+            'lieblingsthema',
         ]);
         $this->autoren = MaddraxDataService::getAutoren();
         $this->zyklen = MaddraxDataService::getZyklen();
         $this->romane = MaddraxDataService::getRomane();
         $this->figuren = MaddraxDataService::getFiguren();
         $this->schauplaetze = MaddraxDataService::getSchauplaetze();
+        $this->schlagworte = MaddraxDataService::getSchlagworte();
     }
 
     public function updateSeriendaten(UpdateUserSeriendaten $updater)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,7 @@ use Carbon\Carbon;
  * @property string|null $lieblingsschauplatz
  * @property string|null $lieblingsautor
  * @property string|null $lieblingszyklus
+ * @property string|null $lieblingsthema
  */
 class User extends Authenticatable
 {
@@ -65,6 +66,7 @@ class User extends Authenticatable
         'lieblingsschauplatz',
         'lieblingsautor',
         'lieblingszyklus',
+        'lieblingsthema',
         'mitglied_seit',
         'bezahlt_bis',
         'notify_new_review',

--- a/app/Services/MaddraxDataService.php
+++ b/app/Services/MaddraxDataService.php
@@ -134,4 +134,22 @@ class MaddraxDataService
 
         return $schauplaetze;
     }
+
+    /**
+     * Alle Schlagworte distinct und alphabetisch sortiert zurückgeben
+     */
+    public static function getSchlagworte(): array
+    {
+        $data = self::loadData();
+
+        $schlagworte = collect($data)
+            ->pluck('schlagworte')
+            ->flatten()
+            ->unique()
+            ->sort()
+            ->values()
+            ->toArray();
+
+        return $schlagworte;
+    }
 }

--- a/database/migrations/2025_08_02_205523_add_lieblingsthema_to_users_table.php
+++ b/database/migrations/2025_08_02_205523_add_lieblingsthema_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('lieblingsthema')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('lieblingsthema');
+        });
+    }
+};

--- a/lang/de/profile.php
+++ b/lang/de/profile.php
@@ -5,6 +5,7 @@ return [
     'Aktueller Lesestand (optional)' => 'Aktueller Lesestand (optional)',
     'Lieblingsautor:in (optional)' => 'Lieblingsautor:in (optional)',
     'Lieblingsroman (optional)' => 'Lieblingsroman (optional)',
+    'Lieblingsthema (optional)' => 'Lieblingsthema (optional)',
     'Persönliche Daten' => 'Persönliche Daten',
     'Hier kannst du ganz einfach deine persönlichen Angaben aktualisieren. Bitte halte diese Informationen möglichst aktuell, damit wir dich erreichen können. Während Namen und Foto für andere sichtbar sind, bleiben deine Adressdaten und dein eingestellter Mitgliedsbeitrag für andere Mitglieder unsichtbar.' => 'Hier kannst du ganz einfach deine persönlichen Angaben aktualisieren. Bitte halte diese Informationen möglichst aktuell, damit wir dich erreichen können. Während Namen und Foto für andere sichtbar sind, bleiben deine Adressdaten und dein eingestellter Mitgliedsbeitrag für andere Mitglieder unsichtbar.',
     'Foto' => 'Foto',

--- a/resources/views/profile/update-seriendaten-form.blade.php
+++ b/resources/views/profile/update-seriendaten-form.blade.php
@@ -94,6 +94,18 @@
             </select>
             <x-input-error for="lieblingsschauplatz" class="mt-2" />
         </div>
+        <!-- Lieblingsthema Dropdown -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="lieblingsthema" value="{{ __('Lieblingsthema (optional)') }}" />
+            <select id="lieblingsthema" wire:model="state.lieblingsthema"
+                class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-800 rounded-md shadow-sm">
+                <option value="">Thema auswählen</option>
+                @foreach($schlagworte as $thema)
+                    <option value="{{ $thema }}">{{ $thema }}</option>
+                @endforeach
+            </select>
+            <x-input-error for="lieblingsthema" class="mt-2" />
+        </div>
         <!-- TODO: Lieblingsmutation -->
     </x-slot>
     <x-slot name="actions">

--- a/resources/views/profile/view.blade.php
+++ b/resources/views/profile/view.blade.php
@@ -224,6 +224,12 @@
                                         <p class="text-gray-600 dark:text-gray-300">{{ $user->lieblingszyklus }}-Zyklus</p>
                                     </div>
                                 @endif
+                                @if($user->lieblingsthema)
+                                    <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg shadow">
+                                        <h3 class="font-semibold text-gray-800 dark:text-white mb-2">Lieblingsthema</h3>
+                                        <p class="text-gray-600 dark:text-gray-300">{{ $user->lieblingsthema }}</p>
+                                    </div>
+                                @endif
                             </div>
                         </div>
                     </div>

--- a/tests/Feature/MaddraxDataServiceTest.php
+++ b/tests/Feature/MaddraxDataServiceTest.php
@@ -37,6 +37,7 @@ class MaddraxDataServiceTest extends TestCase
                 'text' => ['Author1', 'Author2'],
                 'personen' => ['Figur1'],
                 'orte' => ['Ort1'],
+                'schlagworte' => ['Thema1'],
             ],
             [
                 'nummer' => 2,
@@ -45,6 +46,7 @@ class MaddraxDataServiceTest extends TestCase
                 'text' => ['Author1'],
                 'personen' => ['Figur2'],
                 'orte' => ['Ort2'],
+                'schlagworte' => ['Thema2'],
             ],
         ];
         File::put($this->testStoragePath . '/app/private/maddrax.json', json_encode($data));
@@ -73,6 +75,7 @@ class MaddraxDataServiceTest extends TestCase
         $this->assertSame(['1 - Roman1', '2 - Roman2'], MaddraxDataService::getRomane());
         $this->assertSame(['Figur1', 'Figur2'], MaddraxDataService::getFiguren());
         $this->assertSame(['Ort1', 'Ort2'], MaddraxDataService::getSchauplaetze());
+        $this->assertSame(['Thema1', 'Thema2'], MaddraxDataService::getSchlagworte());
     }
 
     public function test_load_data_returns_empty_when_file_is_missing(): void

--- a/tests/Feature/UpdateSeriendatenFormTest.php
+++ b/tests/Feature/UpdateSeriendatenFormTest.php
@@ -42,6 +42,7 @@ class UpdateSeriendatenFormTest extends TestCase
                 'text' => ['Author1', 'Author2'],
                 'personen' => ['Figur1'],
                 'orte' => ['Ort1'],
+                'schlagworte' => ['Thema1'],
             ],
             [
                 'nummer' => 2,
@@ -50,6 +51,7 @@ class UpdateSeriendatenFormTest extends TestCase
                 'text' => ['Author1'],
                 'personen' => ['Figur2'],
                 'orte' => ['Ort2'],
+                'schlagworte' => ['Thema2'],
             ],
         ];
         File::put($this->testStoragePath . '/app/private/maddrax.json', json_encode($data));
@@ -81,6 +83,7 @@ class UpdateSeriendatenFormTest extends TestCase
             'lieblingsschauplatz' => 'Ort1',
             'lieblingsautor' => 'Author1',
             'lieblingszyklus' => 'Z1',
+            'lieblingsthema' => 'Thema1',
         ])->save();
 
         $this->actingAs($user);
@@ -97,11 +100,13 @@ class UpdateSeriendatenFormTest extends TestCase
             ->assertSet('state.lieblingsschauplatz', 'Ort1')
             ->assertSet('state.lieblingsautor', 'Author1')
             ->assertSet('state.lieblingszyklus', 'Z1')
+            ->assertSet('state.lieblingsthema', 'Thema1')
             ->assertSet('autoren', ['Author1', 'Author2'])
             ->assertSet('zyklen', ['Z1', 'Z2'])
             ->assertSet('romane', ['1 - Roman1', '2 - Roman2'])
             ->assertSet('figuren', ['Figur1', 'Figur2'])
-            ->assertSet('schauplaetze', ['Ort1', 'Ort2']);
+            ->assertSet('schauplaetze', ['Ort1', 'Ort2'])
+            ->assertSet('schlagworte', ['Thema1', 'Thema2']);
     }
 
     public function test_seriendaten_can_be_updated(): void
@@ -119,6 +124,7 @@ class UpdateSeriendatenFormTest extends TestCase
                 'lieblingsschauplatz' => 'Ort2',
                 'lieblingsautor' => 'Author2',
                 'lieblingszyklus' => 'Z2',
+                'lieblingsthema' => 'Thema2',
             ])
             ->call('updateSeriendaten')
             ->assertDispatched('saved');
@@ -133,5 +139,6 @@ class UpdateSeriendatenFormTest extends TestCase
         $this->assertSame('Ort2', $user->lieblingsschauplatz);
         $this->assertSame('Author2', $user->lieblingsautor);
         $this->assertSame('Z2', $user->lieblingszyklus);
+        $this->assertSame('Thema2', $user->lieblingsthema);
     }
 }

--- a/tests/Feature/UpdateSeriendatenTest.php
+++ b/tests/Feature/UpdateSeriendatenTest.php
@@ -23,6 +23,7 @@ class UpdateSeriendatenTest extends TestCase
             'lieblingsschauplatz' => 'Ort',
             'lieblingsautor' => 'Autor',
             'lieblingszyklus' => 'Zyklus',
+            'lieblingsthema' => 'Thema',
         ]));
 
         $component = Livewire::test(UpdateSeriendatenForm::class);
@@ -35,6 +36,7 @@ class UpdateSeriendatenTest extends TestCase
         $this->assertSame('Ort', $component->get('state.lieblingsschauplatz'));
         $this->assertSame('Autor', $component->get('state.lieblingsautor'));
         $this->assertSame('Zyklus', $component->get('state.lieblingszyklus'));
+        $this->assertSame('Thema', $component->get('state.lieblingsthema'));
     }
 
     public function test_seriendaten_can_be_updated(): void
@@ -51,6 +53,7 @@ class UpdateSeriendatenTest extends TestCase
                 'lieblingsschauplatz' => 'F',
                 'lieblingsautor' => 'G',
                 'lieblingszyklus' => 'H',
+                'lieblingsthema' => 'I',
             ])
             ->call('updateSeriendaten');
 
@@ -64,6 +67,7 @@ class UpdateSeriendatenTest extends TestCase
         $this->assertSame('F', $user->lieblingsschauplatz);
         $this->assertSame('G', $user->lieblingsautor);
         $this->assertSame('H', $user->lieblingszyklus);
+        $this->assertSame('I', $user->lieblingsthema);
     }
 
     public function test_validation_fails_for_too_long_values(): void


### PR DESCRIPTION
This pull request introduces a new "Lieblingsthema" (favorite topic) feature to the user profile, allowing users to select and manage their favorite topics. The changes span across the backend, frontend, and tests to fully integrate this feature. Below is a breakdown of the most important changes:

### Backend Changes
* Added a new nullable `lieblingsthema` column to the `users` table via a migration (`database/migrations/2025_08_02_205523_add_lieblingsthema_to_users_table.php`).
* Updated the `User` model to include `lieblingsthema` as a fillable property and added it to the model's PHPDoc (`app/Models/User.php`) [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR29) [[2]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR69).
* Modified the `UpdateUserSeriendaten` action to handle the `lieblingsthema` field during validation and data updates (`app/Actions/Fortify/UpdateUserSeriendaten.php`) [[1]](diffhunk://#diff-2c91a5acbaae159d3c7703fbd36ddeae5939a6f58cc2b30e729f15d077f0573aR22) [[2]](diffhunk://#diff-2c91a5acbaae159d3c7703fbd36ddeae5939a6f58cc2b30e729f15d077f0573aR34).
* Added a new method `getSchlagworte()` to the `MaddraxDataService` to retrieve distinct and sorted topics (`app/Services/MaddraxDataService.php`).

### Frontend Changes
* Updated the `UpdateSeriendatenForm` Livewire component to include `lieblingsthema` in the state and fetch Schlagworte (topics) from the service (`app/Livewire/Profile/UpdateSeriendatenForm.php`) [[1]](diffhunk://#diff-f0c82d7ea9149bbb3e2797cb528ccbd375225cbf69290484682e0ad3a880a93cR18) [[2]](diffhunk://#diff-f0c82d7ea9149bbb3e2797cb528ccbd375225cbf69290484682e0ad3a880a93cR31-R38).
* Added a dropdown for selecting `lieblingsthema` in the profile update form (`resources/views/profile/update-seriendaten-form.blade.php`).
* Displayed the selected `lieblingsthema` in the user profile view (`resources/views/profile/view.blade.php`).
* Updated the German localization file to include a label for "Lieblingsthema" (`lang/de/profile.php`).

### Tests
* Extended test data and assertions in the `MaddraxDataServiceTest` to validate the new `getSchlagworte()` method (`tests/Feature/MaddraxDataServiceTest.php`) [[1]](diffhunk://#diff-f40161185859e6fef31451231438eb61f6b0de98f6817ab5906c270e9d84a2f4R40) [[2]](diffhunk://#diff-f40161185859e6fef31451231438eb61f6b0de98f6817ab5906c270e9d84a2f4R78).
* Updated `UpdateSeriendatenFormTest` to test the integration of `lieblingsthema` in the form state and its update functionality (`tests/Feature/UpdateSeriendatenFormTest.php`) [[1]](diffhunk://#diff-3d5b7f9447233b70270e48873e01df376acf1134ec7fc6bc5e85b27d50d9ee75R86) [[2]](diffhunk://#diff-3d5b7f9447233b70270e48873e01df376acf1134ec7fc6bc5e85b27d50d9ee75R103-R109) [[3]](diffhunk://#diff-3d5b7f9447233b70270e48873e01df376acf1134ec7fc6bc5e85b27d50d9ee75R127).
* Adjusted `UpdateSeriendatenTest` to validate the availability and update of `lieblingsthema` in the user profile (`tests/Feature/UpdateSeriendatenTest.php`) [[1]](diffhunk://#diff-090df499a8798a4ffc41db1f85a11cd2f7aecefc2e07e8c8b9bc3ce908a424a8R26) [[2]](diffhunk://#diff-090df499a8798a4ffc41db1f85a11cd2f7aecefc2e07e8c8b9bc3ce908a424a8R70).