### PR TITLE
Fix Livewire script path causing JS syntax error

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -33,9 +33,9 @@
 
 <body class="font-sans antialiased">
     <!-- Livewire Scripts -->
-    <script src="/livewire/livewire.min.js" 
-        data-csrf="{{ csrf_token() }}" 
-        data-update-uri="/livewire/update" 
+    <script src="{{ asset('vendor/livewire/livewire.min.js') }}"
+        data-csrf="{{ csrf_token() }}"
+        data-update-uri="/livewire/update"
         data-navigate-once="true">
     </script>
 


### PR DESCRIPTION
This pull request updates how the Livewire JavaScript asset is referenced in the application layout. Instead of using a hardcoded path, it now uses Laravel's asset helper function to ensure the correct path is generated, which improves compatibility across environments.

Asset reference improvement:

* Changed the script source for Livewire in `resources/views/layouts/app.blade.php` to use the `asset` helper, ensuring proper URL generation for the Livewire JavaScript file.