### PR TITLE
feat: add organization schema to impressum

### DIFF
--- a/resources/views/pages/impressum.blade.php
+++ b/resources/views/pages/impressum.blade.php
@@ -39,4 +39,35 @@
                 Registernummer: 9677</p>
         </section>
     </x-public-page>
+
+    <script type="application/ld+json">
+        {
+            "@@context": "https://schema.org",
+            "@@type": "Organization",
+            "name": "Offizieller MADDRAX Fanclub e. V.",
+            "legalName": "Offizieller MADDRAX Fanclub e. V.",
+            "foundingDate": "2023-05-20",
+            "url": "https://www.maddrax-fanclub.de",
+            "address": {
+                "@@type": "PostalAddress",
+                "streetAddress": "Guido-Seeber-Weg 12",
+                "postalCode": "14480",
+                "addressLocality": "Potsdam",
+                "addressCountry": "DE"
+            },
+            "contactPoint": [
+                {
+                    "@@type": "ContactPoint",
+                    "telephone": "+49 179 4218330",
+                    "email": "info@maddrax-fanclub.de",
+                    "contactType": "customer service"
+                }
+            ],
+            "sameAs": [
+                "https://www.facebook.com/mxikon",
+                "https://www.instagram.com/offizieller_maddrax_fanclub/",
+                "https://www.youtube.com/@mxikon"
+            ]
+        }
+    </script>
 </x-app-layout>


### PR DESCRIPTION
## Summary
- embed Organization JSON-LD with contact and social profile metadata on the Impressum page

## Testing
- `npx structured-data-testing-tool --file /tmp/impressum-ld.json`
- `php artisan test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892f549bec0832e9d48b988a1d9df4b