### PR TITLE
Add weekday activity chart to admin dashboard

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -19,6 +19,42 @@ class AdminController extends Controller
             ->groupBy('path', 'user_id')
             ->get();
 
-        return view('admin.index', compact('visitData', 'userVisitData'));
+        $driver = DB::getDriverName();
+        if ($driver === 'sqlite') {
+            $activityRaw = PageVisit::selectRaw('strftime("%w", created_at) as weekday, strftime("%H", created_at) as hour, COUNT(DISTINCT user_id) as total')
+                ->groupBy('weekday', 'hour')
+                ->orderBy('weekday')
+                ->orderBy('hour')
+                ->get();
+        } else {
+            $activityRaw = PageVisit::selectRaw('WEEKDAY(created_at) as weekday, HOUR(created_at) as hour, COUNT(DISTINCT user_id) as total')
+                ->groupBy('weekday', 'hour')
+                ->orderBy('weekday')
+                ->orderBy('hour')
+                ->get();
+        }
+
+        $activityData = [];
+        for ($day = 0; $day < 7; $day++) {
+            for ($hour = 0; $hour < 24; $hour++) {
+                $activityData[$day][$hour] = 0;
+            }
+        }
+
+        foreach ($activityRaw as $row) {
+            $weekday = $driver === 'sqlite' ? ((int) $row->weekday + 6) % 7 : (int) $row->weekday;
+            $hour = (int) $row->hour;
+            $activityData[$weekday][$hour] = (int) $row->total;
+        }
+
+        for ($hour = 0; $hour < 24; $hour++) {
+            $sum = 0;
+            for ($day = 0; $day < 7; $day++) {
+                $sum += $activityData[$day][$hour];
+            }
+            $activityData['all'][$hour] = $sum / 7;
+        }
+
+        return view('admin.index', compact('visitData', 'userVisitData', 'activityData'));
     }
 }

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -9,6 +9,11 @@
             <select id="userSelect" class="mb-4 border-gray-300 dark:bg-gray-700 dark:border-gray-600 rounded-md"></select>
             <canvas id="userVisitsChart"></canvas>
         </div>
+        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6 mt-8">
+            <h3 class="font-semibold text-lg mb-4">Aktive Mitglieder nach Uhrzeit</h3>
+            <select id="weekdaySelect" class="mb-4 border-gray-300 dark:bg-gray-700 dark:border-gray-600 rounded-md"></select>
+            <canvas id="activeUsersChart"></canvas>
+        </div>
     </x-member-page>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -82,5 +87,50 @@
         updateUserChart(users[0]);
 
         userSelect.addEventListener('change', (e) => updateUserChart(e.target.value));
+
+        const activityData = @json($activityData);
+        const weekdaySelect = document.getElementById('weekdaySelect');
+        const dayNames = ['Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag', 'Sonntag'];
+        dayNames.forEach((day, index) => {
+            const option = document.createElement('option');
+            option.value = index;
+            option.textContent = day;
+            weekdaySelect.appendChild(option);
+        });
+        const allOption = document.createElement('option');
+        allOption.value = 'all';
+        allOption.textContent = 'Alle';
+        weekdaySelect.appendChild(allOption);
+
+        const hours = Array.from({ length: 24 }, (_, i) => String(i).padStart(2, '0') + ':00');
+        const ctx3 = document.getElementById('activeUsersChart').getContext('2d');
+        const activeChart = new Chart(ctx3, {
+            type: 'line',
+            data: {
+                labels: hours,
+                datasets: [{
+                    label: dayNames[0],
+                    data: activityData[0],
+                    borderColor: 'rgba(54, 162, 235, 1)',
+                    backgroundColor: 'rgba(54, 162, 235, 0.2)',
+                    fill: false,
+                }],
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    y: { beginAtZero: true },
+                },
+            },
+        });
+
+        function updateActiveChart(selected) {
+            activeChart.data.datasets[0].data = activityData[selected];
+            activeChart.data.datasets[0].label = selected === 'all' ? 'Alle' : dayNames[selected];
+            activeChart.update();
+        }
+
+        updateActiveChart(0);
+        weekdaySelect.addEventListener('change', (e) => updateActiveChart(e.target.value));
     </script>
 </x-app-layout>


### PR DESCRIPTION
This pull request adds a new feature to the admin dashboard that visualizes active user counts by hour and day of the week. It introduces backend logic to aggregate user activity data for both MySQL and SQLite, processes the data for charting, and updates the frontend to display an interactive chart allowing admins to view activity by weekday or as a weekly average.

**Backend data aggregation and processing:**

* Added logic in `AdminController.php` to aggregate distinct user activity by hour and weekday, supporting both MySQL and SQLite by using the appropriate SQL functions. The results are normalized for charting, including calculation of average activity per hour across all days.

**Frontend chart integration:**

* Updated `admin/index.blade.php` to add a new card showing active members by time, including a weekday selector and a new chart canvas for visualizing the data.
* Implemented JavaScript logic to initialize the chart with hourly activity data, populate the weekday selector, and allow dynamic switching between weekdays and the weekly average. The chart updates interactively based on user selection.