### PR TITLE
Add statistics and reward for Schatten-Zyklus

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -182,6 +182,14 @@ class StatistikController extends Controller
         $antarktisLabels = $antarktisCycle->pluck('nummer');
         $antarktisValues = $antarktisCycle->pluck('bewertung');
 
+        // ── Card 18 – Bewertungen des Schatten-Zyklus ───────────────────
+        $schattenCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 250 && ($r['nummer'] ?? 0) <= 275)
+            ->sortBy('nummer');
+
+        $schattenLabels = $schattenCycle->pluck('nummer');
+        $schattenValues = $schattenCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -287,6 +295,8 @@ class StatistikController extends Controller
             'afraValues' => $afraValues,
             'antarktisLabels' => $antarktisLabels,
             'antarktisValues' => $antarktisValues,
+            'schattenLabels' => $schattenLabels,
+            'schattenValues' => $schattenValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -112,6 +112,11 @@ return [
         'points' => 22,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Schatten-Zyklus',
+        'description' => 'Zeigt Bewertungen des Schatten-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 23,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -406,6 +406,21 @@
                 </script>
             @endif
 
+            {{-- Card 18 – Bewertungen des Schatten-Zyklus (≥ 23 Baxx) --}}
+            @if ($userPoints >= 23)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Schatten-Zyklus
+                    </h2>
+                    <canvas id="schattenChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.schattenChartLabels = @json($schattenLabels);
+                    window.schattenChartValues = @json($schattenValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -265,4 +265,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Antarktis-Zyklus');
     }
+
+    public function test_schatten_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(23);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Schatten-Zyklus');
+    }
+
+    public function test_schatten_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(22);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Schatten-Zyklus');
+    }
 }


### PR DESCRIPTION
This pull request introduces support for displaying and managing data related to the "Schatten-Zyklus" in the statistics feature. The changes include backend logic, frontend updates, configuration adjustments, and new tests to ensure proper functionality.

### Backend Changes:
* Added logic in `StatistikController` to filter and process data for the "Schatten-Zyklus" (`schattenLabels` and `schattenValues`) and include it in the view model. (`[[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR185-R192)`, `[[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR298-R299)`)

### Frontend Changes:
* Updated `statistik.js` to include "schatten" in the list of cycles for chart rendering. (`[resources/js/statistik.jsL82-R82](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L82-R82)`)
* Added a new card in the Blade template (`statistik/index.blade.php`) to display the "Schatten-Zyklus" chart, visible only to users with sufficient points (≥ 23). (`[resources/views/statistik/index.blade.phpR409-R423](diffhunk://#diff-795a31d8f92444380f7cdd19e6c80df1650a2ea058f5f457e77e5fff9f5127f6R409-R423)`)

### Configuration Changes:
* Added a new reward configuration for the "Schatten-Zyklus" chart with a threshold of 23 points in `config/rewards.php`. (`[config/rewards.phpR114-R118](diffhunk://#diff-82c0883e350b0b9606e4bb5919e2d1ebc22e3f5885495759de01ac14c7149eddR114-R118)`)

### Testing:
* Added feature tests in `StatistikTest` to verify visibility of the "Schatten-Zyklus" chart based on user points (visible at 23 points, hidden below 23 points). (`[tests/Feature/StatistikTest.phpR268-R291](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R268-R291)`)