### PR TITLE
Render review content as Markdown

### DIFF
--- a/resources/views/reviews/show.blade.php
+++ b/resources/views/reviews/show.blade.php
@@ -14,8 +14,8 @@
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200">{{ $review->title }}</h2>
                     <p class="text-sm text-gray-500 dark:text-gray-400">von {{ $review->user->name }} am {{ $review->created_at->format('d.m.Y') }}</p>
-                    <div class="mt-4 text-gray-800 dark:text-gray-200 whitespace-pre-line">
-                        {{ $review->content }}
+                    <div class="mt-4 text-gray-800 dark:text-gray-200">
+                        {!! $review->formatted_content !!}
                     </div>
 
                     @if(in_array($role ?? null, ['Vorstand','Admin'], true) || auth()->id() === $review->user_id)


### PR DESCRIPTION
## Summary
- add `formatted_content` accessor to render and sanitize review Markdown with safe tags and rel attributes
- display formatted review HTML in review show view and remove plaintext styling

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689807ef1014832e91eb2888b086eb05