### PR TITLE
Link members to profile pages

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -65,7 +65,7 @@
                     @forelse($activities as $activity)
                         <li class="py-2 flex justify-between">
                             <span class="text-sm text-gray-600 dark:text-gray-400">
-                                {{ $activity->created_at->format('d.m.Y H:i') }} - {{ $activity->user->name }}
+                                {{ $activity->created_at->format('d.m.Y H:i') }} - <a href="{{ route('profile.view', $activity->user->id) }}" class="text-[#8B0116] hover:underline">{{ $activity->user->name }}</a>
                             </span>
                             @if($activity->subject_type === \App\Models\Review::class)
                                 <a href="{{ route('reviews.show', $activity->subject->book_id) }}" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
@@ -81,7 +81,7 @@
                                 </a>
                             @elseif($activity->subject_type === \App\Models\ReviewComment::class)
                                 <a href="{{ route('reviews.show', $activity->subject->review->book_id) }}" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
-                                    Kommentar zu {{ $activity->subject->review->title }} von {{ $activity->user->name }}
+                                    Kommentar zu {{ $activity->subject->review->title }} von <a href="{{ route('profile.view', $activity->user->id) }}" class="text-[#8B0116] hover:underline">{{ $activity->user->name }}</a>
                                 </a>
                             @elseif($activity->subject_type === \App\Models\Todo::class && $activity->action === 'accepted')
                                 <span class="text-sm">hat die Challenge {{ $activity->subject->title }} angenommen</span>
@@ -171,7 +171,7 @@
                             <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
                                 @foreach($anwaerter as $person)
                                     <tr>
-                                        <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ $person->name }}</td>
+                                        <td class="px-4 py-2 text-gray-800 dark:text-gray-200"><a href="{{ route('profile.view', $person->id) }}" class="text-[#8B0116] hover:underline">{{ $person->name }}</a></td>
                                         <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ $person->email }}</td>
                                         <td class="px-4 py-2 text-gray-800 dark:text-gray-200">
                                             {{ $person->mitgliedsbeitrag }}</td>
@@ -203,7 +203,7 @@
                             <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg shadow">
                                 <div class="mb-2">
                                     <span class="font-semibold text-gray-700 dark:text-gray-300">Name:</span>
-                                    <span class="block mt-1 text-gray-800 dark:text-gray-200">{{ $person->name }}</span>
+                                    <span class="block mt-1 text-gray-800 dark:text-gray-200"><a href="{{ route('profile.view', $person->id) }}" class="text-[#8B0116] hover:underline">{{ $person->name }}</a></span>
                                 </div>
                                 <div class="mb-2">
                                     <span class="font-semibold text-gray-700 dark:text-gray-300">E-Mail:</span>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -80,9 +80,9 @@
                                     Neues Gesuch: {{ $activity->subject->book_title }}
                                 </a>
                             @elseif($activity->subject_type === \App\Models\ReviewComment::class)
-                                <a href="{{ route('reviews.show', $activity->subject->review->book_id) }}" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
-                                    Kommentar zu {{ $activity->subject->review->title }} von <a href="{{ route('profile.view', $activity->user->id) }}" class="text-[#8B0116] hover:underline">{{ $activity->user->name }}</a>
-                                </a>
+                                <span class="text-sm">
+                                    Kommentar zu <a href="{{ route('reviews.show', $activity->subject->review->book_id) }}" class="text-blue-600 dark:text-blue-400 hover:underline">{{ $activity->subject->review->title }}</a> von <a href="{{ route('profile.view', $activity->user->id) }}" class="text-[#8B0116] hover:underline">{{ $activity->user->name }}</a>
+                                </span>
                             @elseif($activity->subject_type === \App\Models\Todo::class && $activity->action === 'accepted')
                                 <span class="text-sm">hat die Challenge {{ $activity->subject->title }} angenommen</span>
                             @elseif($activity->subject_type === \App\Models\Todo::class && $activity->action === 'completed')

