### PR TITLE
Add Zeitsprung cycle statistics and rewards

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -214,6 +214,14 @@ class StatistikController extends Controller
         $archivarLabels = $archivarCycle->pluck('nummer');
         $archivarValues = $archivarCycle->pluck('bewertung');
 
+        // ── Card 22 – Bewertungen des Zeitsprung-Zyklus ───────────────────
+        $zeitsprungCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 350 && ($r['nummer'] ?? 0) <= 399)
+            ->sortBy('nummer');
+
+        $zeitsprungLabels = $zeitsprungCycle->pluck('nummer');
+        $zeitsprungValues = $zeitsprungCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -327,6 +335,8 @@ class StatistikController extends Controller
             'streiterValues' => $streiterValues,
             'archivarLabels' => $archivarLabels,
             'archivarValues' => $archivarValues,
+            'zeitsprungLabels' => $zeitsprungLabels,
+            'zeitsprungValues' => $zeitsprungValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -132,6 +132,11 @@ return [
         'points' => 26,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Zeitsprung-Zyklus',
+        'description' => 'Zeigt Bewertungen des Zeitsprung-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 27,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -466,6 +466,21 @@
                 </script>
             @endif
 
+            {{-- Card 22 – Bewertungen des Zeitsprung-Zyklus (≥ 27 Baxx) --}}
+            @if ($userPoints >= 27)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Zeitsprung-Zyklus
+                    </h2>
+                    <canvas id="zeitsprungChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.zeitsprungChartLabels = @json($zeitsprungLabels);
+                    window.zeitsprungChartValues = @json($zeitsprungValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -361,4 +361,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Archivar-Zyklus');
     }
+
+    public function test_zeitsprung_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(27);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Zeitsprung-Zyklus');
+    }
+
+    public function test_zeitsprung_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(26);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Zeitsprung-Zyklus');
+    }
 }


### PR DESCRIPTION
This pull request introduces functionality to display a new "Zeitsprung-Zyklus" chart in the statistics section of the application. The changes include backend logic, frontend updates, configuration adjustments, and test cases to support this new feature.

### Backend Updates:
* Added filtering and sorting logic for the "Zeitsprung-Zyklus" cycle in the `StatistikController` to prepare labels and values for the chart (`app/Http/Controllers/StatistikController.php`, [app/Http/Controllers/StatistikController.phpR217-R224](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR217-R224)).  
* Passed the prepared `zeitsprungLabels` and `zeitsprungValues` to the view for rendering (`app/Http/Controllers/StatistikController.php`, [app/Http/Controllers/StatistikController.phpR338-R339](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR338-R339)).

### Frontend Updates:
* Included the "zeitsprung" cycle in the list of cycles processed by the JavaScript chart rendering logic (`resources/js/statistik.js`, [resources/js/statistik.jsL82-R82](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L82-R82)).  
* Added a new card to the statistics page for displaying the "Zeitsprung-Zyklus" chart, visible only to users with at least 27 points (`resources/views/statistik/index.blade.php`, [resources/views/statistik/index.blade.phpR469-R483](diffhunk://#diff-795a31d8f92444380f7cdd19e6c80df1650a2ea058f5f457e77e5fff9f5127f6R469-R483)).

### Configuration Updates:
* Added a new reward configuration entry for the "Zeitsprung-Zyklus" chart, requiring 27 points to unlock (`config/rewards.php`, [config/rewards.phpR134-R138](diffhunk://#diff-82c0883e350b0b9606e4bb5919e2d1ebc22e3f5885495759de01ac14c7149eddR134-R138)).

### Tests:
* Added tests to verify that the "Zeitsprung-Zyklus" chart is visible to users with sufficient points and hidden otherwise (`tests/Feature/StatistikTest.php`, [tests/Feature/StatistikTest.phpR364-R387](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R364-R387)).