### PR TITLE
Add Weltrat-Zyklus statistics and reward

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -254,6 +254,13 @@ class StatistikController extends Controller
         $amrakaLabels = $amrakaCycle->pluck('nummer');
         $amrakaValues = $amrakaCycle->pluck('bewertung');
 
+        // ── Card 27 – Bewertungen des Weltrat-Zyklus ───────────────────
+        $weltratLabels = collect(range(650, 699));
+        $weltratValues = $weltratLabels->map(function ($nummer) use ($romane) {
+            $roman = $romane->firstWhere('nummer', $nummer);
+            return $roman['bewertung'] ?? null;
+        });
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -377,6 +384,8 @@ class StatistikController extends Controller
             'weltenrissValues' => $weltenrissValues,
             'amrakaLabels' => $amrakaLabels,
             'amrakaValues' => $amrakaValues,
+            'weltratLabels' => $weltratLabels,
+            'weltratValues' => $weltratValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -157,6 +157,11 @@ return [
         'points' => 31,
     ],
     [
+        'title' => 'Statistik - Bewertungen des Weltrat-Zyklus',
+        'description' => 'Zeigt Bewertungen des Weltrat-Zyklus aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 32,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka', 'weltrat'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -541,6 +541,21 @@
                 </script>
             @endif
 
+            {{-- Card 27 – Bewertungen des Weltrat-Zyklus (≥ 32 Baxx) --}}
+            @if ($userPoints >= 32)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen des Weltrat-Zyklus
+                    </h2>
+                    <canvas id="weltratChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.weltratChartLabels = @json($weltratLabels);
+                    window.weltratChartValues = @json($weltratValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -481,4 +481,28 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertDontSee('Bewertungen des Amraka-Zyklus');
     }
+
+    public function test_weltrat_cycle_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(32);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Bewertungen des Weltrat-Zyklus');
+    }
+
+    public function test_weltrat_cycle_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(31);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Bewertungen des Weltrat-Zyklus');
+    }
 }


### PR DESCRIPTION
## Summary
- extend rewards with Weltrat-Zyklus stats unlockable at 32 Baxx
- display Weltrat-Zyklus chart spanning issues 650‑699 in statistics page
- include tests for Weltrat-Zyklus visibility rules

## Testing
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68905b2f0afc832ea5ef20ccde4d1fda