### PR TITLE
Fix coverage badge generation in tests workflow

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -108,11 +108,12 @@ jobs:
           echo "coverage/coverage-summary.json not found" >&2
           exit 1
         fi
-        npx --yes make-coverage-badge --input-path=coverage/coverage-summary.json --badge-label="JS Coverage" --output=output/js-coverage.svg
+        npx --yes make-coverage-badge --report-path=coverage/coverage-summary.json --output-path=output/js-coverage.svg
         if [ ! -f output/js-coverage.svg ]; then
           echo "JS coverage badge was not created" >&2
           exit 1
         fi
+        sed -i 's/Coverage/JS Coverage/' output/js-coverage.svg
 
     - name: Create PHP coverage badge
       if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
@@ -120,8 +121,17 @@ jobs:
       with:
         report: coverage.xml
         coverage_badge_path: output/php-coverage.svg
-        badge_label: 'PHP Coverage'
         push_badge: false
+
+    - name: Customize PHP coverage badge label
+      if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
+      run: |
+        if [ -f output/php-coverage.svg ]; then
+          sed -i 's/Coverage/PHP Coverage/' output/php-coverage.svg
+        else
+          echo "PHP coverage badge was not created" >&2
+          exit 1
+        fi
 
     - name: Deploy coverage badges to image-data branch
       if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
This pull request updates the workflow for generating coverage badges in `.github/workflows/unittests.yml`. The main changes focus on improving badge creation and ensuring the correct labels are applied for both JS and PHP coverage badges.

**Coverage badge generation and customization:**

* Updated the JS coverage badge step to use `--report-path` and `--output-path` arguments instead of the previous ones, and added a `sed` command to change the badge label to "JS Coverage" in the generated SVG.
* Removed the `badge_label` input from the PHP coverage badge step and added a new step that uses `sed` to update the label in the SVG to "PHP Coverage" after badge generation.