### PR TITLE
Add Archivar cycle statistics and reward

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -206,6 +206,14 @@ class StatistikController extends Controller
         $streiterLabels = $streiterCycle->pluck('nummer');
         $streiterValues = $streiterCycle->pluck('bewertung');
 
+        // ── Card 21 – Bewertungen des Archivar-Zyklus ───────────────────
+        $archivarCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 325 && ($r['nummer'] ?? 0) <= 349)
+            ->sortBy('nummer');
+
+        $archivarLabels = $archivarCycle->pluck('nummer');
+        $archivarValues = $archivarCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -317,6 +325,8 @@ class StatistikController extends Controller
             'ursprungValues' => $ursprungValues,
             'streiterLabels' => $streiterLabels,
             'streiterValues' => $streiterValues,
+            'archivarLabels' => $archivarLabels,
+            'archivarValues' => $archivarValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -127,6 +127,11 @@ return [
         'points' => 25,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Archivar-Zyklus',
+        'description' => 'Zeigt Bewertungen des Archivar-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 26,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -451,6 +451,21 @@
                 </script>
             @endif
 
+            {{-- Card 21 – Bewertungen des Archivar-Zyklus (≥ 26 Baxx) --}}
+            @if ($userPoints >= 26)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Archivar-Zyklus
+                    </h2>
+                    <canvas id="archivarChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.archivarChartLabels = @json($archivarLabels);
+                    window.archivarChartValues = @json($archivarValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -337,4 +337,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Streiter-Zyklus');
     }
+
+    public function test_archivar_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(26);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Archivar-Zyklus');
+    }
+
+    public function test_archivar_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(25);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Archivar-Zyklus');
+    }
 }


### PR DESCRIPTION
This pull request introduces functionality to display statistics for the "Archivar-Zyklus" in the application. The changes include backend logic, frontend updates, configuration adjustments, and new tests to ensure proper behavior.

### Backend Changes:
* Added logic in `StatistikController` to filter and process data for the "Archivar-Zyklus," including labels and values for the cycle (`app/Http/Controllers/StatistikController.php`, [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR209-R216) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR328-R329).
* Updated the rewards configuration to include a new reward for accessing the "Archivar-Zyklus" statistics (`config/rewards.php`, [config/rewards.phpR129-R133](diffhunk://#diff-82c0883e350b0b9606e4bb5919e2d1ebc22e3f5885495759de01ac14c7149eddR129-R133)).

### Frontend Changes:
* Extended the list of cycles in `statistik.js` to include "archivar," enabling dynamic chart rendering for the new cycle (`resources/js/statistik.js`, [resources/js/statistik.jsL82-R82](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L82-R82)).
* Added a new card in the statistics view to display the "Archivar-Zyklus" chart, visible only to users with sufficient points (`resources/views/statistik/index.blade.php`, [resources/views/statistik/index.blade.phpR454-R468](diffhunk://#diff-795a31d8f92444380f7cdd19e6c80df1650a2ea058f5f457e77e5fff9f5127f6R454-R468)).

### Testing:
* Added feature tests to verify the visibility of the "Archivar-Zyklus" chart based on user points, ensuring the chart is displayed only when the threshold is met (`tests/Feature/StatistikTest.php`, [tests/Feature/StatistikTest.phpR340-R363](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R340-R363)).