### PR TITLE
Allow editing and deleting review comments

### DIFF
--- a/resources/views/reviews/partials/comment.blade.php
+++ b/resources/views/reviews/partials/comment.blade.php
@@ -6,9 +6,33 @@
         {{ $comment->content }}
     </div>
 
+    @if(auth()->id() === $comment->user_id)
+        <div x-data="{ editing: false }" class="mt-2">
+            <button type="button" @click="editing = !editing" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Bearbeiten</button>
+
+            <form x-show="editing" method="POST" action="{{ route('reviews.comments.update', $comment) }}" class="mt-2">
+                @csrf
+                @method('PUT')
+                <textarea name="content" rows="2" class="w-full border-gray-300 dark:border-gray-600 dark:bg-gray-800 rounded mt-1" required>{{ old('content', $comment->content) }}</textarea>
+                <div class="mt-2 flex gap-2">
+                    <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Speichern</button>
+                    <button type="button" @click="editing = false" class="bg-gray-600 hover:bg-gray-700 text-white px-3 py-1 rounded">Abbrechen</button>
+                </div>
+            </form>
+        </div>
+    @endif
+
+    @if(auth()->id() === $comment->user_id || in_array($role ?? null, ['Vorstand','Admin'], true))
+        <form method="POST" action="{{ route('reviews.comments.destroy', $comment) }}" class="mt-2">
+            @csrf
+            @method('DELETE')
+            <button type="submit" class="bg-red-600 hover:bg-red-700 text-white px-3 py-1 rounded">Löschen</button>
+        </form>
+    @endif
+
     @foreach($comment->children as $child)
         <div class="ml-6">
-            @include('reviews.partials.comment', ['comment' => $child])
+            @include('reviews.partials.comment', ['comment' => $child, 'role' => $role])
         </div>
     @endforeach
 

--- a/resources/views/reviews/show.blade.php
+++ b/resources/views/reviews/show.blade.php
@@ -34,7 +34,7 @@
                     @endif
                     <div class="mt-6">
                         @foreach($review->comments->whereNull('parent_id') as $comment)
-                            @include('reviews.partials.comment', ['comment' => $comment])
+                            @include('reviews.partials.comment', ['comment' => $comment, 'role' => $role])
                         @endforeach
 
                         <form method="POST" action="{{ route('reviews.comments.store', $review) }}" class="mt-4">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\AdminController;
 use App\Http\Controllers\Auth\CustomEmailVerificationController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\DownloadsController;
@@ -19,7 +20,6 @@ use App\Http\Controllers\RezensionController;
 use App\Http\Controllers\RomantauschController;
 use App\Http\Controllers\StatistikController;
 use App\Http\Controllers\TodoController;
-use App\Http\Controllers\AdminController;
 use App\Http\Middleware\RedirectIfAnwaerter;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
@@ -119,8 +119,8 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
     });
 
     Route::get('/abzeichen/{filename}', function ($filename) {
-        $path = public_path('images/badges/' . $filename);
-        if (!file_exists($path)) {
+        $path = public_path('images/badges/'.$filename);
+        if (! file_exists($path)) {
             abort(404);
         }
 
@@ -160,5 +160,7 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::put('/{review}', [RezensionController::class, 'update'])->name('update');
         Route::delete('/{review}', [RezensionController::class, 'destroy'])->name('destroy');
         Route::post('/{review}/kommentar', [ReviewCommentController::class, 'store'])->name('comments.store');
+        Route::put('/kommentar/{comment}', [ReviewCommentController::class, 'update'])->name('comments.update');
+        Route::delete('/kommentar/{comment}', [ReviewCommentController::class, 'destroy'])->name('comments.destroy');
     });
 });

--- a/tests/Feature/ReviewCommentControllerTest.php
+++ b/tests/Feature/ReviewCommentControllerTest.php
@@ -2,14 +2,15 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-use App\Models\Team;
-use App\Models\User;
+use App\Mail\ReviewCommentNotification;
 use App\Models\Book;
 use App\Models\Review;
-use App\Mail\ReviewCommentNotification;
+use App\Models\ReviewComment;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
 
 class ReviewCommentControllerTest extends TestCase
 {
@@ -20,6 +21,7 @@ class ReviewCommentControllerTest extends TestCase
         $team = Team::where('name', 'Mitglieder')->first();
         $user = User::factory()->create(['current_team_id' => $team->id]);
         $team->users()->attach($user, ['role' => $role]);
+
         return $user;
     }
 
