### PR TITLE
Add public donation page with PayPal button

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -123,6 +123,11 @@ class PageController extends Controller
         return view('pages.datenschutz');
     }
 
+    public function spenden()
+    {
+        return view('pages.spenden');
+    }
+
     public function changelog()
     {
         return view('pages.changelog');

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -68,6 +68,7 @@
                         <x-nav-link href="{{ route('termine') }}">Termine</x-nav-link>
                         <x-nav-link href="{{ route('satzung') }}">Satzung</x-nav-link>
                         <x-nav-link href="{{ route('mitglied.werden') }}">Mitglied werden</x-nav-link>
+                        <x-nav-link href="{{ route('spenden') }}">Spenden</x-nav-link>
                         <x-nav-link href="{{ route('changelog') }}">Changelog</x-nav-link>
                     @endguest
                 </div>
@@ -160,6 +161,7 @@
             <x-responsive-nav-link href="{{ route('termine') }}">Termine</x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('satzung') }}">Satzung</x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('mitglied.werden') }}">Mitglied werden</x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('spenden') }}">Spenden</x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('changelog') }}">Changelog</x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('login') }}">Login</x-responsive-nav-link>
         @endguest

--- a/resources/views/pages/spenden.blade.php
+++ b/resources/views/pages/spenden.blade.php
@@ -1,0 +1,14 @@
+<x-app-layout>
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 bg-gray-100 dark:bg-gray-800">
+        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Spenden</h1>
+        <p class="mb-4">Der Offizielle MADDRAX Fanclub e. V. bietet Fans der Science-Fiction-Serie eine Plattform zum Austausch und zur gemeinsamen Organisation.</p>
+        <p class="mb-6">Spenden helfen uns bei der Finanzierung der jährlichen Fantreffen sowie der Serverkosten dieser Webseite.</p>
+        <form action="https://www.paypal.com/donate" method="post" target="_top" class="mt-4">
+            <input type="hidden" name="business" value="kassenwart@maddrax-fanclub.de" />
+            <input type="hidden" name="no_recurring" value="0" />
+            <input type="hidden" name="currency_code" value="EUR" />
+            <input type="image" src="https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donateCC_LG.gif" name="submit" alt="Spenden mit PayPal" />
+            <img alt="" src="https://www.paypal.com/en_DE/i/scr/pixel.gif" width="1" height="1" />
+        </form>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ Route::get('/termine', [PageController::class, 'termine'])->name('termine');
 Route::get('/mitglied-werden', [PageController::class, 'mitgliedWerden'])->name('mitglied.werden');
 Route::get('/impressum', [PageController::class, 'impressum'])->name('impressum');
 Route::get('/datenschutz', [PageController::class, 'datenschutz'])->name('datenschutz');
+Route::get('/spenden', [PageController::class, 'spenden'])->name('spenden');
 Route::get('/changelog', [PageController::class, 'changelog'])->name('changelog');
 Route::get('/mitglied-werden/erfolgreich', [PageController::class, 'mitgliedWerdenErfolgreich'])->name('mitglied.werden.erfolgreich');
 Route::get('/mitglied-werden/bestaetigt', [PageController::class, 'mitgliedWerdenBestaetigt'])->name('mitglied.werden.bestaetigt');

--- a/tests/Feature/PageAccessibilityTest.php
+++ b/tests/Feature/PageAccessibilityTest.php
@@ -22,6 +22,7 @@ class PageAccessibilityTest extends TestCase
             '/arbeitsgruppen',
             '/termine',
             '/mitglied-werden',
+            '/spenden',
             '/impressum',
             '/datenschutz',
             '/changelog',


### PR DESCRIPTION
This pull request introduces a new "Spenden" (Donations) page to the application, along with its associated routing, navigation links, and accessibility tests. Below is a summary of the most important changes:

### New "Spenden" Page Implementation:

* Added a new `spenden` method in `PageController` to render the "Spenden" view (`app/Http/Controllers/PageController.php`).
* Created a new Blade template for the "Spenden" page, which includes a description and a PayPal donation form (`resources/views/pages/spenden.blade.php`).

### Navigation Updates:

* Added a "Spenden" link to the primary navigation menu (`resources/views/navigation-menu.blade.php`).
* Added a "Spenden" link to the responsive navigation menu (`resources/views/navigation-menu.blade.php`).

### Routing and Testing:

* Added a new route for the "Spenden" page in the web routes file (`routes/web.php`).
* Updated the accessibility test to include the "Spenden" page (`tests/Feature/PageAccessibilityTest.php`).