### PR TITLE
Handle missing git version gracefully

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,8 +32,12 @@ class AppServiceProvider extends ServiceProvider
         $version = Config::get('app.version');
 
         if ($version === null || $version === '0.0.0') {
-            $process = Process::run('git describe --tags --abbrev=0');
-            $version = $process->successful() ? trim($process->output()) : '0.0.0';
+            try {
+                $process = Process::run(['git', 'describe', '--tags', '--abbrev=0']);
+                $version = $process->successful() ? trim($process->output()) : '0.0.0';
+            } catch (\Throwable $e) {
+                $version = '0.0.0';
+            }
         }
 
         View::share('appVersion', $version);

--- a/tests/Feature/FooterVersionTest.php
+++ b/tests/Feature/FooterVersionTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Support\Facades\Process;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Process;
+use Tests\TestCase;
 
 class FooterVersionTest extends TestCase
 {
@@ -12,7 +12,9 @@ class FooterVersionTest extends TestCase
 
     public function test_footer_displays_version_and_changelog_link(): void
     {
-        $version = trim(Process::run('git describe --tags --abbrev=0')->output());
+        $process = Process::run(['git', 'describe', '--tags', '--abbrev=0']);
+        $version = $process->successful() ? trim($process->output()) : '0.0.0';
+
         $response = $this->get('/');
         $response->assertSee("Version {$version}");
         $response->assertSee('/changelog');


### PR DESCRIPTION
This pull request improves error handling and updates the usage of the `Process::run` method for better reliability and consistency. The most important changes include wrapping `Process::run` calls in a `try-catch` block to handle exceptions and updating the method's arguments to use an array format.

### Error handling improvements:
* In `app/Providers/AppServiceProvider.php`, the `Process::run` call is now wrapped in a `try-catch` block to handle potential exceptions and ensure the application falls back to a default version (`0.0.0`) if an error occurs.

### Code consistency updates:
* Updated the `Process::run` method in `app/Providers/AppServiceProvider.php` and `tests/Feature/FooterVersionTest.php` to use an array format for arguments instead of a string, improving consistency and compatibility. [[1]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eL35-R40) [[2]](diffhunk://#diff-5162b51c51b8036907d07d36883a59ac1077dfea6a155145da31504f2d67dc9bL5-R17)