### PR TITLE
Add Termine to members' Veranstaltungen menu

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -37,6 +37,7 @@
                             <div id="veranstaltungen-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
                                 <x-dropdown-link href="{{ route('fotogalerie') }}">Fotos</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('meetings') }}">Meetings</x-dropdown-link>
+                                <x-dropdown-link href="{{ route('termine') }}">Termine</x-dropdown-link>
                             </div>
                         </div>
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
@@ -135,6 +136,7 @@
             <div id="veranstaltungen-mobile-menu" x-show="openMenu === 'veranstaltungen'" x-cloak class="italic">
                 <x-responsive-nav-link href="{{ route('fotogalerie') }}">Fotos</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('meetings') }}">Meetings</x-responsive-nav-link>
+                <x-responsive-nav-link href="{{ route('termine') }}">Termine</x-responsive-nav-link>
             </div>
 
             <button id="baxx-mobile-button" type="button" @click="openMenu = (openMenu === 'baxx' ? null : 'baxx')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'baxx' }" :aria-expanded="openMenu === 'baxx'" aria-controls="baxx-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'baxx' ? null : 'baxx')" @keydown.space.prevent="openMenu = (openMenu === 'baxx' ? null : 'baxx')">

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+
+class NavigationMenuTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_users_see_termine_link_in_veranstaltungen_menu(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertSee(route('termine'));
+    }
+}


### PR DESCRIPTION
This pull request introduces a new "Termine" link to the navigation menu and its mobile equivalent, along with a corresponding feature test to ensure proper functionality. The changes improve the navigation experience and add test coverage for the new functionality.

### Navigation menu updates:
* Added a "Termine" link to the desktop navigation menu under the "Veranstaltungen" dropdown. (`resources/views/navigation-menu.blade.php`, [resources/views/navigation-menu.blade.phpR40](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR40))
* Added a "Termine" link to the mobile navigation menu under the "Veranstaltungen" section. (`resources/views/navigation-menu.blade.php`, [resources/views/navigation-menu.blade.phpR139](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR139))

### Test coverage:
* Added a new feature test, `NavigationMenuTest`, to verify that authenticated users can see the "Termine" link in the "Veranstaltungen" menu. (`tests/Feature/NavigationMenuTest.php`, [tests/Feature/NavigationMenuTest.phpR1-R21](diffhunk://#diff-f07fc19527b4a5bab3d806bcfae04538554be984c2baf74012660dc78ac8672aR1-R21))