### PR TITLE
Remove mobile indentation for nested review comments

### DIFF
--- a/resources/views/reviews/partials/comment.blade.php
+++ b/resources/views/reviews/partials/comment.blade.php
@@ -2,6 +2,11 @@
     <p class="text-sm text-gray-500 dark:text-gray-300">
         {{ $comment->user->name }} am {{ $comment->created_at->format('d.m.Y H:i') }}
     </p>
+    @isset($parentAuthor)
+        <p class="text-xs text-gray-500 dark:text-gray-400 md:hidden">
+            Antwort auf {{ $parentAuthor }}
+        </p>
+    @endisset
     <div class="mt-2 text-gray-800 dark:text-gray-200 whitespace-pre-line">
         {{ $comment->content }}
     </div>
@@ -31,8 +36,8 @@
     @endif
 
     @foreach($comment->children as $child)
-        <div class="ml-6">
-            @include('reviews.partials.comment', ['comment' => $child, 'role' => $role])
+        <div class="md:ml-6">
+            @include('reviews.partials.comment', ['comment' => $child, 'role' => $role, 'parentAuthor' => $comment->user->name])
         </div>
     @endforeach
 


### PR DESCRIPTION
This pull request updates the comment display in the reviews section to improve clarity, especially for replies. The changes ensure that replies indicate which comment they are responding to and enhance the visual indentation for better readability on different screen sizes.

Comment reply improvements:

* Added a line to show "Antwort auf [parent author]" for replies, visible on mobile devices, making it clear who is being replied to.
* Passed the parent comment author's name to child comments when rendering replies, so the reply indicator can be shown.

UI/UX adjustments:

* Changed the indentation class from `ml-6` to `md:ml-6` for child comments, so indentation only applies on medium and larger screens, improving mobile layout.