### PR TITLE
Add Parallelwelt-Zyklus statistics and rewards

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -230,6 +230,14 @@ class StatistikController extends Controller
         $fremdweltLabels = $fremdweltCycle->pluck('nummer');
         $fremdweltValues = $fremdweltCycle->pluck('bewertung');
 
+        // ── Card 24 – Bewertungen des Parallelwelt-Zyklus ───────────────────
+        $parallelweltCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 500 && ($r['nummer'] ?? 0) <= 549)
+            ->sortBy('nummer');
+
+        $parallelweltLabels = $parallelweltCycle->pluck('nummer');
+        $parallelweltValues = $parallelweltCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -347,6 +355,8 @@ class StatistikController extends Controller
             'zeitsprungValues' => $zeitsprungValues,
             'fremdweltLabels' => $fremdweltLabels,
             'fremdweltValues' => $fremdweltValues,
+            'parallelweltLabels' => $parallelweltLabels,
+            'parallelweltValues' => $parallelweltValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -142,6 +142,11 @@ return [
         'points' => 28,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Parallelwelt-Zyklus',
+        'description' => 'Zeigt Bewertungen des Parallelwelt-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 29,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -496,6 +496,21 @@
                 </script>
             @endif
 
+            {{-- Card 24 – Bewertungen des Parallelwelt-Zyklus (≥ 29 Baxx) --}}
+            @if ($userPoints >= 29)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Parallelwelt-Zyklus
+                    </h2>
+                    <canvas id="parallelweltChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.parallelweltChartLabels = @json($parallelweltLabels);
+                    window.parallelweltChartValues = @json($parallelweltValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -409,4 +409,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Fremdwelt-Zyklus');
     }
+
+    public function test_parallelwelt_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(29);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Parallelwelt-Zyklus');
+    }
+
+    public function test_parallelwelt_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(28);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Parallelwelt-Zyklus');
+    }
 }


### PR DESCRIPTION
This pull request introduces a new feature to display statistics for the "Parallelwelt-Zyklus" in the application. The changes include backend logic, frontend updates, and test cases to support this feature. Below is a summary of the most important changes:

### Backend Changes:
* Added logic in `StatistikController` to filter and prepare data for the "Parallelwelt-Zyklus" (`parallelweltLabels` and `parallelweltValues`) for display. [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR233-R240) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR358-R359)
* Updated `config/rewards.php` to include a new reward for unlocking the "Parallelwelt-Zyklus" chart, requiring 29 points.

### Frontend Changes:
* Updated `resources/js/statistik.js` to include "parallelwelt" in the list of cycles for rendering charts dynamically.
* Added a new card in `resources/views/statistik/index.blade.php` to display the "Parallelwelt-Zyklus" chart, visible only to users with at least 29 points.

### Testing:
* Added new test cases in `StatistikTest` to verify that the "Parallelwelt-Zyklus" chart is visible to users with sufficient points and hidden otherwise.