### PR TITLE
Add Amraka cycle statistics and reward

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -246,6 +246,14 @@ class StatistikController extends Controller
         $weltenrissLabels = $weltenrissCycle->pluck('nummer');
         $weltenrissValues = $weltenrissCycle->pluck('bewertung');
 
+        // ── Card 26 – Bewertungen des Amraka-Zyklus ───────────────────
+        $amrakaCycle = $romane
+            ->filter(fn($r) => ($r['nummer'] ?? 0) >= 600 && ($r['nummer'] ?? 0) <= 649)
+            ->sortBy('nummer');
+
+        $amrakaLabels = $amrakaCycle->pluck('nummer');
+        $amrakaValues = $amrakaCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -367,6 +375,8 @@ class StatistikController extends Controller
             'parallelweltValues' => $parallelweltValues,
             'weltenrissLabels' => $weltenrissLabels,
             'weltenrissValues' => $weltenrissValues,
+            'amrakaLabels' => $amrakaLabels,
+            'amrakaValues' => $amrakaValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -152,6 +152,11 @@ return [
         'points' => 30,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Amraka-Zyklus',
+        'description' => 'Zeigt Bewertungen des Amraka-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 31,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -526,6 +526,21 @@
                 </script>
             @endif
 
+            {{-- Card 26 – Bewertungen des Amraka-Zyklus (≥ 31 Baxx) --}}
+            @if ($userPoints >= 31)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Amraka-Zyklus
+                    </h2>
+                    <canvas id="amrakaChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.amrakaChartLabels = @json($amrakaLabels);
+                    window.amrakaChartValues = @json($amrakaValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -457,4 +457,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Weltenriss-Zyklus');
     }
+
+    public function test_amraka_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(31);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Amraka-Zyklus');
+    }
+
+    public function test_amraka_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(30);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Amraka-Zyklus');
+    }
 }


### PR DESCRIPTION
This pull request introduces support for displaying statistics related to the "Amraka-Zyklus" in the application. The changes include backend logic, frontend updates, configuration adjustments, and new tests to ensure the feature works correctly.

### Backend Changes:

* [`app/Http/Controllers/StatistikController.php`](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR249-R256): Added logic to filter, sort, and extract labels and values for the "Amraka-Zyklus" (`amrakaLabels` and `amrakaValues`) and included these in the view data passed to the frontend. [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR249-R256) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR378-R379)

* [`config/rewards.php`](diffhunk://#diff-82c0883e350b0b9606e4bb5919e2d1ebc22e3f5885495759de01ac14c7149eddR154-R158): Added a new reward configuration for the "Amraka-Zyklus" chart, requiring 31 points to unlock it.

### Frontend Changes:

* [`resources/js/statistik.js`](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L82-R82): Updated the cycle list to include "amraka" for rendering its chart dynamically.

* [`resources/views/statistik/index.blade.php`](diffhunk://#diff-795a31d8f92444380f7cdd19e6c80df1650a2ea058f5f457e77e5fff9f5127f6R529-R543): Added a new card for the "Amraka-Zyklus" chart, conditionally displayed for users with at least 31 points.

### Testing:

* [`tests/Feature/StatistikTest.php`](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R460-R483): Added tests to verify the visibility of the "Amraka-Zyklus" chart based on user points, ensuring it is shown or hidden correctly at the 31-point threshold.