### PR TITLE
Use cross-platform git commands for version retrieval

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -33,17 +33,20 @@ class AppServiceProvider extends ServiceProvider
         $version = Config::get('app.version');
 
         if ($version === null || $version === '0.0.0') {
+            $version = '0.0.0';
+
             try {
                 $commit = trim(Process::run(['git', 'rev-list', '--tags', '--max-count=1'])->output());
 
                 if ($commit !== '') {
-                    $process = Process::run(['git', 'describe', '--tags', $commit]);
-                    $version = $process->successful() ? trim($process->output()) : '0.0.0';
-                } else {
-                    $version = '0.0.0';
+                    $describe = Process::run(['git', 'describe', '--tags', $commit]);
+
+                    if ($describe->successful()) {
+                        $version = trim($describe->output());
+                    }
                 }
             } catch (\Throwable $e) {
-                $version = '0.0.0';
+                // use default version
             }
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,7 +36,12 @@ class AppServiceProvider extends ServiceProvider
             $version = '0.0.0';
 
             try {
-                $commit = trim(Process::run(['git', 'rev-list', '--tags', '--max-count=1'])->output());
+                $commit = '';
+                $revList = Process::run(['git', 'rev-list', '--tags', '--max-count=1']);
+
+                if ($revList->successful()) {
+                    $commit = trim($revList->output());
+                }
 
                 if ($commit !== '') {
                     $describe = Process::run(['git', 'describe', '--tags', $commit]);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,8 +34,14 @@ class AppServiceProvider extends ServiceProvider
 
         if ($version === null || $version === '0.0.0') {
             try {
-                $process = Process::run(['bash', '-c', 'git describe --tags $(git rev-list --tags --max-count=1)']);
-                $version = $process->successful() ? trim($process->output()) : '0.0.0';
+                $commit = trim(Process::run(['git', 'rev-list', '--tags', '--max-count=1'])->output());
+
+                if ($commit !== '') {
+                    $process = Process::run(['git', 'describe', '--tags', $commit]);
+                    $version = $process->successful() ? trim($process->output()) : '0.0.0';
+                } else {
+                    $version = '0.0.0';
+                }
             } catch (\Throwable $e) {
                 $version = '0.0.0';
             }

--- a/tests/Feature/FooterVersionTest.php
+++ b/tests/Feature/FooterVersionTest.php
@@ -12,8 +12,14 @@ class FooterVersionTest extends TestCase
 
     public function test_footer_displays_version_and_changelog_link(): void
     {
-        $process = Process::run(['bash', '-c', 'git describe --tags $(git rev-list --tags --max-count=1)']);
-        $version = $process->successful() ? trim($process->output()) : '0.0.0';
+        $commit = trim(Process::run(['git', 'rev-list', '--tags', '--max-count=1'])->output());
+
+        if ($commit !== '') {
+            $process = Process::run(['git', 'describe', '--tags', $commit]);
+            $version = $process->successful() ? trim($process->output()) : '0.0.0';
+        } else {
+            $version = '0.0.0';
+        }
 
         $response = $this->get('/');
         $response->assertSee("Version {$version}");

--- a/tests/Feature/FooterVersionTest.php
+++ b/tests/Feature/FooterVersionTest.php
@@ -14,11 +14,14 @@ class FooterVersionTest extends TestCase
     {
         $commit = trim(Process::run(['git', 'rev-list', '--tags', '--max-count=1'])->output());
 
+        $version = '0.0.0';
+
         if ($commit !== '') {
-            $process = Process::run(['git', 'describe', '--tags', $commit]);
-            $version = $process->successful() ? trim($process->output()) : '0.0.0';
-        } else {
-            $version = '0.0.0';
+            $describe = Process::run(['git', 'describe', '--tags', $commit]);
+
+            if ($describe->successful()) {
+                $version = trim($describe->output());
+            }
         }
 
         $response = $this->get('/');

--- a/tests/Feature/FooterVersionTest.php
+++ b/tests/Feature/FooterVersionTest.php
@@ -12,15 +12,19 @@ class FooterVersionTest extends TestCase
 
     public function test_footer_displays_version_and_changelog_link(): void
     {
-        $commit = trim(Process::run(['git', 'rev-list', '--tags', '--max-count=1'])->output());
-
         $version = '0.0.0';
 
-        if ($commit !== '') {
-            $describe = Process::run(['git', 'describe', '--tags', $commit]);
+        $revList = Process::run(['git', 'rev-list', '--tags', '--max-count=1']);
 
-            if ($describe->successful()) {
-                $version = trim($describe->output());
+        if ($revList->successful()) {
+            $commit = trim($revList->output());
+
+            if ($commit !== '') {
+                $describe = Process::run(['git', 'describe', '--tags', $commit]);
+
+                if ($describe->successful()) {
+                    $version = trim($describe->output());
+                }
             }
         }
 


### PR DESCRIPTION
This pull request refactors the logic for retrieving the current Git version tag both in the application service provider and the corresponding feature test. The main improvement is replacing the previous usage of a Bash command with direct Git commands, making the code more robust and platform-independent.

**Refactoring version retrieval logic:**

* In `app/Providers/AppServiceProvider.php`, replaced the Bash command for describing the latest tag with direct Git commands, improving reliability and removing the shell dependency.
* In `tests/Feature/FooterVersionTest.php`, updated the test to use the same Git command logic as the application code, ensuring consistency and easier maintenance.