### PR TITLE
Add additional feature tests for profile and download access

### DIFF
--- a/tests/Feature/DownloadsTest.php
+++ b/tests/Feature/DownloadsTest.php
@@ -100,4 +100,14 @@ class DownloadsTest extends TestCase
         $response->assertRedirect('/downloads');
         $response->assertSessionHasErrors();
     }
+
+    public function test_guest_is_redirected_to_login_when_accessing_downloads_page(): void
+    {
+        $this->get('/downloads')->assertRedirect('/login');
+    }
+
+    public function test_guest_is_redirected_to_login_when_downloading_file(): void
+    {
+        $this->get('/downloads/herunterladen/BauanleitungEuphoriewurmV2.pdf')->assertRedirect('/login');
+    }
 }

--- a/tests/Feature/ProfileEhrenmitgliedSettingTest.php
+++ b/tests/Feature/ProfileEhrenmitgliedSettingTest.php
@@ -19,6 +19,14 @@ class ProfileEhrenmitgliedSettingTest extends TestCase
         return $user;
     }
 
+    private function createMitglied(): User
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => 'Mitglied']);
+        return $user;
+    }
+
     public function test_ehrenmitglied_sees_review_notification_setting(): void
     {
         $user = $this->createEhrenmitglied();
@@ -34,5 +42,16 @@ class ProfileEhrenmitgliedSettingTest extends TestCase
             'role' => 'Ehrenmitglied',
         ]);
         $response->assertSee('E-Mail bei neuer Rezension erhalten');
+    }
+
+    public function test_regular_member_does_not_see_review_notification_setting(): void
+    {
+        $user = $this->createMitglied();
+        $this->actingAs($user);
+
+        $response = $this->get('/user/profile');
+
+        $response->assertOk();
+        $response->assertDontSee('E-Mail bei neuer Rezension erhalten');
     }
 }


### PR DESCRIPTION
This pull request adds new test cases to improve coverage for user authentication and profile settings. The main focus is on ensuring proper access control for downloads and verifying that only specific user roles see certain notification settings.

**Authentication and access control for downloads:**

* Added tests to verify that guests are redirected to the login page when accessing the downloads page or attempting to download a file (`DownloadsTest.php`).

**Profile settings visibility by user role:**

* Added a helper method `createMitglied()` to generate a regular member user for testing (`ProfileEhrenmitgliedSettingTest.php`).
* Added a test to confirm that regular members do not see the "E-Mail bei neuer Rezension erhalten" notification setting on their profile page (`ProfileEhrenmitgliedSettingTest.php`).