### PR TITLE
Add canonical links to layout templates

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,7 +14,7 @@
     <meta name="twitter:title" content="{{ $title ?? config('app.name', 'OMXFC e. V.') }}">
     <meta name="twitter:description" content="{{ $description ?? 'Der Offizielle MADDRAX Fanclub e. V. vernetzt Fans der postapokalyptischen Romanserie und informiert über Projekte, Termine und Mitgliedschaft.' }}">
     <meta name="twitter:image" content="{{ $socialImage }}">
-    <link rel="canonical" href="{{ url()->current() }}" />
+    <link rel="canonical" href="{{ request()->url() }}" />
     <!-- Favicon -->
     <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicon/apple-touch-icon.png') }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicon/favicon-32x32.png') }}">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,6 +14,7 @@
     <meta name="twitter:title" content="{{ $title ?? config('app.name', 'OMXFC e. V.') }}">
     <meta name="twitter:description" content="{{ $description ?? 'Der Offizielle MADDRAX Fanclub e. V. vernetzt Fans der postapokalyptischen Romanserie und informiert über Projekte, Termine und Mitgliedschaft.' }}">
     <meta name="twitter:image" content="{{ $socialImage }}">
+    <link rel="canonical" href="{{ url()->current() }}" />
     <!-- Favicon -->
     <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('favicon/apple-touch-icon.png') }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('favicon/favicon-32x32.png') }}">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -15,6 +15,7 @@
         <meta name="twitter:title" content="{{ $title ?? config('app.name', 'Laravel') }}">
         <meta name="twitter:description" content="{{ $description ?? 'Offizieller MADDRAX Fanclub e. V. – Informationen zu Projekten, Terminen und Mitgliedschaft.' }}">
         <meta name="twitter:image" content="{{ $socialImage }}">
+        <link rel="canonical" href="{{ url()->current() }}" />
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -15,7 +15,7 @@
         <meta name="twitter:title" content="{{ $title ?? config('app.name', 'Laravel') }}">
         <meta name="twitter:description" content="{{ $description ?? 'Offizieller MADDRAX Fanclub e. V. – Informationen zu Projekten, Terminen und Mitgliedschaft.' }}">
         <meta name="twitter:image" content="{{ $socialImage }}">
-        <link rel="canonical" href="{{ url()->current() }}" />
+        <link rel="canonical" href="{{ request()->url() }}" />
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">


### PR DESCRIPTION
This pull request introduces a small but important SEO enhancement by adding canonical link tags to the main layout files. This helps search engines correctly identify the preferred URL for each page, which can improve search ranking and prevent duplicate content issues.

* SEO improvement:
  * Added a `<link rel="canonical">` tag referencing the current request URL to the `app.blade.php` and `guest.blade.php` layout files, ensuring each page specifies its canonical URL for search engines. [[1]](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7R17) [[2]](diffhunk://#diff-05ed95a005677b19cdca1e1e1371e90fca89f16d7284070225931eee6ddc2f41R18)