### PR TITLE
Add social image view composer tests

### DIFF
--- a/tests/Feature/AppServiceProviderTest.php
+++ b/tests/Feature/AppServiceProviderTest.php
@@ -26,4 +26,32 @@ class AppServiceProviderTest extends TestCase
         $this->assertTrue($user->hasVerifiedEmail());
         $this->assertEquals($timestamp->getTimestamp(), $user->email_verified_at->getTimestamp());
     }
+
+    public function test_social_image_defaults_to_logo_when_no_image_provided(): void
+    {
+        $view = view('layouts.guest', ['slot' => '']);
+        $view->render();
+
+        $socialImage = $view->getData()['socialImage'];
+
+        $this->assertStringContainsString('omxfc-logo', $socialImage);
+        $this->assertStringEndsWith('.png', $socialImage);
+    }
+
+    public function test_social_image_uses_asset_for_relative_path(): void
+    {
+        $view = view('layouts.guest', ['slot' => '', 'image' => 'images/custom.png']);
+        $view->render();
+
+        $this->assertSame(asset('images/custom.png'), $view->getData()['socialImage']);
+    }
+
+    public function test_social_image_uses_provided_absolute_url(): void
+    {
+        $url = 'https://example.com/social.png';
+        $view = view('layouts.guest', ['slot' => '', 'image' => $url]);
+        $view->render();
+
+        $this->assertSame($url, $view->getData()['socialImage']);
+    }
 }


### PR DESCRIPTION
This pull request adds new test cases to ensure the correct behavior of the social image logic in the `layouts.guest` view. The most important changes are the addition of tests that verify the default, relative, and absolute URL handling for the social image.

**Social image logic tests:**

* Added a test to ensure that when no image is provided, the social image defaults to the logo (`omxfc-logo`) and ends with `.png`.
* Added a test to verify that a relative image path uses the `asset` helper to generate the correct URL for the social image.
* Added a test to confirm that an absolute image URL is used directly as the social image without modification.