### PR TITLE
Fix duplicated verification route name causing deploy failure

### DIFF
--- a/app/Mail/MitgliedAntragEingereicht.php
+++ b/app/Mail/MitgliedAntragEingereicht.php
@@ -45,7 +45,7 @@ class MitgliedAntragEingereicht extends Mailable
             with: [
                 'user' => $this->user,
                 'verificationUrl' => URL::temporarySignedRoute(
-                    'verification.verify',
+                    'verification.verify.de',
                     now()->addMinutes(60), // Link ist 60 Min. gültig
                     [
                         'id' => $this->user->id,

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,7 +46,7 @@ Route::post('/mitglied-werden', [MitgliedschaftController::class, 'store'])->nam
 Route::get('/email/bestaetigen/{id}/{hash}', CustomEmailVerificationController::class)
     ->middleware(['signed', 'throttle:6,1'])
     ->withoutMiddleware([RedirectIfAnwaerter::class])
-    ->name('verification.verify');
+    ->name('verification.verify.de');
 
 // Nur für eingeloggte und verifizierte Mitglieder, die NICHT Anwärter sind
 Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function () {

--- a/tests/Feature/CustomEmailVerificationControllerTest.php
+++ b/tests/Feature/CustomEmailVerificationControllerTest.php
@@ -21,7 +21,7 @@ class CustomEmailVerificationControllerTest extends TestCase
         $user = User::factory()->unverified()->create();
 
         $verificationUrl = URL::temporarySignedRoute(
-            'verification.verify',
+            'verification.verify.de',
             now()->addMinutes(60),
             ['id' => $user->id, 'hash' => sha1($user->email)]
         );
@@ -41,7 +41,7 @@ class CustomEmailVerificationControllerTest extends TestCase
         $user = User::factory()->unverified()->create();
 
         $verificationUrl = URL::temporarySignedRoute(
-            'verification.verify',
+            'verification.verify.de',
             now()->addMinutes(60),
             ['id' => $user->id, 'hash' => sha1('wrong-email')]
         );
@@ -60,7 +60,7 @@ class CustomEmailVerificationControllerTest extends TestCase
         $user = User::factory()->create();
 
         $verificationUrl = URL::temporarySignedRoute(
-            'verification.verify',
+            'verification.verify.de',
             now()->addMinutes(60),
             ['id' => $user->id, 'hash' => sha1($user->email)]
         );

--- a/tests/Feature/EmailVerificationTest.php
+++ b/tests/Feature/EmailVerificationTest.php
@@ -38,7 +38,7 @@ class EmailVerificationTest extends TestCase
         $user = User::factory()->unverified()->create();
 
         $verificationUrl = URL::temporarySignedRoute(
-            'verification.verify',
+            'verification.verify.de',
             now()->addMinutes(60),
             ['id' => $user->id, 'hash' => sha1($user->email)]
         );
@@ -60,7 +60,7 @@ class EmailVerificationTest extends TestCase
         $user = User::factory()->unverified()->create();
 
         $verificationUrl = URL::temporarySignedRoute(
-            'verification.verify',
+            'verification.verify.de',
             now()->addMinutes(60),
             ['id' => $user->id, 'hash' => sha1('wrong-email')]
         );


### PR DESCRIPTION
This pull request updates the email verification route name throughout the application to improve localization by appending `.de` to the route name. The changes ensure consistency across the codebase and include updates to the route definition, mail content, and associated tests.

### Route name update for email verification:

* Updated the route name in `routes/web.php` from `verification.verify` to `verification.verify.de` to reflect localization.

### Updates to mail content:

* Modified the `MitgliedAntragEingereicht` mail class to use the updated route name `verification.verify.de` in the temporary signed URL.

### Test updates for consistency:

* Updated the route name in multiple test methods in `CustomEmailVerificationControllerTest` to use `verification.verify.de`, ensuring the tests align with the new route name:
  - `test_email_can_be_verified_and_mails_sent`
  - `test_verification_fails_with_invalid_hash`
  - `test_already_verified_user_gets_redirected_with_message`
* Similarly, updated the route name in `EmailVerificationTest` for the following methods:
  - `test_email_can_be_verified`
  - `test_email_can_not_verified_with_invalid_hash`