### PR TITLE
Disallow headings in reviews

### DIFF
--- a/app/Http/Controllers/RezensionController.php
+++ b/app/Http/Controllers/RezensionController.php
@@ -172,8 +172,10 @@ class RezensionController extends Controller
 
         $data = $request->validate([
             'title' => 'required|string|max:255',
-            'content' => 'required|string|min:140',
+            'content' => 'required|string|min:140|not_regex:/^\\s*#/m',
         ]);
+
+        $data['content'] = preg_replace('/^\\s*#+\\s*/m', '', $data['content']);
 
         $review = Review::create([
             'team_id' => $teamId,
@@ -238,8 +240,10 @@ class RezensionController extends Controller
         if ($review->user_id === $user->id || in_array($role, ['Vorstand', 'Admin'], true)) {
             $data = $request->validate([
                 'title' => 'required|string|max:255',
-                'content' => 'required|string|min:140',
+                'content' => 'required|string|min:140|not_regex:/^\\s*#/m',
             ]);
+
+            $data['content'] = preg_replace('/^\\s*#+\\s*/m', '', $data['content']);
 
             $review->update($data);
 

--- a/app/Http/Controllers/RezensionController.php
+++ b/app/Http/Controllers/RezensionController.php
@@ -170,12 +170,14 @@ class RezensionController extends Controller
             abort(403);
         }
 
-        $data = $request->validate([
-            'title' => 'required|string|max:255',
-            'content' => 'required|string|min:140|not_regex:/^\\s*#/m',
+        $request->merge([
+            'content' => preg_replace('/^\\s*#+\\s*/m', '', (string) $request->input('content')),
         ]);
 
-        $data['content'] = preg_replace('/^\\s*#+\\s*/m', '', $data['content']);
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'content' => 'required|string|min:140',
+        ]);
 
         $review = Review::create([
             'team_id' => $teamId,
@@ -238,12 +240,14 @@ class RezensionController extends Controller
         $role = $this->getRoleInMemberTeam();
 
         if ($review->user_id === $user->id || in_array($role, ['Vorstand', 'Admin'], true)) {
-            $data = $request->validate([
-                'title' => 'required|string|max:255',
-                'content' => 'required|string|min:140|not_regex:/^\\s*#/m',
+            $request->merge([
+                'content' => preg_replace('/^\\s*#+\\s*/m', '', (string) $request->input('content')),
             ]);
 
-            $data['content'] = preg_replace('/^\\s*#+\\s*/m', '', $data['content']);
+            $data = $request->validate([
+                'title' => 'required|string|max:255',
+                'content' => 'required|string|min:140',
+            ]);
 
             $review->update($data);
 


### PR DESCRIPTION
This pull request improves validation and sanitization for review content in the `RezensionController`, specifically preventing the use of Markdown heading markers at the start of lines. It also adds new feature tests to ensure these rules are enforced for both creating and updating reviews.

**Validation and sanitization improvements:**

* Updated the `store` and `update` methods in `RezensionController` to reject review content starting with heading markers (`#`) using the `not_regex` validation rule, and to strip any heading markers from the beginning of lines before saving. [[1]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L175-R179) [[2]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L241-R247)

**Test coverage enhancements:**

* Added `test_store_rejects_heading_markers_in_content` to verify that review creation fails if the content contains heading markers at the start of lines.
* Added `test_update_rejects_heading_markers_in_content` to verify that review updates are also rejected if the content contains heading markers at the start of lines.