### PR TITLE
feat: add JS coverage badge and rename PHP coverage

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -97,18 +97,29 @@ jobs:
         XDEBUG_MODE: coverage
       run: php artisan test tests/Feature --coverage-clover=coverage.xml
 
-    - name: Run Jest tests
-      run: npm test
+    - name: Run Jest tests with coverage
+      run: npm test -- --coverage --coverageReporters=lcov,json-summary
 
-    - name: Create coverage badge
+    - name: Create JS coverage badge
+      if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
+      run: |
+        npx make-coverage-badge
+        mv coverage.svg output/js-coverage.svg
+        sed -i 's/Coverage/JS Coverage/' output/js-coverage.svg
+
+    - name: Create PHP coverage badge
       if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
       uses: timkrase/phpunit-coverage-badge@v1.2.1
       with:
         report: coverage.xml
-        coverage_badge_path: output/coverage.svg
+        coverage_badge_path: output/php-coverage.svg
         push_badge: false
 
-    - name: Deploy coverage badge to image-data branch
+    - name: Rename PHP coverage badge label
+      if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
+      run: sed -i 's/Coverage/PHP Coverage/' output/php-coverage.svg
+
+    - name: Deploy coverage badges to image-data branch
       if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![Laravel 12](https://img.shields.io/badge/laravel-12-red?logo=laravel&style=flat)
 ![PHP 8.4](https://img.shields.io/badge/php-%5E8.2-blue?logo=php)
 [![Build & Deploy](https://github.com/mcnamara84/omxfc-vereinswebseite/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/mcnamara84/omxfc-vereinswebseite/actions/workflows/deploy.yml)
-![Laravel Tests](https://github.com/McNamara84/omxfc-vereinswebseite/workflows/Laravel%20Feature%20Tests/badge.svg)
-![Coverage Badge](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/coverage.svg)
+![JS Coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/js-coverage.svg)
+![PHP Coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/php-coverage.svg)
 [![License](https://img.shields.io/badge/license-GPLv3-green)](https://github.com/mcnamara84/omxfc-vereinswebseite/blob/main/LICENSE)
 
 Eine Laravel 12 Anwendung für die Vereinswebseite des OMFXC.


### PR DESCRIPTION
## Summary
- add badge generation for Jest coverage
- rename PHP coverage badge and deploy both badges
- show JS and PHP coverage badges in README

## Testing
- `npm test -- --coverage --coverageReporters=lcov --coverageReporters=json-summary`
- `php artisan test tests/Feature`
- `npx make-coverage-badge` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689865250b8c832eadd104a83d24bb0f