### PR TITLE
Invalidate dashboard cache after processing membership applications

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -191,6 +191,9 @@ class DashboardController extends Controller
         $user->save();
         Mail::to($user->email)->queue(new MitgliedGenehmigtMail($user));
 
+        Cache::forget("member_count_{$team->id}");
+        Cache::forget("anwaerter_{$team->id}");
+
         return back()->with('status', 'Antrag genehmigt.');
     }
 
@@ -199,6 +202,9 @@ class DashboardController extends Controller
         $team = $user->currentTeam;
         $team->users()->detach($user->id);
         $user->delete();
+
+        Cache::forget("member_count_{$team->id}");
+        Cache::forget("anwaerter_{$team->id}");
 
         return back()->with('status', 'Antrag abgelehnt und gelöscht.');
     }

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -62,6 +62,25 @@ class DashboardControllerTest extends TestCase
         $this->assertDatabaseMissing('team_user', ['user_id' => $applicant->id]);
     }
 
+    public function test_approving_applicant_clears_dashboard_cache(): void
+    {
+        Mail::fake();
+        $admin = $this->actingAdmin();
+        $applicant = $this->createApplicant();
+
+        $this->actingAs($admin)->get('/dashboard');
+
+        $this->actingAs($admin)
+            ->from('/dashboard')
+            ->post(route('anwaerter.approve', $applicant))
+            ->assertRedirect('/dashboard');
+
+        $response = $this->actingAs($admin)->get('/dashboard');
+
+        $response->assertViewHas('memberCount', 3);
+        $this->assertFalse($response->viewData('anwaerter')->contains($applicant));
+    }
+
     public function test_index_displays_dashboard_statistics(): void
     {
         $team = Team::where('name', 'Mitglieder')->first();


### PR DESCRIPTION
This pull request improves cache management in the dashboard by ensuring that relevant cache entries are cleared when an applicant is approved or rejected. It also adds a new test to verify that the cache is properly invalidated after approving an applicant.

**Cache invalidation improvements:**

* In `DashboardController.php`, the `approveAnwaerter` and `rejectAnwaerter` methods now clear the `member_count` and `anwaerter` cache entries for the relevant team after an applicant is approved or rejected. [[1]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bR194-R196) [[2]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bR206-R208)

**Testing enhancements:**

* Added a new test `test_approving_applicant_clears_dashboard_cache` in `DashboardControllerTest.php` to verify that approving an applicant correctly clears the dashboard cache and updates the displayed member count and applicant list.