### PR TITLE
Add meta titles and descriptions for multiple pages

### DIFF
--- a/app/Http/Controllers/RezensionController.php
+++ b/app/Http/Controllers/RezensionController.php
@@ -98,7 +98,11 @@ class RezensionController extends Controller
 
         $booksByCycle = $books->sortByDesc('roman_number')->groupBy('cycle');
 
-        return view('reviews.index', compact('booksByCycle'));
+        return view('reviews.index', [
+            'booksByCycle' => $booksByCycle,
+            'title' => 'Rezensionen – Offizieller MADDRAX Fanclub e. V.',
+            'description' => 'Alle Vereinsrezensionen zu den Maddrax-Romanen im Überblick.',
+        ]);
     }
 
     /**
@@ -121,7 +125,13 @@ class RezensionController extends Controller
                     $query->with(['user', 'children.user'])->orderBy('created_at');
                 }])
                 ->get();
-            return view('reviews.show', compact('book', 'reviews', 'role'));
+            return view('reviews.show', [
+                'book' => $book,
+                'reviews' => $reviews,
+                'role' => $role,
+                'title' => 'Rezensionen zu ' . $book->title . ' – Offizieller MADDRAX Fanclub e. V.',
+                'description' => 'Leserrezensionen zum Roman "' . $book->title . '".',
+            ]);
         }
 
         return redirect()->route('reviews.create', $book);
@@ -149,7 +159,11 @@ class RezensionController extends Controller
             abort(403);
         }
 
-        return view('reviews.create', compact('book'));
+        return view('reviews.create', [
+            'book' => $book,
+            'title' => 'Rezension zu ' . $book->title . ' verfassen – Offizieller MADDRAX Fanclub e. V.',
+            'description' => 'Schreibe deine Rezension zum Roman "' . $book->title . '".',
+        ]);
     }
 
     /**
@@ -225,7 +239,11 @@ class RezensionController extends Controller
         $role = $this->getRoleInMemberTeam();
 
         if ($review->user_id === $user->id || in_array($role, ['Vorstand', 'Admin'], true)) {
-            return view('reviews.edit', compact('review'));
+            return view('reviews.edit', [
+                'review' => $review,
+                'title' => 'Rezension zu ' . $review->book->title . ' bearbeiten – Offizieller MADDRAX Fanclub e. V.',
+                'description' => 'Überarbeite deine Rezension zum Roman "' . $review->book->title . '".',
+            ]);
         }
 
         abort(403);

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Passwort vergessen – Offizieller MADDRAX Fanclub e. V." description="Fordere einen Link zum Zurücksetzen deines Passworts an.">
     <div class="max-w-md mx-auto px-6 py-12 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md">
         <h2 class="text-2xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6 text-center">
             {{ __('Passwort vergessen') }}

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Login – Offizieller MADDRAX Fanclub e. V." description="Melde dich mit deinem Konto beim Offiziellen MADDRAX Fanclub an.">
     <div class="max-w-md mx-auto px-6 py-12 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md">
         <h2 class="text-2xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6 text-center">
             {{ __('Login') }}

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Zugriff verweigert – Offizieller MADDRAX Fanclub e. V." description="Du besitzt keine Berechtigung für diesen Bereich.">
     <div class="container mx-auto py-12 text-center">
         <h1 class="text-5xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6">403</h1>
         <img src="{{ asset('images/errors/403.png') }}" alt="Verbotene Zone" class="mx-auto w-64 h-auto mb-6">

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Seite nicht gefunden – Offizieller MADDRAX Fanclub e. V." description="Die angeforderte Seite existiert nicht.">
     <div class="container mx-auto py-12 text-center">
         <h1 class="text-5xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6">404</h1>
         <img src="{{ asset('images/errors/404.png') }}" alt="Seite verschollen" class="mx-auto w-64 h-auto mb-6">

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Serverfehler – Offizieller MADDRAX Fanclub e. V." description="Es ist ein unerwarteter Fehler aufgetreten.">
     <div class="container mx-auto py-12 text-center">
         <h1 class="text-5xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-6">500</h1>
         <img src="{{ asset('images/errors/500.png') }}" alt="Server zerstört" class="mx-auto w-64 h-auto mb-6">

--- a/resources/views/pages/downloads.blade.php
+++ b/resources/views/pages/downloads.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Downloads – Offizieller MADDRAX Fanclub e. V." description="Exklusive Dateien wie Bauanleitungen und Fanstories für Vereinsmitglieder.">
     <div class="pb-8">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">

--- a/resources/views/pages/fotogalerie.blade.php
+++ b/resources/views/pages/fotogalerie.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Fotogalerie – Offizieller MADDRAX Fanclub e. V." description="Bilder von Veranstaltungen und Treffen des Fanclubs.">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pb-6 sm:pb-10 bg-gray-100 dark:bg-gray-800 rounded-lg shadow-sm">
         <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Fotogalerie</h1>
 

--- a/resources/views/pages/kompendium.blade.php
+++ b/resources/views/pages/kompendium.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Kompendium – Offizieller MADDRAX Fanclub e. V." description="Volltextsuche durch Maddrax-Romane für Mitglieder.">
     <div class="pb-8">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">

--- a/resources/views/pages/meetings.blade.php
+++ b/resources/views/pages/meetings.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Meetings – Offizieller MADDRAX Fanclub e. V." description="Übersicht regelmäßiger AG-Termine und Stammtische.">
     <div class="pb-8 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
             <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-6">Meetings</h1>

--- a/resources/views/pages/protokolle.blade.php
+++ b/resources/views/pages/protokolle.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout title="Protokolle – Offizieller MADDRAX Fanclub e. V." description="Versammlungsprotokolle als PDF zum Download.">
     <div class="pb-8">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">

--- a/resources/views/reviews/create.blade.php
+++ b/resources/views/reviews/create.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout :title="$title" :description="$description">
     <x-member-page class="max-w-3xl">
             <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
                 Neue Rezension zu „{{ $book->title }}“ (Nr. {{ $book->roman_number }})

--- a/resources/views/reviews/edit.blade.php
+++ b/resources/views/reviews/edit.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout :title="$title" :description="$description">
     <x-member-page class="max-w-3xl">
             <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
                 Rezension zu „{{ $review->book->title }}“ bearbeiten

--- a/resources/views/reviews/index.blade.php
+++ b/resources/views/reviews/index.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout :title="$title" :description="$description">
     <x-member-page>
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                 <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-2">Rezensionen</h1>

--- a/resources/views/reviews/show.blade.php
+++ b/resources/views/reviews/show.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout>
+<x-app-layout :title="$title" :description="$description">
     <x-member-page class="max-w-3xl">
             @if(session('success'))
                 <div class="mb-4 p-4 bg-green-100 dark:bg-green-800 border border-green-400 dark:border-green-600 text-green-800 dark:text-green-100 rounded">


### PR DESCRIPTION
This pull request introduces consistent support for dynamic page titles and descriptions across both controller logic and Blade views. By passing `title` and `description` variables from controllers to views and updating the layout components to accept these parameters, the application now provides improved SEO and user experience with more descriptive metadata on all major pages.

**Controller changes for metadata support:**

* Updated `RezensionController` methods (`index`, `show`, `create`, `edit`) to pass `title` and `description` variables to their respective views for reviews, using associative arrays instead of `compact`. [[1]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L101-R105) [[2]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L124-R134) [[3]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L152-R166) [[4]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L228-R246)

**Blade view changes for metadata support:**

* Modified review-related Blade views (`reviews/index`, `reviews/show`, `reviews/create`, `reviews/edit`) to accept and use dynamic `title` and `description` parameters via the `x-app-layout` component. [[1]](diffhunk://#diff-00ef715388ea5b0565ff6b9058b2ab80c1a490f94a14128b08276675b98bd7adL1-R1) [[2]](diffhunk://#diff-9cd87369466636f28751884bd7d4e05e7b82ea7df7226c4bc95f0b7b66f9f699L1-R1) [[3]](diffhunk://#diff-95f123d2764d30e8702d8f6482a5e730c0f43fb5dde8770b1adfb611033289fdL1-R1) [[4]](diffhunk://#diff-6b72c5130e56a05688e80b81da04febd37baf4f07c3cc7a95f6dc416dd369169L1-R1)

**General page and error view improvements:**

* Updated general pages (`downloads`, `fotogalerie`, `kompendium`, `meetings`, `protokolle`) and authentication/error views (`forgot-password`, `login`, `403`, `404`, `500`) to set static but descriptive `title` and `description` attributes in the `x-app-layout` component for better clarity and SEO. [[1]](diffhunk://#diff-0d60778ef960d4822b246b851116d0ce6860db52805826b26a3fd282f05a492eL1-R1) [[2]](diffhunk://#diff-65c909755e14f4116010a58a048f7086fe191ce65510bf55203bc02304c771caL1-R1) [[3]](diffhunk://#diff-5175fa063768ad35dd06de86cf7c1b68b4103c1e8752f820b503f9392bf36d47L1-R1) [[4]](diffhunk://#diff-875216a324769c643f9832a09cf3d95ace6f2b8aee7657cece1c5f850bbdd416L1-R1) [[5]](diffhunk://#diff-66be67f5ef0db6faedd41c7293dcf5825a9a54afe72393b49e0b75c8aa0e78c5L1-R1) [[6]](diffhunk://#diff-7b474cbc38482e78ab8214ec239adb703c5c758c13663f954609dcd6ddf41b3aL1-R1) [[7]](diffhunk://#diff-332225f8604cb668907b62918844105dc8fd499d5345dd6da8e9bc3f96ddb425L1-R1) [[8]](diffhunk://#diff-bffa870cede126097d1b2b387c25e471cf3883b601f627a7f7eff245bff1bc7eL1-R1) [[9]](diffhunk://#diff-68172ed31c58d21c420da9c9ca6ca4b1e81635111b0df0c10ccce04ac8150e2fL1-R1) [[10]](diffhunk://#diff-66941da8f1c9be5b3a9fd1df1f6121f2e4e2efcdd577aea5e0dcbfb1381da484L1-R1)