### PR TITLE
Add coverage for navigation menu links

### DIFF
--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\User;
+use App\Models\Team;
 
 class NavigationMenuTest extends TestCase
 {
@@ -17,5 +18,34 @@ class NavigationMenuTest extends TestCase
         $response = $this->actingAs($user)->get('/');
 
         $response->assertSee(route('termine'));
+    }
+
+    public function test_guests_see_termine_link_in_navigation(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertSee(route('termine'));
+    }
+
+    public function test_admin_users_see_admin_link_in_navigation_menu(): void
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => 'Admin']);
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertSee(route('admin.index'));
+    }
+
+    public function test_non_admin_users_do_not_see_admin_link_in_navigation_menu(): void
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => 'Mitglied']);
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertDontSee(route('admin.index'));
     }
 }


### PR DESCRIPTION
## Summary
- test that guests see Termine link
- ensure admin users see Admin link while members do not

## Testing
- `./vendor/bin/phpunit tests/Feature/NavigationMenuTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68976e3ebd04832e9bddf0ecea2e9906