### PR TITLE
Add Fremdwelt cycle statistics and reward

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -222,6 +222,14 @@ class StatistikController extends Controller
         $zeitsprungLabels = $zeitsprungCycle->pluck('nummer');
         $zeitsprungValues = $zeitsprungCycle->pluck('bewertung');
 
+        // ── Card 23 – Bewertungen des Fremdwelt-Zyklus ───────────────────
+        $fremdweltCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 400 && ($r['nummer'] ?? 0) <= 499)
+            ->sortBy('nummer');
+
+        $fremdweltLabels = $fremdweltCycle->pluck('nummer');
+        $fremdweltValues = $fremdweltCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -337,6 +345,8 @@ class StatistikController extends Controller
             'archivarValues' => $archivarValues,
             'zeitsprungLabels' => $zeitsprungLabels,
             'zeitsprungValues' => $zeitsprungValues,
+            'fremdweltLabels' => $fremdweltLabels,
+            'fremdweltValues' => $fremdweltValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -137,6 +137,11 @@ return [
         'points' => 27,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Fremdwelt-Zyklus',
+        'description' => 'Zeigt Bewertungen des Fremdwelt-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 28,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -481,6 +481,21 @@
                 </script>
             @endif
 
+            {{-- Card 23 – Bewertungen des Fremdwelt-Zyklus (≥ 28 Baxx) --}}
+            @if ($userPoints >= 28)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Fremdwelt-Zyklus
+                    </h2>
+                    <canvas id="fremdweltChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.fremdweltChartLabels = @json($fremdweltLabels);
+                    window.fremdweltChartValues = @json($fremdweltValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -385,4 +385,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Zeitsprung-Zyklus');
     }
+
+    public function test_fremdwelt_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(28);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Fremdwelt-Zyklus');
+    }
+
+    public function test_fremdwelt_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(27);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Fremdwelt-Zyklus');
+    }
 }


### PR DESCRIPTION
This pull request introduces functionality for displaying and managing statistics for the "Fremdwelt-Zyklus" cycle in the application. The changes include updates to the backend logic, frontend rendering, configuration, and testing to support this new feature.

### Backend Changes:
* Added logic in `StatistikController` to filter, sort, and prepare labels and values for the "Fremdwelt-Zyklus" cycle (`fremdweltLabels` and `fremdweltValues`) to be used in the view. [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR225-R232) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR348-R349)

### Frontend Changes:
* Updated `statistik.js` to include "fremdwelt" in the list of cycles for rendering charts dynamically.
* Added a new card in `index.blade.php` to display the "Fremdwelt-Zyklus" chart, visible only to users with at least 28 points.

### Configuration Changes:
* Added a new reward entry in `rewards.php` for the "Fremdwelt-Zyklus" chart with a description and point threshold.

### Testing Changes:
* Added feature tests in `StatistikTest` to ensure the "Fremdwelt-Zyklus" chart is visible to users with sufficient points and hidden for others.