### PR TITLE
feat: fetch latest git tag for footer version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 Eine Laravel 12 Anwendung für die Vereinswebseite des OMFXC.
 
+## Versionsanzeige
+
+Die im Footer angezeigte Versionsnummer wird automatisch aus dem neuesten Git-Tag des Repositories ermittelt.
+
 ## Installation
 
 1. Repository clonen und ins Projektverzeichnis wechseln.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -33,7 +33,7 @@ class AppServiceProvider extends ServiceProvider
 
         if ($version === null || $version === '0.0.0') {
             try {
-                $process = Process::run(['git', 'describe', '--tags', '--abbrev=0']);
+                $process = Process::run(['bash', '-c', 'git describe --tags $(git rev-list --tags --max-count=1)']);
                 $version = $process->successful() ? trim($process->output()) : '0.0.0';
             } catch (\Throwable $e) {
                 $version = '0.0.0';

--- a/tests/Feature/FooterVersionTest.php
+++ b/tests/Feature/FooterVersionTest.php
@@ -12,7 +12,7 @@ class FooterVersionTest extends TestCase
 
     public function test_footer_displays_version_and_changelog_link(): void
     {
-        $process = Process::run(['git', 'describe', '--tags', '--abbrev=0']);
+        $process = Process::run(['bash', '-c', 'git describe --tags $(git rev-list --tags --max-count=1)']);
         $version = $process->successful() ? trim($process->output()) : '0.0.0';
 
         $response = $this->get('/');


### PR DESCRIPTION
This pull request introduces a feature to display the application version in the footer and updates the method used to retrieve the version from Git tags. The changes affect the application logic, testing, and documentation.

### Feature Addition:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R12-R15): Added a new section explaining that the footer version number is automatically retrieved from the latest Git tag.

### Code Updates:

* [`app/Providers/AppServiceProvider.php`](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eL36-R36): Updated the command for retrieving the latest Git tag to use a more robust method (`git describe --tags $(git rev-list --tags --max-count=1)`), ensuring the correct tag is fetched.

### Test Updates:

* [`tests/Feature/FooterVersionTest.php`](diffhunk://#diff-5162b51c51b8036907d07d36883a59ac1077dfea6a155145da31504f2d67dc9bL15-R15): Updated the test logic to match the new method for retrieving the latest Git tag.