### PR TITLE
Add Afra cycle statistics and reward

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -166,6 +166,14 @@ class StatistikController extends Controller
         $ausalaLabels = $ausalaCycle->pluck('nummer');
         $ausalaValues = $ausalaCycle->pluck('bewertung');
 
+        // ── Card 16 – Bewertungen des Afra-Zyklus ───────────────────
+        $afraCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 200 && ($r['nummer'] ?? 0) <= 224)
+            ->sortBy('nummer');
+
+        $afraLabels = $afraCycle->pluck('nummer');
+        $afraValues = $afraCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -267,6 +275,8 @@ class StatistikController extends Controller
             'marsValues' => $marsValues,
             'ausalaLabels' => $ausalaLabels,
             'ausalaValues' => $ausalaValues,
+            'afraLabels' => $afraLabels,
+            'afraValues' => $afraValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -102,6 +102,11 @@ return [
         'points' => 20,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Afra-Zyklus',
+        'description' => 'Zeigt Bewertungen des Afra-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 21,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -376,6 +376,21 @@
                 </script>
             @endif
 
+            {{-- Card 16 – Bewertungen des Afra-Zyklus (≥ 21 Baxx) --}}
+            @if ($userPoints >= 21)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Afra-Zyklus
+                    </h2>
+                    <canvas id="afraChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.afraChartLabels = @json($afraLabels);
+                    window.afraChartValues = @json($afraValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -217,4 +217,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Rezensionen unserer Mitglieder');
     }
+
+    public function test_afra_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(21);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Afra-Zyklus');
+    }
+
+    public function test_afra_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(20);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Afra-Zyklus');
+    }
 }


### PR DESCRIPTION
This pull request introduces functionality to display a new chart for the "Afra-Zyklus" ratings on the statistics page. The changes include updates to the backend logic, frontend rendering, configuration, and tests to support this feature.

### Backend Changes:
* Added logic in `StatistikController.php` to filter and process data for the "Afra-Zyklus" ratings, including labels and values for the chart (`afraLabels`, `afraValues`). [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR169-R176) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR278-R279)

### Frontend Changes:
* Updated `statistik.js` to include "afra" in the list of cycles processed for rendering charts.
* Modified `index.blade.php` to render a new card for the "Afra-Zyklus" chart, visible only to users with sufficient points (≥ 21).

### Configuration Changes:
* Added a new reward entry in `rewards.php` for the "Afra-Zyklus" chart, requiring 21 points.

### Test Coverage:
* Added feature tests in `StatistikTest.php` to ensure the "Afra-Zyklus" chart is visible for users with ≥ 21 points and hidden for those with fewer points.