### PR TITLE
Add social meta tags to layout templates

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -6,6 +6,14 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ $title ?? config('app.name', 'OMXFC e. V.') }}</title>
     <meta name="description" content="{{ $description ?? 'Der Offizielle MADDRAX Fanclub e. V. vernetzt Fans der postapokalyptischen Romanserie und informiert über Projekte, Termine und Mitgliedschaft.' }}">
+    <meta property="og:title" content="{{ $title ?? config('app.name', 'OMXFC e. V.') }}">
+    <meta property="og:description" content="{{ $description ?? 'Der Offizielle MADDRAX Fanclub e. V. vernetzt Fans der postapokalyptischen Romanserie und informiert über Projekte, Termine und Mitgliedschaft.' }}">
+    <meta property="og:image" content="{{ $image ?? Vite::asset('resources/images/omxfc-logo.png') }}">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ $title ?? config('app.name', 'OMXFC e. V.') }}">
+    <meta name="twitter:description" content="{{ $description ?? 'Der Offizielle MADDRAX Fanclub e. V. vernetzt Fans der postapokalyptischen Romanserie und informiert über Projekte, Termine und Mitgliedschaft.' }}">
+    <meta name="twitter:image" content="{{ $image ?? Vite::asset('resources/images/omxfc-logo.png') }}">
     <!-- Favicon -->
     <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicon/apple-touch-icon.png') }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicon/favicon-32x32.png') }}">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -7,6 +7,14 @@
 
         <title>{{ $title ?? config('app.name', 'Laravel') }}</title>
         <meta name="description" content="{{ $description ?? 'Offizieller MADDRAX Fanclub e. V. – Informationen zu Projekten, Terminen und Mitgliedschaft.' }}">
+        <meta property="og:title" content="{{ $title ?? config('app.name', 'Laravel') }}">
+        <meta property="og:description" content="{{ $description ?? 'Offizieller MADDRAX Fanclub e. V. – Informationen zu Projekten, Terminen und Mitgliedschaft.' }}">
+        <meta property="og:image" content="{{ $image ?? Vite::asset('resources/images/omxfc-logo.png') }}">
+        <meta property="og:type" content="website">
+        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:title" content="{{ $title ?? config('app.name', 'Laravel') }}">
+        <meta name="twitter:description" content="{{ $description ?? 'Offizieller MADDRAX Fanclub e. V. – Informationen zu Projekten, Terminen und Mitgliedschaft.' }}">
+        <meta name="twitter:image" content="{{ $image ?? Vite::asset('resources/images/omxfc-logo.png') }}">
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter meta tags to authenticated app layout
- add Open Graph and Twitter meta tags to guest layout

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68968b6fdfb4832eb88818da2eaafa39