### PR TITLE
Sort last online column descending by default

### DIFF
--- a/app/Http/Controllers/MitgliederController.php
+++ b/app/Http/Controllers/MitgliederController.php
@@ -17,8 +17,6 @@ class MitgliederController extends Controller
 
         // Sortierparameter auslesen
         $sortBy = $request->input('sort', 'nachname'); // Standardsortierung: Nachname
-        // Standardrichtung: aufsteigend, außer bei letzter Aktivität
-        $sortDir = $request->input('dir', $sortBy === 'last_activity' ? 'desc' : 'asc');
 
         // Nur erlaubte Sortierfelder akzeptieren
         $allowedSortFields = ['nachname', 'role', 'mitgliedsbeitrag', 'mitglied_seit', 'last_activity'];
@@ -26,9 +24,13 @@ class MitgliederController extends Controller
             $sortBy = 'nachname';
         }
 
+        // Standardrichtung nach Validierung bestimmen
+        $defaultSortDir = $sortBy === 'last_activity' ? 'desc' : 'asc';
+        $sortDir = $request->input('dir', $defaultSortDir);
+
         // Sortierrichtung validieren
         if (!in_array($sortDir, ['asc', 'desc'])) {
-            $sortDir = 'asc';
+            $sortDir = $defaultSortDir;
         }
 
         // Nur Nutzer mit Rollen außer "Anwärter" anzeigen

--- a/app/Http/Controllers/MitgliederController.php
+++ b/app/Http/Controllers/MitgliederController.php
@@ -17,7 +17,8 @@ class MitgliederController extends Controller
 
         // Sortierparameter auslesen
         $sortBy = $request->input('sort', 'nachname'); // Standardsortierung: Nachname
-        $sortDir = $request->input('dir', 'asc'); // Standardrichtung: aufsteigend
+        // Standardrichtung: aufsteigend, außer bei letzter Aktivität
+        $sortDir = $request->input('dir', $sortBy === 'last_activity' ? 'desc' : 'asc');
 
         // Nur erlaubte Sortierfelder akzeptieren
         $allowedSortFields = ['nachname', 'role', 'mitgliedsbeitrag', 'mitglied_seit', 'last_activity'];

--- a/resources/views/mitglieder/index.blade.php
+++ b/resources/views/mitglieder/index.blade.php
@@ -182,7 +182,7 @@
     
     @if($canViewDetails)
     <th class="px-4 py-2 text-left">
-    <a href="{{ route('mitglieder.index', array_merge(request()->query(), ['sort' => 'last_activity', 'dir' => ($sortBy === 'last_activity' && $sortDir === 'asc') ? 'desc' : 'asc'])) }}"
+    <a href="{{ route('mitglieder.index', array_merge(request()->query(), ['sort' => 'last_activity', 'dir' => ($sortBy === 'last_activity' && $sortDir === 'desc') ? 'asc' : 'desc'])) }}"
     class="flex items-center group text-gray-700 dark:text-gray-300 hover:text-[#8B0116] dark:hover:text-red-400">
     Zuletzt online
     @if($sortBy === 'last_activity')
@@ -386,7 +386,7 @@
     Rolle {{ $sortBy === 'role' ? ($sortDir === 'asc' ? '↑' : '↓') : '' }}
     </a>
     @if($canViewDetails)
-    <a href="{{ route('mitglieder.index', array_merge(request()->query(), ['sort' => 'last_activity', 'dir' => ($sortBy === 'last_activity' && $sortDir === 'asc') ? 'desc' : 'asc'])) }}"
+    <a href="{{ route('mitglieder.index', array_merge(request()->query(), ['sort' => 'last_activity', 'dir' => ($sortBy === 'last_activity' && $sortDir === 'desc') ? 'asc' : 'desc'])) }}"
     class="px-3 py-1 text-xs rounded-full {{ $sortBy === 'last_activity' ? 'bg-[#8B0116] text-white' : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300' }}">
     Zuletzt online {{ $sortBy === 'last_activity' ? ($sortDir === 'asc' ? '↑' : '↓') : '' }}
     </a>

--- a/tests/Feature/MitgliederControllerTest.php
+++ b/tests/Feature/MitgliederControllerTest.php
@@ -270,18 +270,19 @@ class MitgliederControllerTest extends TestCase
         ]);
         $this->actingAs($acting);
 
-        $response = $this->get('/mitglieder?sort=foo&dir=desc');
+        $response = $this->get('/mitglieder?sort=foo');
         $response->assertOk();
         $this->assertSame('nachname', $response->viewData('sortBy'));
+        $this->assertSame('asc', $response->viewData('sortDir'));
 
         $members = $response->viewData('members');
         $names = $members->pluck('name')->all();
 
         $this->assertSame([
-            'Bob Second',
-            'Alice First',
-            'Holger Ehrmann',
             'Charlie Current',
+            'Holger Ehrmann',
+            'Alice First',
+            'Bob Second',
         ], $names);
     }
 

--- a/tests/Feature/MitgliederControllerTest.php
+++ b/tests/Feature/MitgliederControllerTest.php
@@ -230,7 +230,7 @@ class MitgliederControllerTest extends TestCase
 
         $this->actingAs($this->actingMember('Mitglied'));
 
-        $response = $this->get('/mitglieder?sort=last_activity&dir=desc');
+        $response = $this->get('/mitglieder?sort=last_activity');
         $response->assertOk();
 
         $members = $response->viewData('members');


### PR DESCRIPTION
This pull request improves the sorting logic for the members list, especially for the "Zuletzt online" (`last_activity`) column. The main change is that sorting by "Zuletzt online" now defaults to descending order, so the most recently active members appear first. The sorting direction toggling in the UI has also been fixed for consistency, and related tests have been updated to reflect the new defaults and behaviors.

**Sorting logic improvements:**

* Updated the backend in `MitgliederController.php` so that sorting by `last_activity` defaults to descending order, while other fields default to ascending. The fallback for invalid sort directions now matches the default for the selected field.

**UI consistency fixes:**

* Fixed the sort direction toggle for "Zuletzt online" links in `index.blade.php` so that the arrow and direction switch correctly between ascending and descending. [[1]](diffhunk://#diff-b66ed4d712d9f70d89687b73abd82ab56302891704f63a17b20b53540cf23a39L185-R185) [[2]](diffhunk://#diff-b66ed4d712d9f70d89687b73abd82ab56302891704f63a17b20b53540cf23a39L389-R389)

**Test updates:**

* Updated feature tests in `MitgliederControllerTest.php` so that sorting by `last_activity` without specifying direction defaults to descending, and invalid sort fields default to sorting by `nachname` in ascending order. [[1]](diffhunk://#diff-184829af18e38beeddf5af13eeebd4cb6e5348777b7115f62b8281e91c8518faL233-R233) [[2]](diffhunk://#diff-184829af18e38beeddf5af13eeebd4cb6e5348777b7115f62b8281e91c8518faL273-R285)