### PR TITLE
Add Ausala cycle statistics and rewards

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -158,6 +158,14 @@ class StatistikController extends Controller
         $marsLabels = $marsCycle->pluck('nummer');
         $marsValues = $marsCycle->pluck('bewertung');
 
+        // ── Card 15 – Bewertungen des Ausala-Zyklus ───────────────────
+        $ausalaCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 175 && ($r['nummer'] ?? 0) <= 199)
+            ->sortBy('nummer');
+
+        $ausalaLabels = $ausalaCycle->pluck('nummer');
+        $ausalaValues = $ausalaCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -257,6 +265,8 @@ class StatistikController extends Controller
             'wandlerValues' => $wandlerValues,
             'marsLabels' => $marsLabels,
             'marsValues' => $marsValues,
+            'ausalaLabels' => $ausalaLabels,
+            'ausalaValues' => $ausalaValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -97,6 +97,11 @@ return [
         'points' => 19,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Ausala-Zyklus',
+        'description' => 'Zeigt Bewertungen des Ausala-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 20,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -361,6 +361,21 @@
                 </script>
             @endif
 
+            {{-- Card 15 – Bewertungen des Ausala-Zyklus (≥ 20 Baxx) --}}
+            @if ($userPoints >= 20)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Ausala-Zyklus
+                    </h2>
+                    <canvas id="ausalaChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.ausalaChartLabels = @json($ausalaLabels);
+                    window.ausalaChartValues = @json($ausalaValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif


### PR DESCRIPTION
## Summary
- Add Ausala cycle (Band 175-199) statistics in controller, view, and JS
- Register Ausala cycle reward for 20 Baxx

## Testing
- `npm run build`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6890268eb234832e89ec5988b4d94631