### PR TITLE
Add Weltenriss cycle statistics and reward

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -238,6 +238,14 @@ class StatistikController extends Controller
         $parallelweltLabels = $parallelweltCycle->pluck('nummer');
         $parallelweltValues = $parallelweltCycle->pluck('bewertung');
 
+        // ── Card 25 – Bewertungen des Weltenriss-Zyklus ───────────────────
+        $weltenrissCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 550 && ($r['nummer'] ?? 0) <= 599)
+            ->sortBy('nummer');
+
+        $weltenrissLabels = $weltenrissCycle->pluck('nummer');
+        $weltenrissValues = $weltenrissCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -357,6 +365,8 @@ class StatistikController extends Controller
             'fremdweltValues' => $fremdweltValues,
             'parallelweltLabels' => $parallelweltLabels,
             'parallelweltValues' => $parallelweltValues,
+            'weltenrissLabels' => $weltenrissLabels,
+            'weltenrissValues' => $weltenrissValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -147,6 +147,11 @@ return [
         'points' => 29,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Weltenriss-Zyklus',
+        'description' => 'Zeigt Bewertungen des Weltenriss-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 30,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -511,6 +511,21 @@
                 </script>
             @endif
 
+            {{-- Card 25 – Bewertungen des Weltenriss-Zyklus (≥ 30 Baxx) --}}
+            @if ($userPoints >= 30)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Weltenriss-Zyklus
+                    </h2>
+                    <canvas id="weltenrissChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.weltenrissChartLabels = @json($weltenrissLabels);
+                    window.weltenrissChartValues = @json($weltenrissValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -433,4 +433,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Parallelwelt-Zyklus');
     }
+
+    public function test_weltenriss_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(30);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Weltenriss-Zyklus');
+    }
+
+    public function test_weltenriss_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(29);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Weltenriss-Zyklus');
+    }
 }


### PR DESCRIPTION
## Summary
- display statistics for the Weltenriss cycle (550-599)
- add reward entry for Weltenriss cycle
- test visibility for new cycle chart

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689055af6ca8832eb9a4e3af1db8c9da