### PR TITLE
Verbessere Responsivität der Rezensionsseiten

### DIFF
--- a/resources/views/reviews/create.blade.php
+++ b/resources/views/reviews/create.blade.php
@@ -33,7 +33,7 @@
                         @enderror
                     </div>
 
-                    <div class="flex items-center justify-between">
+                    <div class="flex flex-col sm:flex-row sm:justify-between gap-4">
                         <a href="{{ route('reviews.index') }}" class="text-gray-600 dark:text-gray-400 hover:underline">Abbrechen</a>
                         <button type="submit" class="bg-[#8B0116] dark:bg-[#FCA5A5] text-white px-4 py-2 rounded">
                             Rezension absenden

--- a/resources/views/reviews/edit.blade.php
+++ b/resources/views/reviews/edit.blade.php
@@ -29,7 +29,7 @@
                         @enderror
                     </div>
 
-                    <div class="flex items-center justify-between">
+                    <div class="flex flex-col sm:flex-row sm:justify-between gap-4">
                         <a href="{{ route('reviews.show', $review->book) }}" class="text-gray-600 dark:text-gray-400 hover:underline">Abbrechen</a>
                         <button type="submit" class="bg-[#8B0116] dark:bg-[#FCA5A5] text-white px-4 py-2 rounded">
                             Rezension aktualisieren

--- a/resources/views/reviews/index.blade.php
+++ b/resources/views/reviews/index.blade.php
@@ -28,9 +28,9 @@
                         </select>
                     </div>
                 </div>
-                <div class="mt-4 flex items-center">
+                <div class="mt-4 flex flex-col sm:flex-row sm:items-center gap-2">
                     <button type="submit" class="bg-[#8B0116] dark:bg-[#FCA5A5] text-white px-4 py-2 rounded">Filtern</button>
-                    <a href="{{ route('reviews.index') }}" class="ml-3 text-gray-600 dark:text-gray-400 hover:underline">Zurücksetzen</a>
+                    <a href="{{ route('reviews.index') }}" class="text-gray-600 dark:text-gray-400 hover:underline">Zurücksetzen</a>
                 </div>
             </form>
             <div id="accordion">
@@ -46,51 +46,83 @@
                                 <span id="icon-{{ $id }}">{{ $loop->first ? '-' : '+' }}</span>
                             </button>
                         </h2>
-                        <div id="content-{{ $id }}" class="{{ $loop->first ? '' : 'hidden' }} bg-white dark:bg-gray-900 px-4 py-2 rounded-b-lg overflow-auto">
-                            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                                <thead>
-                                    <tr>
-                                        <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Nr.</th>
-                                        <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Titel</th>
-                                        <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Autor</th>
-                                        <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Status</th>
-                                        <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Rezensionen</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                                    @foreach($cycleBooks->sortByDesc('roman_number') as $book)
+                        <div id="content-{{ $id }}" class="{{ $loop->first ? '' : 'hidden' }} bg-white dark:bg-gray-900 px-4 py-2 rounded-b-lg">
+                            <div class="hidden md:block overflow-x-auto">
+                                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                    <thead>
                                         <tr>
-                                            <td class="px-4 py-2">
-                                                <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline">
-                                                    {{ $book->roman_number }}
-                                                </a>
-                                            </td>
-                                            <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ $book->title }}</td>
-                                            <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ $book->author }}</td>
-                                            <td class="px-4 py-2">
-                                                @if($book->has_review)
-                                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                                                            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 00-1.414-1.414L8.5 10.672 5.707 7.879a1 1 0 00-1.414 1.414l3.647 3.647a1 1 0 001.414 0l7.353-7.353z" clip-rule="evenodd" />
-                                                        </svg>
-                                                    </span>
-                                                @else
-                                                    <a href="{{ route('reviews.create', $book) }}" class="inline-flex items-center p-1 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100 hover:bg-blue-200 dark:hover:bg-blue-700" title="Rezension schreiben">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                                                            <path d="m2.695 14.762-1.262 3.155a.5.5 0 0 0 .65.65l3.155-1.262a4 4 0 0 0 1.343-.886L17.5 5.501a2.121 2.121 0 0 0-3-3L3.58 13.419a4 4 0 0 0-.885 1.343Z" />
-                                                        </svg>
-                                                    </a>
-                                                @endif
-                                            </td>
-                                            <td class="px-4 py-2">
-                                                <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline">
-                                                    {{ $book->reviews_count }} {{ $book->reviews_count === 1 ? 'Rezension' : 'Rezensionen' }}
-                                                </a>
-                                            </td>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Nr.</th>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Titel</th>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Autor</th>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Status</th>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Rezensionen</th>
                                         </tr>
