### PR TITLE
Improve readability of review pages

### DIFF
--- a/resources/views/reviews/create.blade.php
+++ b/resources/views/reviews/create.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <x-member-page class="max-w-3xl">
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-6">
+            <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
                 Neue Rezension zu „{{ $book->title }}“ (Nr. {{ $book->roman_number }})
             </h1>
 

--- a/resources/views/reviews/edit.blade.php
+++ b/resources/views/reviews/edit.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <x-member-page class="max-w-3xl">
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-6">
+            <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
                 Rezension zu „{{ $review->book->title }}“ bearbeiten
             </h1>
 

--- a/resources/views/reviews/index.blade.php
+++ b/resources/views/reviews/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-member-page>
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-4">Rezensionen</h1>
-            <p class="mb-6 text-sm text-gray-600 dark:text-gray-400">
+            <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">Rezensionen</h1>
+            <p class="mb-6 text-base font-medium text-gray-700 dark:text-gray-300">
                 Für jede <strong>zehnte</strong> verfasste Rezension erhältst du automatisch
                 <strong>1 Baxx</strong>.
             </p>

--- a/resources/views/reviews/show.blade.php
+++ b/resources/views/reviews/show.blade.php
@@ -6,7 +6,7 @@
                 </div>
             @endif
 
-            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-6">
+            <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
                 Rezensionen zu „{{ $book->title }}“ (Nr. {{ $book->roman_number }})
             </h1>
 


### PR DESCRIPTION
This pull request updates the styling of headings and text across multiple review-related Blade templates to improve consistency and readability. The most important changes involve increasing the font size, adjusting font weights, and standardizing color schemes.

### Heading Style Updates:
* [`resources/views/reviews/create.blade.php`](diffhunk://#diff-95f123d2764d30e8702d8f6482a5e730c0f43fb5dde8770b1adfb611033289fdL3-R3): Updated the heading to use a larger font size (`text-3xl`), bold font weight (`font-bold`), and standardized colors (`text-gray-900` for light mode, `text-gray-100` for dark mode).
* [`resources/views/reviews/edit.blade.php`](diffhunk://#diff-6b72c5130e56a05688e80b81da04febd37baf4f07c3cc7a95f6dc416dd369169L3-R3): Applied the same heading style updates as in the create view for consistency.
* [`resources/views/reviews/show.blade.php`](diffhunk://#diff-9cd87369466636f28751884bd7d4e05e7b82ea7df7226c4bc95f0b7b66f9f699L9-R9): Updated the heading style to match the changes in the create and edit views.

### Paragraph Style Updates:
* [`resources/views/reviews/index.blade.php`](diffhunk://#diff-00ef715388ea5b0565ff6b9058b2ab80c1a490f94a14128b08276675b98bd7adL3-R4): Updated the heading with the same style changes as above, and modified a paragraph to use a slightly larger font size (`text-base`), medium font weight (`font-medium`), and adjusted colors for better readability (`text-gray-700` for light mode, `text-gray-300` for dark mode).