### PR TITLE
Add Ursprung-Zyklus statistics and rewards

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -190,6 +190,14 @@ class StatistikController extends Controller
         $schattenLabels = $schattenCycle->pluck('nummer');
         $schattenValues = $schattenCycle->pluck('bewertung');
 
+        // ── Card 19 – Bewertungen des Ursprung-Zyklus ───────────────────
+        $ursprungCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 276 && ($r['nummer'] ?? 0) <= 299)
+            ->sortBy('nummer');
+
+        $ursprungLabels = $ursprungCycle->pluck('nummer');
+        $ursprungValues = $ursprungCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -297,6 +305,8 @@ class StatistikController extends Controller
             'antarktisValues' => $antarktisValues,
             'schattenLabels' => $schattenLabels,
             'schattenValues' => $schattenValues,
+            'ursprungLabels' => $ursprungLabels,
+            'ursprungValues' => $ursprungValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -117,6 +117,11 @@ return [
         'points' => 23,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Ursprung-Zyklus',
+        'description' => 'Zeigt Bewertungen des Ursprung-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 24,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -421,6 +421,21 @@
                 </script>
             @endif
 
+            {{-- Card 19 – Bewertungen des Ursprung-Zyklus (≥ 24 Baxx) --}}
+            @if ($userPoints >= 24)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Ursprung-Zyklus
+                    </h2>
+                    <canvas id="ursprungChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.ursprungChartLabels = @json($ursprungLabels);
+                    window.ursprungChartValues = @json($ursprungValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -289,4 +289,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Schatten-Zyklus');
     }
+
+    public function test_ursprung_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(24);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Ursprung-Zyklus');
+    }
+
+    public function test_ursprung_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(23);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Ursprung-Zyklus');
+    }
 }


### PR DESCRIPTION
This pull request adds functionality to display ratings for the "Ursprung-Zyklus" cycle in the statistics section of the application. The changes include updates to the backend logic, frontend display, configuration, and test coverage.

### Backend Changes:
* Added logic in `StatistikController.php` to filter and prepare data for the "Ursprung-Zyklus" cycle, including labels and values for the ratings. [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR193-R200) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR308-R309)

### Frontend Changes:
* Updated `statistik.js` to include "ursprung" in the list of cycles for rendering charts.
* Added a new card in `index.blade.php` to display the "Ursprung-Zyklus" ratings chart, visible only to users with at least 24 points.

### Configuration Updates:
* Added a new reward configuration for the "Ursprung-Zyklus" ratings feature in `rewards.php`.

### Test Coverage:
* Added feature tests in `StatistikTest.php` to verify the visibility of the "Ursprung-Zyklus" chart based on user points.