--- a/resources/views/kassenbuch/index.blade.php
+++ b/resources/views/kassenbuch/index.blade.php
@@ -209,7 +209,7 @@
                                             @endif
                                         </td>
                                         <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
-                                            {{ $entry->creator->name }}
+                                            <a href="{{ route('profile.view', $entry->creator->id) }}" class="text-[#8B0116] hover:underline">{{ $entry->creator->name }}</a>
                                         </td>
                                     </tr>
                                     @endforeach

--- a/resources/views/kassenbuch/index.blade.php
+++ b/resources/views/kassenbuch/index.blade.php
@@ -98,7 +98,7 @@
                                 @foreach($members as $member)
                                 <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
                                     <td class="px-4 py-3 whitespace-nowrap">
-                                        <div class="flex items-center">
+                                        <a href="{{ route('profile.view', $member->id) }}" class="flex items-center">
                                             <div class="h-8 w-8 flex-shrink-0">
                                                 <img class="h-8 w-8 rounded-full" src="{{ $member->profile_photo_url }}" alt="{{ $member->name }}">
                                             </div>
@@ -106,7 +106,7 @@
                                                 <div class="text-sm font-medium text-gray-900 dark:text-white">{{ $member->name }}</div>
                                                 <div class="text-xs text-gray-500 dark:text-gray-400">{{ $member->vorname }} {{ $member->nachname }}</div>
                                             </div>
-                                        </div>
+                                        </a>
                                     </td>
                                     <td class="px-4 py-3 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                                         {{ $member->email }}

--- a/resources/views/mitglieder/index.blade.php
+++ b/resources/views/mitglieder/index.blade.php
@@ -231,7 +231,7 @@
     @foreach($members as $member)
     <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
     <td class="px-4 py-3">
-    <div class="flex items-center">
+    <a href="{{ route('profile.view', $member->id) }}" class="flex items-center">
     <div class="h-10 w-10 flex-shrink-0">
     <img class="h-10 w-10 rounded-full" src="{{ $member->profile_photo_url }}" alt="{{ $member->name }}">
     </div>
@@ -244,7 +244,7 @@
     <div class="text-sm text-gray-500 dark:text-gray-400">{{ $member->vorname }} {{ $member->nachname }}</div>
     @endif
     </div>
-    </div>
+    </a>
     </td>
     
     <td class="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
@@ -400,7 +400,7 @@
     
     @foreach($members as $member)
     <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg shadow">
-    <div class="flex items-center mb-4">
+    <a href="{{ route('profile.view', $member->id) }}" class="flex items-center mb-4">
     <div class="h-12 w-12 flex-shrink-0">
     <img class="h-12 w-12 rounded-full" src="{{ $member->profile_photo_url }}" alt="{{ $member->name }}">
     </div>
@@ -414,7 +414,7 @@
     Mitglied seit {{ $member->mitglied_seit ? $member->mitglied_seit->format('d.m.Y') : 'k.A.' }}
     </div>
     </div>
-    </div>
+    </a>
     
     <div class="mb-4">
     <div class="grid grid-cols-2 gap-4">

--- a/resources/views/reviews/partials/comment.blade.php
+++ b/resources/views/reviews/partials/comment.blade.php
@@ -3,7 +3,7 @@
 @endphp
 <div class="mt-4 bg-gray-50 dark:bg-gray-700 p-4 rounded">
     <p class="text-sm text-gray-500 dark:text-gray-300">
-        {{ $comment->user->name }} am {{ $comment->created_at->format('d.m.Y H:i') }}
+        <a href="{{ route('profile.view', $comment->user->id) }}" class="text-[#8B0116] hover:underline">{{ $comment->user->name }}</a> am {{ $comment->created_at->format('d.m.Y H:i') }}
     </p>
     @isset($parentAuthor)
         <p class="text-xs text-gray-500 dark:text-gray-400 md:hidden">

