### PR TITLE
feat(admin): display per-user page visit chart

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -14,6 +14,11 @@ class AdminController extends Controller
             ->orderByDesc('total')
             ->get();
 
-        return view('admin.index', compact('visitData'));
+        $userVisitData = PageVisit::select('path', 'user_id', DB::raw('COUNT(*) as total'))
+            ->with('user:id,name')
+            ->groupBy('path', 'user_id')
+            ->get();
+
+        return view('admin.index', compact('visitData', 'userVisitData'));
     }
 }

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -13,6 +13,15 @@
         </div>
     </div>
 
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6">
+                <h3 class="font-semibold text-lg mb-4">Seitenaufrufe nach Nutzer</h3>
+                <canvas id="userVisitsChart"></canvas>
+            </div>
+        </div>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
         const visitData = @json($visitData);
@@ -33,6 +42,38 @@
                 }]
             },
             options: {
+                scales: {
+                    y: { beginAtZero: true }
+                }
+            }
+        });
+
+        const userVisitData = @json($userVisitData);
+        const paths = [...new Set(userVisitData.map(v => v.path))];
+        const users = [...new Set(userVisitData.map(v => v.user.name))];
+
+        const datasets = users.map((user, index) => {
+            const color = `hsl(${index * 360 / users.length}, 70%, 50%)`;
+            const data = paths.map(path => {
+                const record = userVisitData.find(v => v.path === path && v.user.name === user);
+                return record ? record.total : 0;
+            });
+            return {
+                label: user,
+                data,
+                backgroundColor: color,
+            };
+        });
+
+        const ctx2 = document.getElementById('userVisitsChart').getContext('2d');
+        new Chart(ctx2, {
+            type: 'bar',
+            data: {
+                labels: paths,
+                datasets: datasets,
+            },
+            options: {
+                responsive: true,
                 scales: {
                     y: { beginAtZero: true }
                 }


### PR DESCRIPTION
This pull request enhances the admin dashboard by introducing a new feature to display page visit data grouped by users. It includes backend changes to fetch additional data and frontend updates to visualize it using a bar chart.

### Backend changes:
* [`app/Http/Controllers/AdminController.php`](diffhunk://#diff-1c6494e1e9cbdc520eac89f9be1dcaff36c5a7aad7d0efaf22beddb70d8c1dc5L17-R22): Updated the `index` method to retrieve page visit data grouped by `path` and `user_id`, including user details, and pass it to the view as `userVisitData`.

### Frontend changes:
* `resources/views/admin/index.blade.php`: 
  * Added a new section to display a bar chart titled "Seitenaufrufe nach Nutzer" (Page Visits by User), utilizing Chart.js.
  * Implemented a script to process `userVisitData` for generating a bar chart, showing page visits per user for each path. Each user is represented with a distinct color.