### PR TITLE
Add Mars cycle statistics and reward

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -150,6 +150,14 @@ class StatistikController extends Controller
         $wandlerLabels = $wandlerCycle->pluck('nummer');
         $wandlerValues = $wandlerCycle->pluck('bewertung');
 
+        // ── Card 14 – Bewertungen des Mars-Zyklus ─────────────────────
+        $marsCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 150 && ($r['nummer'] ?? 0) <= 174)
+            ->sortBy('nummer');
+
+        $marsLabels = $marsCycle->pluck('nummer');
+        $marsValues = $marsCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -247,6 +255,8 @@ class StatistikController extends Controller
             'daaMurenValues' => $daaMurenValues,
             'wandlerLabels' => $wandlerLabels,
             'wandlerValues' => $wandlerValues,
+            'marsLabels' => $marsLabels,
+            'marsValues' => $marsValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -92,6 +92,11 @@ return [
         'points' => 18,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Mars-Zyklus',
+        'description' => 'Zeigt Bewertungen des Mars-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 19,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -346,6 +346,21 @@
                 </script>
             @endif
 
+            {{-- Card 14 – Bewertungen des Mars-Zyklus (≥ 19 Baxx) --}}
+            @if ($userPoints >= 19)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Mars-Zyklus
+                    </h2>
+                    <canvas id="marsChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.marsChartLabels = @json($marsLabels);
+                    window.marsChartValues = @json($marsValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif


### PR DESCRIPTION
This pull request introduces functionality to display ratings for the Mars cycle in the statistics section of the application. Key changes include updates to the backend to process Mars cycle data, modifications to the frontend to render the new chart, and configuration updates to integrate this feature into the rewards system.

### Backend updates for Mars cycle data:
* Added logic in `StatistikController.php` to filter and process Mars cycle data (`marsLabels` and `marsValues`) for display in the statistics view. [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR153-R160) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR258-R259)

### Frontend updates for Mars cycle chart:
* Updated `statistik.js` to include the Mars cycle in the list of cycles rendered on the page.
* Added a new card in `index.blade.php` to display the Mars cycle chart, which is conditionally shown based on user points (≥ 19). This includes rendering a canvas element and passing chart data via JavaScript.

### Rewards configuration:
* Added a new reward entry in `rewards.php` for the Mars cycle chart, specifying its title, description, and required points (19).