### PR TITLE
Enlarge PayPal donate button

### DIFF
--- a/resources/views/pages/spenden.blade.php
+++ b/resources/views/pages/spenden.blade.php
@@ -7,7 +7,7 @@
             <input type="hidden" name="business" value="kassenwart@maddrax-fanclub.de" />
             <input type="hidden" name="no_recurring" value="0" />
             <input type="hidden" name="currency_code" value="EUR" />
-            <input type="image" src="https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donateCC_LG.gif" name="submit" alt="Spenden mit PayPal" />
+            <input type="image" src="https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donateCC_LG.gif" name="submit" alt="Spenden mit PayPal" class="w-48" />
             <img alt="" src="https://www.paypal.com/en_DE/i/scr/pixel.gif" width="1" height="1" />
         </form>
     </x-public-page>


### PR DESCRIPTION
This pull request makes a minor update to the PayPal donation button on the `spenden.blade.php` page by adding a CSS class to control its width.

- Style update:
  * Added the `w-48` CSS class to the PayPal donation button image to standardize its width.