### PR TITLE
feat: add 3d effect to desktop navigation

### DIFF
--- a/resources/views/components/nav-link.blade.php
+++ b/resources/views/components/nav-link.blade.php
@@ -2,8 +2,8 @@
 
 @php
 $classes = ($active ?? false)
-            ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 dark:border-indigo-600 text-sm font-medium leading-5 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-indigo-700 transition duration-150 ease-in-out'
-            : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-700 focus:outline-none focus:text-gray-700 dark:focus:text-gray-300 focus:border-gray-300 dark:focus:border-gray-700 transition duration-150 ease-in-out';
+            ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 dark:border-indigo-600 text-sm font-medium leading-5 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-indigo-700 transition duration-150 ease-in-out lg:hover:-translate-y-0.5 lg:hover:shadow-md dark:lg:hover:translate-y-0 dark:lg:hover:shadow-none'
+            : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-700 focus:outline-none focus:text-gray-700 dark:focus:text-gray-300 focus:border-gray-300 dark:focus:border-gray-700 transition duration-150 ease-in-out lg:hover:-translate-y-0.5 lg:hover:shadow-md dark:lg:hover:translate-y-0 dark:lg:hover:shadow-none';
 @endphp
 
 <a {{ $attributes->merge(['class' => $classes]) }}>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -1,4 +1,4 @@
-<nav x-data="{ open: false, openMenu: null }" class="bg-white dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700 xl:fixed xl:top-0 xl:left-0 xl:right-0 xl:z-50">
+<nav x-data="{ open: false, openMenu: null }" class="bg-white dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700 xl:fixed xl:top-0 xl:left-0 xl:right-0 xl:z-50 lg:shadow-md dark:lg:shadow-none">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
             <!-- Linker Bereich: Logo + Hauptmenü -->


### PR DESCRIPTION
## Summary
- add subtle shadow to main navigation bar in light mode
- add hover lift and shadow for desktop navigation links

## Testing
- `npm run build`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_688ee483af7c832e8cbe07d9689ae1f9