### PR TITLE
Add Vorstand menu for admins

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -63,7 +63,7 @@
                             <button id="vorstand-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="vorstand-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
                                 Vorstand
                             </button>
-                            <div id="vorstand-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
+                            <div id="vorstand-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="vorstand-button">
                                 <x-dropdown-link href="{{ route('admin.index') }}">Admin</x-dropdown-link>
                             </div>
                         </div>
@@ -160,7 +160,7 @@
             @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
             <button id="vorstand-mobile-button" type="button" @click="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'vorstand' }" :aria-expanded="openMenu === 'vorstand'" aria-controls="vorstand-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" @keydown.space.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')">
             Vorstand</button>
-            <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic">
+            <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic" aria-labelledby="vorstand-mobile-button">
                 <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
             </div>
             @endif

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -12,9 +12,6 @@
                 <div class="hidden sm:ml-10 sm:flex sm:space-x-8">
                     @auth
                         <x-nav-link href="{{ route('dashboard') }}">Dashboard</x-nav-link>
-                        @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
-                            <x-nav-link href="{{ route('admin.index') }}">Admin</x-nav-link>
-                        @endif
                         <!-- Dropdown Verein -->
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
                             <button id="verein-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="verein-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
@@ -61,6 +58,16 @@
                                 <x-dropdown-link href="{{ route('statistik.index') }}">Statistik</x-dropdown-link>
                             </div>
                         </div>
+                        @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
+                        <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
+                            <button id="vorstand-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="vorstand-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                                Vorstand
+                            </button>
+                            <div id="vorstand-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
+                                <x-dropdown-link href="{{ route('admin.index') }}">Admin</x-dropdown-link>
+                            </div>
+                        </div>
+                        @endif
                     @endauth
                     @guest
                         <x-nav-link href="{{ route('chronik') }}">Chronik</x-nav-link>
@@ -117,9 +124,6 @@
     <div :class="{'block': open, 'hidden': !open}" class="hidden sm:hidden">
         @auth
             <x-responsive-nav-link href="{{ route('dashboard') }}">Dashboard</x-responsive-nav-link>
-            @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
-                <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
-            @endif
             <button id="verein-mobile-button" type="button" @click="openMenu = (openMenu === 'verein' ? null : 'verein')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'verein' }" :aria-expanded="openMenu === 'verein'" aria-controls="verein-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'verein' ? null : 'verein')" @keydown.space.prevent="openMenu = (openMenu === 'verein' ? null : 'verein')">
             Verein</button>
             <div id="verein-mobile-menu" x-show="openMenu === 'verein'" x-cloak class="italic">
@@ -153,7 +157,14 @@
                 <x-responsive-nav-link href="{{ route('kompendium.index') }}">Kompendium</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('statistik.index') }}">Statistik</x-responsive-nav-link>
             </div>
-    
+            @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
+            <button id="vorstand-mobile-button" type="button" @click="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'vorstand' }" :aria-expanded="openMenu === 'vorstand'" aria-controls="vorstand-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" @keydown.space.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')">
+            Vorstand</button>
+            <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic">
+                <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
+            </div>
+            @endif
+
         @endauth
 
         @guest


### PR DESCRIPTION
This pull request updates the navigation menu to improve how admin links are presented for users with the "Admin" role. Instead of showing the "Admin" link directly, it is now nested under a new "Vorstand" dropdown (or expandable section on mobile), making the navigation cleaner and more organized for admins.

**Navigation improvements for admin users:**

* Replaced the direct "Admin" link in the desktop navigation with a "Vorstand" dropdown that contains the "Admin" link, visible only to users with the "Admin" role in their current team. (`resources/views/navigation-menu.blade.php`) [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL15-L17) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR61-R70)
* Updated the mobile navigation to use a "Vorstand" expandable section containing the "Admin" link, shown only for admin users. (`resources/views/navigation-menu.blade.php`) [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL120-L122) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR160-R166)