--- a/resources/views/reviews/show.blade.php
+++ b/resources/views/reviews/show.blade.php
@@ -13,7 +13,7 @@
             @forelse($reviews as $review)
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-lg font-semibold text-gray-800 dark:text-gray-200">{{ $review->title }}</h2>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">von {{ $review->user->name }} am {{ $review->created_at->format('d.m.Y') }}</p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">von <a href="{{ route('profile.view', $review->user->id) }}" class="text-[#8B0116] hover:underline">{{ $review->user->name }}</a> am {{ $review->created_at->format('d.m.Y') }}</p>
                     <div class="mt-4 text-gray-800 dark:text-gray-200">
                         {!! $review->formatted_content !!}
                     </div>

--- a/resources/views/romantausch/index.blade.php
+++ b/resources/views/romantausch/index.blade.php
@@ -33,7 +33,7 @@
                             <li class="bg-gray-100 dark:bg-gray-700 p-3 rounded">
                                 <div class="font-semibold mb-1">{{ $swap->offer->book_number }} - {{ $swap->offer->book_title }}</div>
                                 <div class="text-sm text-gray-600 dark:text-gray-300 mb-2">
-                                    {{ $swap->offer->user->name }} ({{ $swap->offer->user->email }}) ↔ {{ $swap->request->user->name }} ({{ $swap->request->user->email }})
+                                    <a href="{{ route('profile.view', $swap->offer->user->id) }}" class="text-[#8B0116] hover:underline">{{ $swap->offer->user->name }}</a> ({{ $swap->offer->user->email }}) ↔ <a href="{{ route('profile.view', $swap->request->user->id) }}" class="text-[#8B0116] hover:underline">{{ $swap->request->user->name }}</a> ({{ $swap->request->user->email }})
                                 </div>
                                 @php $user = auth()->user(); @endphp
                                 @if(($user->is($swap->offer->user) && !$swap->offer_confirmed) || ($user->is($swap->request->user) && !$swap->request_confirmed))
@@ -59,7 +59,7 @@
                         @foreach($offers as $offer)
                             <li class="bg-gray-100 dark:bg-gray-700 p-3 rounded flex justify-between items-center">
                                 <span>{{ $offer->book_number }} - {{ $offer->book_title }} ({{ $offer->condition }})</span>
-                                <span class="text-sm text-gray-600 dark:text-gray-300">von {{ $offer->user->name }}</span>
+                                <span class="text-sm text-gray-600 dark:text-gray-300">von <a href="{{ route('profile.view', $offer->user->id) }}" class="text-[#8B0116] hover:underline">{{ $offer->user->name }}</a></span>
                             </li>
                         @endforeach
                     </ul>
@@ -75,7 +75,7 @@
                         @foreach($requests as $request)
                             <li class="bg-gray-100 dark:bg-gray-700 p-3 rounded flex justify-between items-center">
                                 <span>{{ $request->book_number }} - {{ $request->book_title }} ({{ $request->condition }} oder besser)</span>
-                                <span class="text-sm text-gray-600 dark:text-gray-300">von {{ $request->user->name }}</span>
+                                <span class="text-sm text-gray-600 dark:text-gray-300">von <a href="{{ route('profile.view', $request->user->id) }}" class="text-[#8B0116] hover:underline">{{ $request->user->name }}</a></span>
                             </li>
                         @endforeach
                     </ul>
@@ -91,7 +91,7 @@
                         @foreach($completedSwaps as $swap)
                             <li class="bg-gray-100 dark:bg-gray-700 p-3 rounded">
                                 <span class="font-semibold">{{ $swap->offer->book_number }} - {{ $swap->offer->book_title }}</span><br>
-                                Getauscht zwischen {{ $swap->offer->user->name }} und {{ $swap->request->user->name }} am {{ $swap->completed_at->format('d.m.Y') }}
+                                Getauscht zwischen <a href="{{ route('profile.view', $swap->offer->user->id) }}" class="text-[#8B0116] hover:underline">{{ $swap->offer->user->name }}</a> und <a href="{{ route('profile.view', $swap->request->user->id) }}" class="text-[#8B0116] hover:underline">{{ $swap->request->user->name }}</a> am {{ $swap->completed_at->format('d.m.Y') }}
                             </li>
                         @endforeach
                     </ul>

--- a/resources/views/teams/team-member-manager.blade.php
+++ b/resources/views/teams/team-member-manager.blade.php
@@ -132,10 +132,10 @@
                     <div class="space-y-6">
                         @foreach ($team->users->sortBy('name') as $user)
                             <div class="flex items-center justify-between">
-                                <div class="flex items-center">
-                                    <img class="size-8 rounded-full object-cover" src="{{ $user->profile_photo_url }}" alt="{{ $user->name }}">
-                                    <div class="ms-4 dark:text-white">{{ $user->name }}</div>
-                                </div>
+                            <a href="{{ route('profile.view', $user->id) }}" class="flex items-center">
+                                <img class="size-8 rounded-full object-cover" src="{{ $user->profile_photo_url }}" alt="{{ $user->name }}">
+                                <div class="ms-4 dark:text-white">{{ $user->name }}</div>
+                            </a>
 
                                 <div class="flex items-center">
                                     <!-- Manage Team Member Role -->

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -172,7 +172,7 @@
                                     <tr>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->title }}</td>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->category ? $todo->category->name : '-' }}</td>
