### PR TITLE
Limit mobile comment indentation depth on mobile

### DIFF
--- a/resources/views/reviews/partials/comment.blade.php
+++ b/resources/views/reviews/partials/comment.blade.php
@@ -1,3 +1,6 @@
+@php
+    $depth = $depth ?? 0;
+@endphp
 <div class="mt-4 bg-gray-50 dark:bg-gray-700 p-4 rounded">
     <p class="text-sm text-gray-500 dark:text-gray-300">
         {{ $comment->user->name }} am {{ $comment->created_at->format('d.m.Y H:i') }}
@@ -36,8 +39,22 @@
     @endif
 
     @foreach($comment->children as $child)
-        <div class="md:ml-6">
-            @include('reviews.partials.comment', ['comment' => $child, 'role' => $role, 'parentAuthor' => $comment->user->name])
+        @php
+            $nextDepth = $depth + 1;
+            $mobileIndent = match (true) {
+                $nextDepth === 1 => 'ml-4',
+                $nextDepth === 2 => 'ml-8',
+                $nextDepth === 3 => 'ml-12',
+                default => '',
+            };
+        @endphp
+        <div class="{{ $mobileIndent }} md:ml-6">
+            @include('reviews.partials.comment', [
+                'comment' => $child,
+                'role' => $role,
+                'parentAuthor' => $comment->user->name,
+                'depth' => $nextDepth,
+            ])
         </div>
     @endforeach
 

--- a/resources/views/reviews/show.blade.php
+++ b/resources/views/reviews/show.blade.php
@@ -34,7 +34,7 @@
                     @endif
                     <div class="mt-6">
                         @foreach($review->comments->whereNull('parent_id') as $comment)
-                            @include('reviews.partials.comment', ['comment' => $comment, 'role' => $role])
+                            @include('reviews.partials.comment', ['comment' => $comment, 'role' => $role, 'depth' => 0])
                         @endforeach
 
                         <form method="POST" action="{{ route('reviews.comments.store', $review) }}" class="mt-4">


### PR DESCRIPTION
## Summary
- Limit mobile indentation for nested review comments to three levels
- Pass depth information into comment partial for recursion

## Testing
- `vendor/bin/pint resources/views/reviews/partials/comment.blade.php resources/views/reviews/show.blade.php`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68917ce612ac832e853bf338dcb8951b