@@ -104,6 +106,122 @@ class ReviewCommentControllerTest extends TestCase
         $this->assertDatabaseMissing('review_comments', [
             'review_id' => $review->id,
             'user_id' => $member->id,
+        ]);
+    }
+
+    public function test_author_can_update_own_comment(): void
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $author = $this->actingMember();
+        $book = Book::create(['roman_number' => 1, 'title' => 'Roman1', 'author' => 'Foo']);
+        $review = Review::create([
+            'team_id' => $team->id,
+            'user_id' => $author->id,
+            'book_id' => $book->id,
+            'title' => 'Review',
+            'content' => str_repeat('B', 140),
+        ]);
+        $comment = ReviewComment::create([
+            'review_id' => $review->id,
+            'user_id' => $author->id,
+            'content' => 'Alt',
+        ]);
+
+        $this->actingAs($author);
+
+        $this->put(route('reviews.comments.update', $comment), [
+            'content' => 'Neu',
+        ])->assertRedirect();
+
+        $this->assertDatabaseHas('review_comments', [
+            'id' => $comment->id,
+            'content' => 'Neu',
+        ]);
+    }
+
+    public function test_other_member_cannot_update_comment(): void
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $author = $this->actingMember();
+        $book = Book::create(['roman_number' => 1, 'title' => 'Roman1', 'author' => 'Foo']);
+        $review = Review::create([
+            'team_id' => $team->id,
+            'user_id' => $author->id,
+            'book_id' => $book->id,
+            'title' => 'Review',
+            'content' => str_repeat('B', 140),
+        ]);
+        $comment = ReviewComment::create([
+            'review_id' => $review->id,
+            'user_id' => $author->id,
+            'content' => 'Original',
+        ]);
+
+        $other = $this->actingMember();
+        $this->actingAs($other);
+
+        $this->put(route('reviews.comments.update', $comment), [
+            'content' => 'Hacked',
+        ])->assertForbidden();
+
+        $this->assertDatabaseHas('review_comments', [
+            'id' => $comment->id,
+            'content' => 'Original',
+        ]);
+    }
+
+    public function test_author_can_delete_own_comment(): void
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $author = $this->actingMember();
+        $book = Book::create(['roman_number' => 1, 'title' => 'Roman1', 'author' => 'Foo']);
+        $review = Review::create([
+            'team_id' => $team->id,
+            'user_id' => $author->id,
+            'book_id' => $book->id,
+            'title' => 'Review',
+            'content' => str_repeat('B', 140),
+        ]);
+        $comment = ReviewComment::create([
+            'review_id' => $review->id,
+            'user_id' => $author->id,
+            'content' => 'Zu löschen',
+        ]);
+
+        $this->actingAs($author);
+
+        $this->delete(route('reviews.comments.destroy', $comment))->assertRedirect();
+
+        $this->assertSoftDeleted('review_comments', [
+            'id' => $comment->id,
+        ]);
+    }
+
+    public function test_vorstand_can_delete_any_comment(): void
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $author = $this->actingMember();
+        $book = Book::create(['roman_number' => 1, 'title' => 'Roman1', 'author' => 'Foo']);
+        $review = Review::create([
+            'team_id' => $team->id,
+            'user_id' => $author->id,
+            'book_id' => $book->id,
+            'title' => 'Review',
+            'content' => str_repeat('B', 140),
+        ]);
+        $comment = ReviewComment::create([
+            'review_id' => $review->id,
+            'user_id' => $author->id,
+            'content' => 'Moderation',
+        ]);
+
+        $vorstand = $this->actingMember('Vorstand');
+        $this->actingAs($vorstand);
+
+        $this->delete(route('reviews.comments.destroy', $comment))->assertRedirect();
+
+        $this->assertSoftDeleted('review_comments', [
+            'id' => $comment->id,
         ]);
     }
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `ReviewCommentController` and related functionality, including the addition of update and delete features for comments, updates to the views to support these features, and corresponding tests to ensure proper functionality. Below is a breakdown of the most important changes:

### Backend functionality for comments:
* Added `update` and `destroy` methods to the `ReviewCommentController` to allow users to edit and delete their own comments, with role-based permissions for deletion by admins or board members.
* Updated the `routes/web.php` file to include new routes for updating and deleting comments (`comments.update` and `comments.destroy`).

### Frontend updates for comment management:
* Updated `resources/views/reviews/partials/comment.blade.php` to include buttons and forms for editing and deleting comments, with appropriate permission checks for visibility.
* Modified `resources/views/reviews/show.blade.php` to pass the user's role to the comment partial for permission handling.

### Test coverage:
* Added new tests in `tests/Feature/ReviewCommentControllerTest.php` to verify:
  - Authors can update and delete their own comments.
  - Other users cannot update comments they do not own.
  - Admins and board members can delete any comment.

### Code cleanup and reorganization:
* Adjusted imports in several files (`ReviewCommentController.php`, `ReviewCommentControllerTest.php`, and `routes/web.php`) to ensure proper organization and remove unused imports. [[1]](diffhunk://#diff-8172677ea5f39753dbec53d4a1601d7cad3f4d09e9cec4a01dd58e1d2aea2cbcL5-L13) [[2]](diffhunk://#diff-ca8b11877527f70d58f79f152f55b4f87eef672110e484c352afbbaa3da8f4f3L5-R13) [[3]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR3) [[4]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL22)