-                                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->creator->name }}</td>
+                                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300"><a href="{{ route('profile.view', $todo->creator->id) }}" class="text-[#8B0116] hover:underline">{{ $todo->creator->name }}</a></td>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->points }}</td>
                                         <td class="px-4 py-2 text-center">
                                             <a href="{{ route('todos.show', $todo) }}"
@@ -208,7 +208,7 @@
                                 </div>
                                 <div class="mb-2">
                                     <span class="text-sm text-gray-600 dark:text-gray-400">Erstellt von:</span>
-                                    <div class="mt-1 text-gray-800 dark:text-gray-200">{{ $todo->creator->name }}</div>
+                                    <div class="mt-1 text-gray-800 dark:text-gray-200"><a href="{{ route('profile.view', $todo->creator->id) }}" class="text-[#8B0116] hover:underline">{{ $todo->creator->name }}</a></div>
                                 </div>
                                 <div class="mb-3">
                                     <span class="text-sm text-gray-600 dark:text-gray-400">Baxx:</span>
@@ -256,7 +256,7 @@
                                 @foreach($completedTodos->where('status', 'completed') as $todo)
                                     <tr>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->title }}</td>
-                                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->assignee->name }}</td>
+                                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300"><a href="{{ route('profile.view', $todo->assignee->id) }}" class="text-[#8B0116] hover:underline">{{ $todo->assignee->name }}</a></td>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
                                             {{ $todo->completed_at->format('d.m.Y H:i') }}</td>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->points }}</td>
@@ -291,7 +291,7 @@
                                 </div>
                                 <div class="mb-2">
                                     <span class="text-sm text-gray-600 dark:text-gray-400">Bearbeitet von:</span>
-                                    <div class="mt-1 text-gray-800 dark:text-gray-200">{{ $todo->assignee->name }}</div>
+                                    <div class="mt-1 text-gray-800 dark:text-gray-200"><a href="{{ route('profile.view', $todo->assignee->id) }}" class="text-[#8B0116] hover:underline">{{ $todo->assignee->name }}</a></div>
                                 </div>
                                 <div class="mb-2">
                                     <span class="text-sm text-gray-600 dark:text-gray-400">Erledigt am:</span>
@@ -348,7 +348,7 @@
                                     <tr>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->title }}</td>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->category ? $todo->category->name : '-' }}</td>
-                                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->assignee->name }}</td>
+                                        <td class="px-4 py-2 text-gray-700 dark:text-gray-300"><a href="{{ route('profile.view', $todo->assignee->id) }}" class="text-[#8B0116] hover:underline">{{ $todo->assignee->name }}</a></td>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->points }}</td>
                                         <td class="px-4 py-2 text-center">
                                             <a href="{{ route('todos.show', $todo) }}"
