### PR TITLE
Log review comments in dashboard activity feed

### DIFF
--- a/app/Http/Controllers/ReviewCommentController.php
+++ b/app/Http/Controllers/ReviewCommentController.php
@@ -6,6 +6,7 @@ use App\Mail\ReviewCommentNotification;
 use App\Models\Review;
 use App\Models\ReviewComment;
 use App\Models\Team;
+use App\Models\Activity;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -70,6 +71,12 @@ class ReviewCommentController extends Controller
             Mail::to($review->user->email)
                 ->send(new ReviewCommentNotification($review, $comment));
         }
+
+        Activity::create([
+            'user_id' => $user->id,
+            'subject_type' => ReviewComment::class,
+            'subject_id' => $comment->id,
+        ]);
 
         return back()->with('success', 'Kommentar erfolgreich gespeichert.');
     }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -79,6 +79,10 @@
                                 <a href="{{ route('romantausch.index') }}" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
                                     Neues Gesuch: {{ $activity->subject->book_title }}
                                 </a>
+                            @elseif($activity->subject_type === \App\Models\ReviewComment::class)
+                                <a href="{{ route('reviews.show', $activity->subject->review->book_id) }}" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+                                    Kommentar zu {{ $activity->subject->review->title }} von {{ $activity->user->name }}
+                                </a>
                             @elseif($activity->subject_type === \App\Models\Todo::class && $activity->action === 'accepted')
                                 <span class="text-sm">hat die Challenge {{ $activity->subject->title }} angenommen</span>
                             @elseif($activity->subject_type === \App\Models\Todo::class && $activity->action === 'completed')


### PR DESCRIPTION
This pull request adds support for tracking and displaying user activity when new review comments are created. Now, whenever a user comments on a review, an activity entry is created and surfaced on the dashboard. The changes also include a new test to ensure this feature works as expected.

**Activity tracking and display for review comments:**

* Added creation of an `Activity` record when a new `ReviewComment` is posted in `ReviewCommentController`, linking the activity to the user and the comment. [[1]](diffhunk://#diff-8172677ea5f39753dbec53d4a1601d7cad3f4d09e9cec4a01dd58e1d2aea2cbcR9) [[2]](diffhunk://#diff-8172677ea5f39753dbec53d4a1601d7cad3f4d09e9cec4a01dd58e1d2aea2cbcR75-R80)
* Updated the dashboard view (`dashboard.blade.php`) to display a message and link when an activity is related to a `ReviewComment`, showing the review title and commenter’s name.

**Testing:**

* Added a feature test to verify that posting a review comment creates an `Activity` record and that the dashboard displays the correct information. [[1]](diffhunk://#diff-6bdef5cc698fedef22d34b4142491edf9dc7f2b6465ee3f45901c1800706c8bbR17) [[2]](diffhunk://#diff-6bdef5cc698fedef22d34b4142491edf9dc7f2b6465ee3f45901c1800706c8bbR103-R138)