### PR TITLE
Add Antarktis cycle statistics and rewards

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -174,6 +174,14 @@ class StatistikController extends Controller
         $afraLabels = $afraCycle->pluck('nummer');
         $afraValues = $afraCycle->pluck('bewertung');
 
+        // ── Card 17 – Bewertungen des Antarktis-Zyklus ───────────────────
+        $antarktisCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 225 && ($r['nummer'] ?? 0) <= 249)
+            ->sortBy('nummer');
+
+        $antarktisLabels = $antarktisCycle->pluck('nummer');
+        $antarktisValues = $antarktisCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -277,6 +285,8 @@ class StatistikController extends Controller
             'ausalaValues' => $ausalaValues,
             'afraLabels' => $afraLabels,
             'afraValues' => $afraValues,
+            'antarktisLabels' => $antarktisLabels,
+            'antarktisValues' => $antarktisValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -107,6 +107,11 @@ return [
         'points' => 21,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Antarktis-Zyklus',
+        'description' => 'Zeigt Bewertungen des Antarktis-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 22,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -391,6 +391,21 @@
                 </script>
             @endif
 
+            {{-- Card 17 – Bewertungen des Antarktis-Zyklus (≥ 22 Baxx) --}}
+            @if ($userPoints >= 22)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Antarktis-Zyklus
+                    </h2>
+                    <canvas id="antarktisChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.antarktisChartLabels = @json($antarktisLabels);
+                    window.antarktisChartValues = @json($antarktisValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -241,4 +241,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Afra-Zyklus');
     }
+
+    public function test_antarktis_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(22);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Antarktis-Zyklus');
+    }
+
+    public function test_antarktis_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(21);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Antarktis-Zyklus');
+    }
 }


### PR DESCRIPTION
## Summary
- add Antarktis-Zyklus (Band 225-249) statistics and chart
- unlock Antarktis cycle stats at 22 Baxx and update rewards list
- cover new cycle visibility with feature tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6890363294b0832e92220c523217292e