### PR TITLE
Nutze deutsche Slugs für Routen

### DIFF
--- a/app/Http/Controllers/KompendiumController.php
+++ b/app/Http/Controllers/KompendiumController.php
@@ -33,7 +33,7 @@ class KompendiumController extends Controller
     }
 
     /* --------------------------------------------------------------------- */
-    /*  GET /kompendium/search  (AJAX)                                       */
+    /*  GET /kompendium/suche  (AJAX)                                       */
     /* --------------------------------------------------------------------- */
     public function search(Request $request): JsonResponse
     {

--- a/resources/js/maddraxiversum.js
+++ b/resources/js/maddraxiversum.js
@@ -44,7 +44,7 @@ const missions = {
 };
 
 // Lade Städte und erstelle Marker mit Popup und Missionslink
-axios.get('/maddraxikon-cities').then(response => {
+axios.get('/maddraxikon-staedte').then(response => {
     const results = response.data.query.results;
     for (const cityName in results) {
         const city = results[cityName];
@@ -212,7 +212,7 @@ startMissionButton.addEventListener('click', async () => {
 
     try {
         // Starte die Mission auf dem Backend
-        const response = await axios.post('/mission/start', {
+        const response = await axios.post('/mission/starten', {
             name: mission.name,
             origin: "Waashton",
             destination: mission.destination,
@@ -235,7 +235,7 @@ startMissionButton.addEventListener('click', async () => {
 
         // 4. Mission als abgeschlossen markieren
         console.log('Sende Status-Check-Request...');
-        const statusResponse = await axios.post('/mission/check-status', {}, {
+        const statusResponse = await axios.post('/mission/status-pruefen', {}, {
             headers: { 'X-CSRF-TOKEN': csrfToken }
         });
         console.log('Status-Check-Response:', statusResponse.data);
@@ -314,7 +314,7 @@ async function loadMissionStatus() {
                 }
 
                 // Mission als abgeschlossen markieren
-                const statusResponse = await axios.post('/mission/check-status', {}, {
+                const statusResponse = await axios.post('/mission/status-pruefen', {}, {
                     headers: { 'X-CSRF-TOKEN': csrfToken }
                 });
 

--- a/resources/views/kassenbuch/index.blade.php
+++ b/resources/views/kassenbuch/index.blade.php
@@ -275,7 +275,7 @@
                         
                         <p class="text-sm text-gray-500 dark:text-gray-400 mb-4" x-text="'Mitglied: ' + user_name"></p>
                         
-                        <form :action="'/kassenbuch/update-payment/' + user_id" method="POST">
+                        <form :action="'/kassenbuch/zahlung-aktualisieren/' + user_id" method="POST">
                             @csrf
                             @method('PUT')
                             <div class="mb-4">

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,6 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/user', function (Request $request) {
+Route::get('/nutzer', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,7 +43,7 @@ Route::get('/mitglied-werden/bestaetigt', [PageController::class, 'mitgliedWerde
 Route::post('/mitglied-werden', [MitgliedschaftController::class, 'store'])->name('mitglied.store');
 
 // Route für E-Mail-Verifizierung (Laravel Jetstream / Fortify)
-Route::get('/email/verify/{id}/{hash}', CustomEmailVerificationController::class)
+Route::get('/email/bestaetigen/{id}/{hash}', CustomEmailVerificationController::class)
     ->middleware(['signed', 'throttle:6,1'])
     ->withoutMiddleware([RedirectIfAnwaerter::class])
     ->name('verification.verify');
@@ -53,8 +53,8 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
     Route::get('/admin', [AdminController::class, 'index'])->name('admin.index')->middleware('admin');
     Route::controller(DashboardController::class)->group(function () {
         Route::get('/dashboard', 'index')->name('dashboard');
-        Route::post('/anwaerter/{user}/approve', 'approveAnwaerter')->name('anwaerter.approve');
-        Route::post('/anwaerter/{user}/reject', 'rejectAnwaerter')->name('anwaerter.reject');
+        Route::post('/anwaerter/{user}/freigeben', 'approveAnwaerter')->name('anwaerter.approve');
+        Route::post('/anwaerter/{user}/ablehnen', 'rejectAnwaerter')->name('anwaerter.reject');
     });
 
     Route::controller(PageController::class)->group(function () {
@@ -72,8 +72,8 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::delete('/{user}', 'removeMember')->name('remove');
     });
 
-    Route::prefix('profile')->name('profile.')->group(function () {
-        Route::get('view', function () {
+    Route::prefix('profil')->name('profile.')->group(function () {
+        Route::get('anzeigen', function () {
             return app(ProfileViewController::class)->show(Auth::user());
         })->name('view.self');
         Route::get('{user}', [ProfileViewController::class, 'show'])->name('view');
@@ -81,44 +81,44 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
 
     Route::prefix('mitglieder/karte')->controller(MitgliederKarteController::class)->group(function () {
         Route::get('/', 'index')->name('mitglieder.karte');
-        Route::get('/locked', 'locked')->name('mitglieder.karte.locked');
+        Route::get('/gesperrt', 'locked')->name('mitglieder.karte.locked');
     });
 
-    Route::prefix('todos')->name('todos.')->controller(TodoController::class)->group(function () {
+    Route::prefix('aufgaben')->name('todos.')->controller(TodoController::class)->group(function () {
         Route::get('/', 'index')->name('index');
-        Route::get('create', 'create')->name('create');
+        Route::get('erstellen', 'create')->name('create');
         Route::post('/', 'store')->name('store');
         Route::get('{todo}', 'show')->name('show');
-        Route::get('{todo}/edit', 'edit')->name('edit');
-        Route::post('{todo}/assign', 'assign')->name('assign');
+        Route::get('{todo}/bearbeiten', 'edit')->name('edit');
+        Route::post('{todo}/zuweisen', 'assign')->name('assign');
         Route::put('{todo}', 'update')->name('update');
-        Route::post('{todo}/complete', 'complete')->name('complete');
-        Route::post('{todo}/verify', 'verify')->name('verify');
-        Route::post('{todo}/release', 'release')->name('release');
+        Route::post('{todo}/abschliessen', 'complete')->name('complete');
+        Route::post('{todo}/pruefen', 'verify')->name('verify');
+        Route::post('{todo}/freigeben', 'release')->name('release');
     });
 
     Route::get('/belohnungen', [RewardController::class, 'index'])->name('rewards.index');
 
-    Route::prefix('meetings')->controller(MeetingController::class)->group(function () {
+    Route::prefix('treffen')->controller(MeetingController::class)->group(function () {
         Route::get('/', 'index')->name('meetings');
-        Route::post('redirect', 'redirectToZoom')->name('meetings.redirect');
+        Route::post('umleiten', 'redirectToZoom')->name('meetings.redirect');
     });
 
     Route::prefix('kassenbuch')->name('kassenbuch.')->controller(KassenbuchController::class)->group(function () {
         Route::get('/', 'index')->name('index');
-        Route::put('update-payment/{user}', 'updatePaymentStatus')->name('update-payment');
-        Route::post('add-entry', 'addKassenbuchEntry')->name('add-entry');
+        Route::put('zahlung-aktualisieren/{user}', 'updatePaymentStatus')->name('update-payment');
+        Route::post('eintrag-hinzufuegen', 'addKassenbuchEntry')->name('add-entry');
     });
 
     Route::controller(MaddraxiversumController::class)->group(function () {
         Route::get('/maddraxiversum', 'index')->name('maddraxiversum.index');
-        Route::get('/maddraxikon-cities', 'getCities');
-        Route::post('/mission/start', 'startMission');
-        Route::post('/mission/check-status', 'checkMissionStatus');
+        Route::get('/maddraxikon-staedte', 'getCities');
+        Route::post('/mission/starten', 'startMission');
+        Route::post('/mission/status-pruefen', 'checkMissionStatus');
         Route::get('/mission/status', 'getMissionStatus');
     });
 
-    Route::get('/badges/{filename}', function ($filename) {
+    Route::get('/abzeichen/{filename}', function ($filename) {
         $path = public_path('images/badges/' . $filename);
         if (!file_exists($path)) {
             abort(404);
@@ -129,24 +129,24 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
 
     Route::prefix('romantauschboerse')->name('romantausch.')->controller(RomantauschController::class)->group(function () {
         Route::get('/', 'index')->name('index');
-        Route::get('create-offer', 'createOffer')->name('create-offer');
-        Route::post('store-offer', 'storeOffer')->name('store-offer');
-        Route::get('create-request', 'createRequest')->name('create-request');
-        Route::post('store-request', 'storeRequest')->name('store-request');
-        Route::post('{offer}/delete-offer', 'deleteOffer')->name('delete-offer');
-        Route::post('{request}/delete-request', 'deleteRequest')->name('delete-request');
-        Route::post('{offer}/{request}/complete', 'completeSwap')->name('complete-swap');
-        Route::post('swaps/{swap}/confirm', 'confirmSwap')->name('confirm-swap');
+        Route::get('angebot-erstellen', 'createOffer')->name('create-offer');
+        Route::post('angebot-speichern', 'storeOffer')->name('store-offer');
+        Route::get('anfrage-erstellen', 'createRequest')->name('create-request');
+        Route::post('anfrage-speichern', 'storeRequest')->name('store-request');
+        Route::post('{offer}/angebot-loeschen', 'deleteOffer')->name('delete-offer');
+        Route::post('{request}/anfrage-loeschen', 'deleteRequest')->name('delete-request');
+        Route::post('{offer}/{request}/abschliessen', 'completeSwap')->name('complete-swap');
+        Route::post('tausche/{swap}/bestaetigen', 'confirmSwap')->name('confirm-swap');
     });
 
     Route::prefix('downloads')->controller(DownloadsController::class)->group(function () {
         Route::get('/', 'index')->name('downloads');
-        Route::get('download/{datei}', 'download')->name('downloads.download');
+        Route::get('herunterladen/{datei}', 'download')->name('downloads.download');
     });
 
     Route::prefix('kompendium')->name('kompendium.')->controller(KompendiumController::class)->group(function () {
         Route::get('/', 'index')->name('index');
-        Route::get('search', 'search')->name('search');
+        Route::get('suche', 'search')->name('search');
     });
 
     Route::get('/statistik', [StatistikController::class, 'index'])->name('statistik.index');
@@ -154,11 +154,11 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
     Route::prefix('rezensionen')->name('reviews.')->group(function () {
         Route::get('/', [RezensionController::class, 'index'])->name('index');
         Route::get('/{book}', [RezensionController::class, 'show'])->name('show');
-        Route::get('/{book}/create', [RezensionController::class, 'create'])->name('create');
+        Route::get('/{book}/erstellen', [RezensionController::class, 'create'])->name('create');
         Route::post('/{book}', [RezensionController::class, 'store'])->name('store');
-        Route::get('/{review}/edit', [RezensionController::class, 'edit'])->name('edit');
+        Route::get('/{review}/bearbeiten', [RezensionController::class, 'edit'])->name('edit');
         Route::put('/{review}', [RezensionController::class, 'update'])->name('update');
         Route::delete('/{review}', [RezensionController::class, 'destroy'])->name('destroy');
-        Route::post('/{review}/comment', [ReviewCommentController::class, 'store'])->name('comments.store');
+        Route::post('/{review}/kommentar', [ReviewCommentController::class, 'store'])->name('comments.store');
     });
 });

--- a/tests/Feature/ActivityFeedTest.php
+++ b/tests/Feature/ActivityFeedTest.php
@@ -66,7 +66,7 @@ class ActivityFeedTest extends TestCase
         $user = $this->actingMember();
         $this->actingAs($user);
 
-        $response = $this->post('/romantauschboerse/store-offer', [
+        $response = $this->post('/romantauschboerse/angebot-speichern', [
             'book_number' => 1,
             'condition' => 'neu',
         ]);
@@ -85,7 +85,7 @@ class ActivityFeedTest extends TestCase
         $user = $this->actingMember();
         $this->actingAs($user);
 
-        $response = $this->post('/romantauschboerse/store-request', [
+        $response = $this->post('/romantauschboerse/anfrage-speichern', [
             'book_number' => 1,
             'condition' => 'neu',
         ]);

--- a/tests/Feature/BadgeImageTest.php
+++ b/tests/Feature/BadgeImageTest.php
@@ -42,7 +42,7 @@ class BadgeImageTest extends TestCase
         file_put_contents($this->filePath, '<svg></svg>');
         $this->actingAs($this->actingMember());
 
-        $response = $this->get('/badges/test.svg');
+        $response = $this->get('/abzeichen/test.svg');
 
         $response->assertOk();
         $this->assertInstanceOf(BinaryFileResponse::class, $response->baseResponse);
@@ -52,7 +52,7 @@ class BadgeImageTest extends TestCase
     {
         $this->actingAs($this->actingMember());
 
-        $response = $this->get('/badges/does-not-exist.svg');
+        $response = $this->get('/abzeichen/does-not-exist.svg');
 
         $response->assertNotFound();
     }

--- a/tests/Feature/DownloadsTest.php
+++ b/tests/Feature/DownloadsTest.php
@@ -34,7 +34,7 @@ class DownloadsTest extends TestCase
         $user = $this->actingMember(2);
         $this->actingAs($user);
 
-        $response = $this->from('/downloads')->get('/downloads/download/BauanleitungEuphoriewurmV2.pdf');
+        $response = $this->from('/downloads')->get('/downloads/herunterladen/BauanleitungEuphoriewurmV2.pdf');
 
         $response->assertRedirect('/downloads');
         $response->assertSessionHasErrors();
@@ -47,7 +47,7 @@ class DownloadsTest extends TestCase
 
         Storage::disk('private')->put('downloads/BauanleitungEuphoriewurmV2.pdf', 'dummy');
 
-        $response = $this->get('/downloads/download/BauanleitungEuphoriewurmV2.pdf');
+        $response = $this->get('/downloads/herunterladen/BauanleitungEuphoriewurmV2.pdf');
 
         $response->assertOk();
         $response->assertHeader('content-disposition');
@@ -58,7 +58,7 @@ class DownloadsTest extends TestCase
         $user = $this->actingMember(20);
         $this->actingAs($user);
 
-        $response = $this->from('/downloads')->get('/downloads/download/BauanleitungEuphoriewurmV2.pdf');
+        $response = $this->from('/downloads')->get('/downloads/herunterladen/BauanleitungEuphoriewurmV2.pdf');
 
         $response->assertRedirect('/downloads');
         $response->assertSessionHasErrors();
@@ -71,7 +71,7 @@ class DownloadsTest extends TestCase
 
         Storage::disk('private')->put('downloads/BauanleitungProtoV11.pdf', 'dummy');
 
-        $response = $this->get('/downloads/download/BauanleitungProtoV11.pdf');
+        $response = $this->get('/downloads/herunterladen/BauanleitungProtoV11.pdf');
 
         $response->assertOk();
         $response->assertHeader('content-disposition');
@@ -95,7 +95,7 @@ class DownloadsTest extends TestCase
         $user = $this->actingMember(10);
         $this->actingAs($user);
 
-        $response = $this->from('/downloads')->get('/downloads/download/unknown.pdf');
+        $response = $this->from('/downloads')->get('/downloads/herunterladen/unknown.pdf');
 
         $response->assertRedirect('/downloads');
         $response->assertSessionHasErrors();

--- a/tests/Feature/KassenbuchControllerTest.php
+++ b/tests/Feature/KassenbuchControllerTest.php
@@ -27,7 +27,7 @@ class KassenbuchControllerTest extends TestCase
         // initialize kassenstand
         $this->get('/kassenbuch');
 
-        $response = $this->post('/kassenbuch/add-entry', [
+        $response = $this->post('/kassenbuch/eintrag-hinzufuegen', [
             'buchungsdatum' => '2025-01-01',
             'betrag' => 5,
             'beschreibung' => 'Beitrag',
@@ -53,7 +53,7 @@ class KassenbuchControllerTest extends TestCase
         $member = User::factory()->create(['current_team_id' => $team->id]);
         $team->users()->attach($member, ['role' => 'Mitglied']);
 
-        $response = $this->from('/kassenbuch')->put("/kassenbuch/update-payment/{$member->id}", [
+        $response = $this->from('/kassenbuch')->put("/kassenbuch/zahlung-aktualisieren/{$member->id}", [
             'mitgliedsbeitrag' => 42,
             'bezahlt_bis' => '2025-12-31',
             'mitglied_seit' => '2024-01-01',
@@ -137,7 +137,7 @@ class KassenbuchControllerTest extends TestCase
         ]);
         $team->users()->attach($target, ['role' => 'Mitglied']);
 
-        $response = $this->from('/kassenbuch')->put("/kassenbuch/update-payment/{$target->id}", [
+        $response = $this->from('/kassenbuch')->put("/kassenbuch/zahlung-aktualisieren/{$target->id}", [
             'mitgliedsbeitrag' => 42,
             'bezahlt_bis' => '2025-12-31',
             'mitglied_seit' => '2024-01-01',
@@ -160,7 +160,7 @@ class KassenbuchControllerTest extends TestCase
         // initialize kassenstand
         $this->get('/kassenbuch');
 
-        $response = $this->from('/kassenbuch')->post('/kassenbuch/add-entry', [
+        $response = $this->from('/kassenbuch')->post('/kassenbuch/eintrag-hinzufuegen', [
             'buchungsdatum' => '2025-01-01',
             'betrag' => 5,
             'beschreibung' => 'Beitrag',

--- a/tests/Feature/KompendiumSearchTest.php
+++ b/tests/Feature/KompendiumSearchTest.php
@@ -34,7 +34,7 @@ class KompendiumSearchTest extends TestCase
         $user = $this->actingMember(50); // below 100
         $this->actingAs($user);
 
-        $this->getJson('/kompendium/search?q=test')
+        $this->getJson('/kompendium/suche?q=test')
             ->assertStatus(403)
             ->assertJson(['message' => 'Mindestens 100 Punkte erforderlich (du hast 50).']);
     }
@@ -44,7 +44,7 @@ class KompendiumSearchTest extends TestCase
         $user = $this->actingMember(150);
         $this->actingAs($user);
 
-        $this->getJson('/kompendium/search?q=a')
+        $this->getJson('/kompendium/suche?q=a')
             ->assertStatus(422);
     }
 
@@ -66,7 +66,7 @@ class KompendiumSearchTest extends TestCase
             ->with('example')
             ->andReturn($mock);
 
-        $response = $this->getJson('/kompendium/search?q=example');
+        $response = $this->getJson('/kompendium/suche?q=example');
 
         $response->assertOk()
             ->assertJson([
@@ -97,7 +97,7 @@ class KompendiumSearchTest extends TestCase
             ->with('nomatch')
             ->andReturn($mock);
 
-        $response = $this->getJson('/kompendium/search?q=nomatch');
+        $response = $this->getJson('/kompendium/suche?q=nomatch');
 
         $response->assertOk()
             ->assertJson([

--- a/tests/Feature/MaddraxiversumControllerTest.php
+++ b/tests/Feature/MaddraxiversumControllerTest.php
@@ -61,7 +61,7 @@ class MaddraxiversumControllerTest extends TestCase
         $user = $this->actingMember('Mitglied', 10);
         $this->actingAs($user);
 
-        $response = $this->get('/maddraxikon-cities');
+        $response = $this->get('/maddraxikon-staedte');
 
         $response->assertOk();
         $response->assertJson(['test' => 'data']);
@@ -79,7 +79,7 @@ class MaddraxiversumControllerTest extends TestCase
 
     private function startMission(User $user): void
     {
-        $this->postJson('/mission/start', [
+        $this->postJson('/mission/starten', [
             'name' => 'Testmission',
             'origin' => 'A',
             'destination' => 'B',

--- a/tests/Feature/MaddraxiversumMissionTest.php
+++ b/tests/Feature/MaddraxiversumMissionTest.php
@@ -28,7 +28,7 @@ class MaddraxiversumMissionTest extends TestCase
         $user = $this->actingMember();
         $this->actingAs($user);
 
-        $response = $this->postJson('/mission/start', [
+        $response = $this->postJson('/mission/starten', [
             'name' => 'Testmission',
             'origin' => 'A',
             'destination' => 'B',
@@ -56,7 +56,7 @@ class MaddraxiversumMissionTest extends TestCase
         $user = $this->actingMember();
         $this->actingAs($user);
 
-        $this->postJson('/mission/start', [
+        $this->postJson('/mission/starten', [
             'name' => 'Testmission',
             'origin' => 'A',
             'destination' => 'B',
@@ -67,7 +67,7 @@ class MaddraxiversumMissionTest extends TestCase
         $mission = Mission::first();
         Carbon::setTestNow('2025-01-01 12:01:00');
 
-        $this->postJson('/mission/check-status')
+        $this->postJson('/mission/status-pruefen')
             ->assertOk()
             ->assertJson(['status' => 'completed']);
 

--- a/tests/Feature/MeetingControllerTest.php
+++ b/tests/Feature/MeetingControllerTest.php
@@ -25,7 +25,7 @@ class MeetingControllerTest extends TestCase
     {
         $this->actingAs($this->actingMember());
 
-        $this->post('/meetings/redirect', ['meeting' => 'unknown'])
+        $this->post('/treffen/umleiten', ['meeting' => 'unknown'])
             ->assertForbidden();
     }
 
@@ -34,7 +34,7 @@ class MeetingControllerTest extends TestCase
         Carbon::setTestNow('2025-03-15');
         $this->actingAs($this->actingMember());
 
-        $response = $this->get('/meetings');
+        $response = $this->get('/treffen');
         $response->assertOk();
 
         $meetings = $response->viewData('meetings');
@@ -48,7 +48,7 @@ class MeetingControllerTest extends TestCase
         Carbon::setTestNow('2025-03-15');
         $this->actingAs($this->actingMember());
 
-        $meetings = $this->get('/meetings')->viewData('meetings');
+        $meetings = $this->get('/treffen')->viewData('meetings');
 
         $last = end($meetings);
         $this->assertSame('CHATDRAX 2.0 - Der MADDRAX-Online-Stammtisch', $last['name']);
@@ -60,7 +60,7 @@ class MeetingControllerTest extends TestCase
         Carbon::setTestNow('2025-03-15');
         $this->actingAs($this->actingMember());
 
-        $meetings = $this->get('/meetings')->viewData('meetings');
+        $meetings = $this->get('/treffen')->viewData('meetings');
 
         $this->assertTrue($meetings[0]['next']->equalTo(Carbon::parse('third monday of this month')));
         $this->assertTrue($meetings[1]['next']->equalTo(Carbon::parse('second wednesday of next month')));
@@ -75,7 +75,7 @@ class MeetingControllerTest extends TestCase
 
         $this->actingAs($this->actingMember());
 
-        $this->post('/meetings/redirect', ['meeting' => 'maddraxikon'])
+        $this->post('/treffen/umleiten', ['meeting' => 'maddraxikon'])
             ->assertRedirect('https://example.com/zoom');
     }
 }

--- a/tests/Feature/ProfileViewControllerTest.php
+++ b/tests/Feature/ProfileViewControllerTest.php
@@ -80,7 +80,7 @@ class ProfileViewControllerTest extends TestCase
         $user = $this->createMember();
         $this->actingAs($user);
 
-        $response = $this->get("/profile/{$user->id}");
+        $response = $this->get("/profil/{$user->id}");
 
         $response->assertOk();
         $response->assertViewHas('isOwnProfile', true);
@@ -94,7 +94,7 @@ class ProfileViewControllerTest extends TestCase
         $target = $this->createMember();
         $this->actingAs($viewer);
 
-        $response = $this->get("/profile/{$target->id}");
+        $response = $this->get("/profil/{$target->id}");
 
         $response->assertOk();
         $response->assertViewHas('isOwnProfile', false);
@@ -108,7 +108,7 @@ class ProfileViewControllerTest extends TestCase
         $target = $this->createMember();
         $this->actingAs($admin);
 
-        $response = $this->get("/profile/{$target->id}");
+        $response = $this->get("/profil/{$target->id}");
 
         $response->assertOk();
         $response->assertViewHas('canViewDetails', true);
@@ -122,7 +122,7 @@ class ProfileViewControllerTest extends TestCase
         $otherTeam->users()->attach($target, ['role' => 'Mitglied']);
         $this->actingAs($viewer);
 
-        $response = $this->get("/profile/{$target->id}");
+        $response = $this->get("/profil/{$target->id}");
 
         $response->assertRedirect('/dashboard');
         $response->assertSessionHas('error');
@@ -135,7 +135,7 @@ class ProfileViewControllerTest extends TestCase
         $target = $this->createMember();
         $this->actingAs($viewer);
 
-        $response = $this->get("/profile/{$target->id}");
+        $response = $this->get("/profil/{$target->id}");
 
         $response->assertRedirect('/dashboard');
         $response->assertSessionHas('error');
@@ -168,7 +168,7 @@ class ProfileViewControllerTest extends TestCase
         }
         $this->actingAs($admin);
 
-        $response = $this->get("/profile/{$member->id}");
+        $response = $this->get("/profil/{$member->id}");
 
         $response->assertOk();
         $response->assertViewHas('userPoints', 8);
@@ -192,7 +192,7 @@ class ProfileViewControllerTest extends TestCase
 
         $this->actingAs($admin);
 
-        $response = $this->get("/profile/{$member->id}");
+        $response = $this->get("/profil/{$member->id}");
 
         $response->assertOk();
         $response->assertViewHas('userPoints', 0);
@@ -209,7 +209,7 @@ class ProfileViewControllerTest extends TestCase
         $this->createCompletedSwaps($member, $partner, 1);
 
         $this->actingAs($admin);
-        $response = $this->get("/profile/{$member->id}");
+        $response = $this->get("/profil/{$member->id}");
 
         $response->assertOk();
         $badges = $response->viewData('badges');
@@ -226,7 +226,7 @@ class ProfileViewControllerTest extends TestCase
         $this->createCompletedSwaps($member, $partner, 10);
 
         $this->actingAs($admin);
-        $response = $this->get("/profile/{$member->id}");
+        $response = $this->get("/profil/{$member->id}");
 
         $response->assertOk();
         $badges = $response->viewData('badges');
@@ -243,7 +243,7 @@ class ProfileViewControllerTest extends TestCase
         $this->createCompletedSwaps($member, $partner, 100);
 
         $this->actingAs($admin);
-        $response = $this->get("/profile/{$member->id}");
+        $response = $this->get("/profil/{$member->id}");
 
         $response->assertOk();
         $badges = $response->viewData('badges');
@@ -260,7 +260,7 @@ class ProfileViewControllerTest extends TestCase
         $this->createCompletedSwaps($member, $partner, 1000);
 
         $this->actingAs($admin);
-        $response = $this->get("/profile/{$member->id}");
+        $response = $this->get("/profil/{$member->id}");
 
         $response->assertOk();
         $badges = $response->viewData('badges');
@@ -283,7 +283,7 @@ class ProfileViewControllerTest extends TestCase
             'last_activity' => now()->timestamp,
         ]);
 
-        $response = $this->get("/profile/{$target->id}");
+        $response = $this->get("/profil/{$target->id}");
 
         $response->assertOk();
         $response->assertViewHas('isOnline', true);
@@ -305,7 +305,7 @@ class ProfileViewControllerTest extends TestCase
             'last_activity' => now()->subMinutes(10)->timestamp,
         ]);
 
-        $response = $this->get("/profile/{$target->id}");
+        $response = $this->get("/profil/{$target->id}");
 
         $response->assertOk();
         $response->assertViewHas('isOnline', false);

--- a/tests/Feature/RomantauschControllerTest.php
+++ b/tests/Feature/RomantauschControllerTest.php
@@ -41,7 +41,7 @@ class RomantauschControllerTest extends TestCase
         rename($path, $path . '.bak');
 
         $this->actingAs($this->actingMember());
-        $this->get('/romantauschboerse/create-offer')->assertStatus(500);
+        $this->get('/romantauschboerse/angebot-erstellen')->assertStatus(500);
 
         rename($path . '.bak', $path);
     }
@@ -67,7 +67,7 @@ class RomantauschControllerTest extends TestCase
         ]);
 
         $this->actingAs($user);
-        $this->post("/romantauschboerse/{$offer->id}/{$request->id}/complete")
+        $this->post("/romantauschboerse/{$offer->id}/{$request->id}/abschliessen")
             ->assertRedirect(route('romantausch.index'));
 
         $this->assertDatabaseHas('book_swaps', [
@@ -87,7 +87,7 @@ class RomantauschControllerTest extends TestCase
         ]));
 
         $this->actingAs($this->actingMember());
-        $response = $this->get('/romantauschboerse/create-offer');
+        $response = $this->get('/romantauschboerse/angebot-erstellen');
 
         $response->assertOk();
         $response->assertViewIs('romantausch.create_offer');
@@ -104,7 +104,7 @@ class RomantauschControllerTest extends TestCase
         file_put_contents($path, '{invalid');
 
         $this->actingAs($this->actingMember());
-        $this->get('/romantauschboerse/create-offer')->assertStatus(500);
+        $this->get('/romantauschboerse/angebot-erstellen')->assertStatus(500);
 
         unlink($path);
         rename($path . '.bak', $path);
@@ -121,7 +121,7 @@ class RomantauschControllerTest extends TestCase
         $user = $this->actingMember();
         $this->actingAs($user);
 
-        $response = $this->post('/romantauschboerse/store-offer', [
+        $response = $this->post('/romantauschboerse/angebot-speichern', [
             'book_number' => 1,
             'condition' => 'neu',
         ]);
@@ -160,7 +160,7 @@ class RomantauschControllerTest extends TestCase
             ]);
         }
 
-        $this->post('/romantauschboerse/store-offer', [
+        $this->post('/romantauschboerse/angebot-speichern', [
             'book_number' => 1,
             'condition' => 'neu',
         ]);
@@ -186,13 +186,13 @@ class RomantauschControllerTest extends TestCase
         $user = $this->actingMember();
         $this->actingAs($user);
 
-        $response = $this->from('/romantauschboerse/create-offer')
-            ->post('/romantauschboerse/store-offer', [
+        $response = $this->from('/romantauschboerse/angebot-erstellen')
+            ->post('/romantauschboerse/angebot-speichern', [
                 'book_number' => 2,
                 'condition' => 'neu',
             ]);
 
-        $response->assertRedirect('/romantauschboerse/create-offer');
+        $response->assertRedirect('/romantauschboerse/angebot-erstellen');
         $response->assertSessionHas('error', 'Ausgewählter Roman nicht gefunden.');
         $this->assertDatabaseCount('book_offers', 0);
 
@@ -245,7 +245,7 @@ class RomantauschControllerTest extends TestCase
         rename($path, $path . '.bak');
 
         $this->actingAs($this->actingMember());
-        $this->get('/romantauschboerse/create-request')->assertStatus(500);
+        $this->get('/romantauschboerse/anfrage-erstellen')->assertStatus(500);
 
         rename($path . '.bak', $path);
     }
@@ -259,7 +259,7 @@ class RomantauschControllerTest extends TestCase
         ]));
 
         $this->actingAs($this->actingMember());
-        $response = $this->get('/romantauschboerse/create-request');
+        $response = $this->get('/romantauschboerse/anfrage-erstellen');
 
         $response->assertOk();
         $response->assertViewIs('romantausch.create_request');
@@ -276,7 +276,7 @@ class RomantauschControllerTest extends TestCase
         file_put_contents($path, '{invalid');
 
         $this->actingAs($this->actingMember());
-        $this->get('/romantauschboerse/create-request')->assertStatus(500);
+        $this->get('/romantauschboerse/anfrage-erstellen')->assertStatus(500);
 
         unlink($path);
         rename($path . '.bak', $path);
@@ -293,7 +293,7 @@ class RomantauschControllerTest extends TestCase
         $user = $this->actingMember();
         $this->actingAs($user);
 
-        $response = $this->post('/romantauschboerse/store-request', [
+        $response = $this->post('/romantauschboerse/anfrage-speichern', [
             'book_number' => 1,
             'condition' => 'neu',
         ]);
@@ -321,13 +321,13 @@ class RomantauschControllerTest extends TestCase
         $user = $this->actingMember();
         $this->actingAs($user);
 
-        $response = $this->from('/romantauschboerse/create-request')
-            ->post('/romantauschboerse/store-request', [
+        $response = $this->from('/romantauschboerse/anfrage-erstellen')
+            ->post('/romantauschboerse/anfrage-speichern', [
                 'book_number' => 2,
                 'condition' => 'neu',
             ]);
 
-        $response->assertRedirect('/romantauschboerse/create-request');
+        $response->assertRedirect('/romantauschboerse/anfrage-erstellen');
         $response->assertSessionHas('error', 'Ausgewählter Roman nicht gefunden.');
         $this->assertDatabaseCount('book_requests', 0);
 

--- a/tests/Feature/TodoAuthorizationTest.php
+++ b/tests/Feature/TodoAuthorizationTest.php
@@ -20,7 +20,7 @@ class TodoAuthorizationTest extends TestCase
         $team->users()->attach($user, ['role' => 'Mitglied']);
         $this->actingAs($user);
 
-        $response = $this->get('/todos/create');
+        $response = $this->get('/aufgaben/erstellen');
 
         $response->assertRedirect(route('todos.index', [], false));
         $response->assertSessionHas('error', 'Du hast keine Berechtigung, Challenges zu erstellen.');
@@ -35,7 +35,7 @@ class TodoAuthorizationTest extends TestCase
 
         TodoCategory::create(['name' => 'Test', 'slug' => 'test']);
 
-        $response = $this->get('/todos/create');
+        $response = $this->get('/aufgaben/erstellen');
 
         $response->assertOk();
         $response->assertViewIs('todos.create');

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -176,7 +176,7 @@ class TodoControllerTest extends TestCase
         ]);
 
         $this->actingAs($user);
-        $response = $this->get('/todos');
+        $response = $this->get('/aufgaben');
 
         $response->assertOk();
         $response->assertViewIs('todos.index');
@@ -198,7 +198,7 @@ class TodoControllerTest extends TestCase
         $category = TodoCategory::first() ?? TodoCategory::create(['name' => 'Test', 'slug' => 'test']);
         $this->actingAs($user);
 
-        $response = $this->post('/todos', [
+        $response = $this->post('/aufgaben', [
             'title' => 'New Todo',
             'description' => 'Desc',
             'points' => 7,


### PR DESCRIPTION
## Summary
- Verwende deutsche Pfade für Benutzerprofile, Aufgaben, Treffen und weitere Bereiche
- Passe Frontend-Skripte und Tests an die neuen deutschen Routen an

## Testing
- `php artisan test`
- `npm test` *(fehlendes Script)*

------
https://chatgpt.com/codex/tasks/task_e_688f1e62825c832ea1d8135f328b13fd