-                                    @endforeach
-                                </tbody>
-                            </table>
+                                    </thead>
+                                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                                        @foreach($cycleBooks->sortByDesc('roman_number') as $book)
+                                            <tr>
+                                                <td class="px-4 py-2">
+                                                    <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline">
+                                                        {{ $book->roman_number }}
+                                                    </a>
+                                                </td>
+                                                <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ $book->title }}</td>
+                                                <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ $book->author }}</td>
+                                                <td class="px-4 py-2">
+                                                    @if($book->has_review)
+                                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 00-1.414-1.414L8.5 10.672 5.707 7.879a1 1 0 00-1.414 1.414l3.647 3.647a1 1 0 001.414 0l7.353-7.353z" clip-rule="evenodd" />
+                                                            </svg>
+                                                        </span>
+                                                    @else
+                                                        <a href="{{ route('reviews.create', $book) }}" class="inline-flex items-center p-1 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100 hover:bg-blue-200 dark:hover:bg-blue-700" title="Rezension schreiben">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                                <path d="m2.695 14.762-1.262 3.155a.5.5 0 0 0 .65.65l3.155-1.262a4 4 0 0 0 1.343-.886L17.5 5.501a2.121 2.121 0 0 0-3-3L3.58 13.419a4 4 0 0 0-.885 1.343Z" />
+                                                            </svg>
+                                                        </a>
+                                                    @endif
+                                                </td>
+                                                <td class="px-4 py-2">
+                                                    <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline">
+                                                        {{ $book->reviews_count }} {{ $book->reviews_count === 1 ? 'Rezension' : 'Rezensionen' }}
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="md:hidden">
+                                @foreach($cycleBooks->sortByDesc('roman_number') as $book)
+                                    <div class="py-2 border-b border-gray-200 dark:border-gray-700 flex justify-between items-start">
+                                        <div>
+                                            <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline font-semibold">
+                                                Nr. {{ $book->roman_number }}: {{ $book->title }}
+                                            </a>
+                                            <p class="text-gray-600 dark:text-gray-400 text-sm">{{ $book->author }}</p>
+                                        </div>
+                                        <div class="text-right">
+                                            @if($book->has_review)
+                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 00-1.414-1.414L8.5 10.672 5.707 7.879a1 1 0 00-1.414 1.414l3.647 3.647a1 1 0 001.414 0l7.353-7.353z" clip-rule="evenodd" />
+                                                    </svg>
+                                                </span>
+                                            @else
+                                                <a href="{{ route('reviews.create', $book) }}" class="inline-flex items-center p-1 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100 hover:bg-blue-200 dark:hover:bg-blue-700" title="Rezension schreiben">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                        <path d="m2.695 14.762-1.262 3.155a.5.5 0 0 0 .65.65l3.155-1.262a4 4 0 0 0 1.343-.886L17.5 5.501a2.121 2.121 0 0 0-3-3L3.58 13.419a4 4 0 0 0-.885 1.343Z" />
+                                                    </svg>
+                                                </a>
+                                            @endif
+                                            <a href="{{ route('reviews.show', $book) }}" class="block text-[#8B0116] hover:underline text-sm mt-1">
+                                                {{ $book->reviews_count }} {{ $book->reviews_count === 1 ? 'Rezension' : 'Rezensionen' }}
+                                            </a>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
                         </div>
                     </div>
                 @endforeach

--- a/resources/views/reviews/partials/comment.blade.php
+++ b/resources/views/reviews/partials/comment.blade.php
@@ -14,7 +14,7 @@
                 @csrf
                 @method('PUT')
                 <textarea name="content" rows="2" class="w-full border-gray-300 dark:border-gray-600 dark:bg-gray-800 rounded mt-1" required>{{ old('content', $comment->content) }}</textarea>
-                <div class="mt-2 flex gap-2">
+                <div class="mt-2 flex flex-col sm:flex-row gap-2">
                     <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded">Speichern</button>
                     <button type="button" @click="editing = false" class="bg-gray-600 hover:bg-gray-700 text-white px-3 py-1 rounded">Abbrechen</button>
                 </div>

--- a/resources/views/reviews/show.blade.php
+++ b/resources/views/reviews/show.blade.php
@@ -19,7 +19,7 @@
                     </div>
 
                     @if(in_array($role ?? null, ['Vorstand','Admin'], true) || auth()->id() === $review->user_id)
-                        <div class="mt-4 flex gap-2">
+                        <div class="mt-4 flex flex-col sm:flex-row gap-2">
                             <a href="{{ route('reviews.edit', $review) }}" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded">
                                 Rezension bearbeiten
                             </a>


### PR DESCRIPTION
## Zusammenfassung
- Tabelle der Rezensionen durch mobile Kartenansicht ergänzt und Filter-Steuerung flexibler gestaltet
- Aktions-Buttons auf Rezensionsseiten und Formularen für kleine Bildschirme gestapelt
- Kommentar-Bearbeitung um responsives Button-Layout erweitert

## Testing
- `npm run build`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6890e7f473b8832ea3dfe0df85d76738