### PR TITLE
feat: show app version in footer

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\View;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -25,5 +27,9 @@ class AppServiceProvider extends ServiceProvider
             URL::forceScheme('https');
             $this->app['request']->server->set('HTTPS', true);
         }
+
+        $process = Process::run('git describe --tags --abbrev=0');
+        $version = $process->successful() ? trim($process->output()) : '0.0.0';
+        View::share('appVersion', $version);
     }
 }

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -2,6 +2,6 @@
     <div class="container mx-auto px-4 text-center">
         <a href="{{ route('impressum') }}">Impressum</a> |
         <a href="{{ route('datenschutz') }}">Datenschutz</a>
-        <p class="mt-2">© OMXFC e.V. {{ date('Y') }}</p>
+        <p class="mt-2">© OMXFC e.V. {{ date('Y') }} | Version {{ $appVersion }} | <a href="{{ route('changelog') }}">Changelog</a></p>
     </div>
 </footer>

--- a/tests/Feature/FooterVersionTest.php
+++ b/tests/Feature/FooterVersionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class FooterVersionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_footer_displays_version_and_changelog_link(): void
+    {
+        $version = trim(Process::run('git describe --tags --abbrev=0')->output());
+        $response = $this->get('/');
+        $response->assertSee("Version {$version}");
+        $response->assertSee('/changelog');
+    }
+}


### PR DESCRIPTION
This pull request introduces functionality to display the application's version and a changelog link in the footer. The version is dynamically determined from the latest Git tag and shared with views. Additionally, a feature test ensures the footer displays this information correctly. Below are the most important changes:

### Backend changes:
* [`app/Providers/AppServiceProvider.php`](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR30-R33): Added logic to retrieve the application's version using the `git describe` command and share it with all views via the `View::share` method.

### Frontend changes:
* [`resources/views/components/footer.blade.php`](diffhunk://#diff-b17dcf85695a8a9d01c05fea3b02223342c3a78b150a4bceccff6cd527c3cfc8L5-R5): Updated the footer to display the application version and a link to the changelog.

### Testing:
* [`tests/Feature/FooterVersionTest.php`](diffhunk://#diff-5162b51c51b8036907d07d36883a59ac1077dfea6a155145da31504f2d67dc9bR1-R20): Introduced a feature test to verify that the footer displays the correct version and includes the changelog link.