@@ -377,7 +377,7 @@
                                 </div>
                                 <div class="mb-2">
                                     <span class="text-sm text-gray-600 dark:text-gray-400">Bearbeitet von:</span>
-                                    <div class="mt-1 text-gray-800 dark:text-gray-200">{{ $todo->assignee->name }}</div>
+                                    <div class="mt-1 text-gray-800 dark:text-gray-200"><a href="{{ route('profile.view', $todo->assignee->id) }}" class="text-[#8B0116] hover:underline">{{ $todo->assignee->name }}</a></div>
                                 </div>
                                 <div class="mb-3">
                                     <span class="text-sm text-gray-600 dark:text-gray-400">Baxx:</span>

--- a/resources/views/todos/show.blade.php
+++ b/resources/views/todos/show.blade.php
@@ -66,7 +66,7 @@
                             </div>
                             <div class="mb-2">
                                 <span class="text-gray-600 dark:text-gray-400 text-sm">Erstellt von:</span>
-                                <span class="ml-2 text-gray-800 dark:text-gray-200">{{ $todo->creator->name }}</span>
+                                <span class="ml-2 text-gray-800 dark:text-gray-200"><a href="{{ route('profile.view', $todo->creator->id) }}" class="text-[#8B0116] hover:underline">{{ $todo->creator->name }}</a></span>
                             </div>
                             <div class="mb-2">
                                 <span class="text-gray-600 dark:text-gray-400 text-sm">Erstellt am:</span>
@@ -82,7 +82,7 @@
                             @if($todo->assigned_to)
                                 <div class="mb-2">
                                     <span class="text-gray-600 dark:text-gray-400 text-sm">Zugewiesen an:</span>
-                                    <span class="ml-2 text-gray-800 dark:text-gray-200">{{ $todo->assignee->name }}</span>
+                                    <span class="ml-2 text-gray-800 dark:text-gray-200"><a href="{{ route('profile.view', $todo->assignee->id) }}" class="text-[#8B0116] hover:underline">{{ $todo->assignee->name }}</a></span>
                                 </div>
                             @endif
 
@@ -97,7 +97,7 @@
                             @if($todo->verified_by)
                                 <div class="mb-2">
                                     <span class="text-gray-600 dark:text-gray-400 text-sm">Verifiziert von:</span>
-                                    <span class="ml-2 text-gray-800 dark:text-gray-200">{{ $todo->verifier->name }}</span>
+                                    <span class="ml-2 text-gray-800 dark:text-gray-200"><a href="{{ route('profile.view', $todo->verifier->id) }}" class="text-[#8B0116] hover:underline">{{ $todo->verifier->name }}</a></span>
                                 </div>
                                 <div class="mb-2">
                                     <span class="text-gray-600 dark:text-gray-400 text-sm">Verifiziert am:</span>

--- a/tests/Feature/ActivityFeedTest.php
+++ b/tests/Feature/ActivityFeedTest.php
@@ -133,7 +133,7 @@ class ActivityFeedTest extends TestCase
 
         $dashboard = $this->get('/dashboard');
         $dashboard->assertOk();
-        $dashboard->assertSee('Kommentar zu Meine Rezension von ' . $user->name);
+        $dashboard->assertSee('Kommentar zu Meine Rezension von <a href="' . route('profile.view', $user->id) . '" class="text-[#8B0116] hover:underline">' . $user->name . '</a>', false);
     }
 
     public function test_dashboard_displays_recent_activities(): void

--- a/tests/Feature/ActivityFeedTest.php
+++ b/tests/Feature/ActivityFeedTest.php
@@ -133,7 +133,7 @@ class ActivityFeedTest extends TestCase
 
         $dashboard = $this->get('/dashboard');
         $dashboard->assertOk();
