### PR TITLE
Add Streiter cycle statistics and reward

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -198,6 +198,14 @@ class StatistikController extends Controller
         $ursprungLabels = $ursprungCycle->pluck('nummer');
         $ursprungValues = $ursprungCycle->pluck('bewertung');
 
+        // ── Card 20 – Bewertungen des Streiter-Zyklus ───────────────────
+        $streiterCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 300 && ($r['nummer'] ?? 0) <= 324)
+            ->sortBy('nummer');
+
+        $streiterLabels = $streiterCycle->pluck('nummer');
+        $streiterValues = $streiterCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -307,6 +315,8 @@ class StatistikController extends Controller
             'schattenValues' => $schattenValues,
             'ursprungLabels' => $ursprungLabels,
             'ursprungValues' => $ursprungValues,
+            'streiterLabels' => $streiterLabels,
+            'streiterValues' => $streiterValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -122,6 +122,11 @@ return [
         'points' => 24,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Streiter-Zyklus',
+        'description' => 'Zeigt Bewertungen des Streiter-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 25,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -436,6 +436,21 @@
                 </script>
             @endif
 
+            {{-- Card 20 – Bewertungen des Streiter-Zyklus (≥ 25 Baxx) --}}
+            @if ($userPoints >= 25)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Streiter-Zyklus
+                    </h2>
+                    <canvas id="streiterChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.streiterChartLabels = @json($streiterLabels);
+                    window.streiterChartValues = @json($streiterValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -313,4 +313,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Ursprung-Zyklus');
     }
+
+    public function test_streiter_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(25);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Streiter-Zyklus');
+    }
+
+    public function test_streiter_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(24);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Streiter-Zyklus');
+    }
 }


### PR DESCRIPTION
This pull request introduces functionality to display a new chart for the "Streiter-Zyklus" ratings in the statistics section of the application. The changes include backend logic, frontend updates, configuration adjustments, and test coverage to support this feature.

### Backend Changes:
* Added logic in `StatistikController` to calculate and pass `streiterLabels` and `streiterValues` for the "Streiter-Zyklus" ratings to the view. [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR201-R208) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR318-R319)

### Frontend Changes:
* Updated `statistik.js` to include "streiter" in the list of cycles for rendering charts dynamically.
* Added a new card in the `statistik/index.blade.php` view to display the "Streiter-Zyklus" chart, visible only to users with at least 25 points.

### Configuration Changes:
* Added a new reward configuration entry for the "Streiter-Zyklus" chart, specifying its title, description, and point threshold.

### Test Coverage:
* Added feature tests in `StatistikTest` to verify that the "Streiter-Zyklus" chart is visible to users with sufficient points and hidden from others.