### PR TITLE
Add structured data for organization and website

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -65,13 +65,45 @@ class PageController extends Controller
             $memberCount = 0;
         }
 
+        $organizationUrl = config('app.url') ?? url('/');
+        $logoUrl = asset('images/omxfc-logo.png');
+        $sameAs = [
+            'https://www.facebook.com/mxikon',
+            'https://www.instagram.com/offizieller_maddrax_fanclub/',
+            'https://www.youtube.com/@mxikon',
+        ];
+
+        $structuredData = [
+            '@context' => 'https://schema.org',
+            '@graph' => [
+                [
+                    '@type' => 'Organization',
+                    'name' => config('app.name', 'Offizieller MADDRAX Fanclub e. V.'),
+                    'url' => $organizationUrl,
+                    'logo' => $logoUrl,
+                    'sameAs' => $sameAs,
+                ],
+                [
+                    '@type' => 'WebSite',
+                    'name' => config('app.name', 'Offizieller MADDRAX Fanclub e. V.'),
+                    'url' => $organizationUrl,
+                    'potentialAction' => [
+                        '@type' => 'SearchAction',
+                        'target' => route('kompendium.search') . '?q={search_term_string}',
+                        'query-input' => 'required name=search_term_string',
+                    ],
+                ],
+            ],
+        ];
+
         return view('pages.home', compact(
             'whoWeAre',
             'whatWeDo',
             'currentProjects',
             'membershipBenefits',
             'galleryImages',
-            'memberCount'
+            'memberCount',
+            'structuredData'
         ));
     }
 

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -67,4 +67,8 @@
             }, 4000);
         });
     </script>
+
+    <script type="application/ld+json">
+        {!! json_encode($structuredData, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) !!}
+    </script>
 </x-app-layout>


### PR DESCRIPTION
This pull request introduces structured data (JSON-LD) for SEO and social media integration on the home page. The main changes include generating organization and website schema data in the controller and injecting it into the home page view.

**Structured data integration:**

* Added generation of structured data for the organization and website (including social media links and search action) in the `home` method of `PageController.php`, and passed it to the view as `structuredData`.
* Injected the structured data as a JSON-LD `<script>` tag into the `home.blade.php` view for improved SEO and discoverability.