-        $dashboard->assertSee('Kommentar zu Meine Rezension von <a href="' . route('profile.view', $user->id) . '" class="text-[#8B0116] hover:underline">' . $user->name . '</a>', false);
+        $dashboard->assertSee('Kommentar zu <a href="' . route('reviews.show', $review->book_id) . '" class="text-blue-600 dark:text-blue-400 hover:underline">Meine Rezension</a> von <a href="' . route('profile.view', $user->id) . '" class="text-[#8B0116] hover:underline">' . $user->name . '</a>', false);
     }
 
     public function test_dashboard_displays_recent_activities(): void


### PR DESCRIPTION
This pull request updates several Blade view templates to consistently link user names to their profile pages throughout the application. The changes improve navigation and user experience by making it easier to access user profiles from various lists, tables, and activity feeds.

**User Profile Link Integration**

* All user names displayed in tables, lists, activity feeds, and comments are now wrapped in an anchor tag that links to their profile page via the `profile.view` route. This change applies to members, creators, assignees, reviewers, commenters, and swap participants across multiple views. [[1]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324L68-R68) [[2]](diffhunk://#diff-7aa2df5a0e171b930924e672154d21c4cb3a17e8db06c3457b7119a9d20f1e99L101-R109) [[3]](diffhunk://#diff-b66ed4d712d9f70d89687b73abd82ab56302891704f63a17b20b53540cf23a39L234-R234) [[4]](diffhunk://#diff-4ba1a19131db2c1fa91dc38dd5530f832e09c39b23e7b221e14b08e3a6ed360bL135-R138) [[5]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L175-R175) [[6]](diffhunk://#diff-989c06045f97dda4b51981c5158c5f5dba13e2002e7e2bae0dd4bfc86f4bfcd2L36-R36) [[7]](diffhunk://#diff-9cd87369466636f28751884bd7d4e05e7b82ea7df7226c4bc95f0b7b66f9f699L16-R16)

**Activity and Comment Feeds**

* In activity feeds and comment lists, both the user name and, where relevant, related review titles are now clickable links, improving access to profiles and review details. [[1]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324L83-R85) [[2]](diffhunk://#diff-70b90a2af653de7e93a479bfd34fb793c391e9bfc002c819d68fbbd056394266L6-R6)

**Members and Teams Tables**

* Member names in tables and team management lists are now linked to profile pages, replacing plain text with clickable elements. This applies to member lists, financial records, and team management interfaces. [[1]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324L174-R174) [[2]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324L206-R206) [[3]](diffhunk://#diff-7aa2df5a0e171b930924e672154d21c4cb3a17e8db06c3457b7119a9d20f1e99L212-R212) [[4]](diffhunk://#diff-b66ed4d712d9f70d89687b73abd82ab56302891704f63a17b20b53540cf23a39L247-R247) [[5]](diffhunk://#diff-b66ed4d712d9f70d89687b73abd82ab56302891704f63a17b20b53540cf23a39L403-R403) [[6]](diffhunk://#diff-b66ed4d712d9f70d89687b73abd82ab56302891704f63a17b20b53540cf23a39L417-R417)

**Book Swap and Review Features**

* In book swap and review views, user names for offer/request participants and reviewers are now linked to their profiles, enhancing traceability and user engagement. [[1]](diffhunk://#diff-989c06045f97dda4b51981c5158c5f5dba13e2002e7e2bae0dd4bfc86f4bfcd2L62-R62) [[2]](diffhunk://#diff-989c06045f97dda4b51981c5158c5f5dba13e2002e7e2bae0dd4bfc86f4bfcd2L78-R78) [[3]](diffhunk://#diff-989c06045f97dda4b51981c5158c5f5dba13e2002e7e2bae0dd4bfc86f4bfcd2L94-R94) [[4]](diffhunk://#diff-9cd87369466636f28751884bd7d4e05e7b82ea7df7226c4bc95f0b7b66f9f699L16-R16)

**Todo Management**

* Creator and assignee names in todo lists, details, and completed tasks are now profile links, making it easier to view user information directly from task management screens. [[1]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L211-R211) [[2]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L259-R259) [[3]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L294-R294)

These changes collectively standardize the user interface and make user profiles more accessible throughout the application.