### PR TITLE
feat: enable lazy loading for images

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -107,7 +107,7 @@
                                     <div class="relative mb-2">
                                         <div class="absolute -top-3 -right-2 w-8 h-8 bg-yellow-400 dark:bg-yellow-500 rounded-full flex items-center justify-center text-white font-bold shadow-md transform group-hover:scale-110 transition-transform">1</div>
                                         <div class="h-20 w-20 rounded-full overflow-hidden border-4 border-yellow-400 dark:border-yellow-500 shadow-lg group-hover:shadow-xl transition-shadow">
-                                            <img src="{{ $topUser['profile_photo_url'] }}" alt="{{ $topUser['name'] }}" class="h-full w-full object-cover">
+                                            <img loading="lazy" src="{{ $topUser['profile_photo_url'] }}" alt="{{ $topUser['name'] }}" class="h-full w-full object-cover">
                                         </div>
                                     </div>
                                 @elseif($index === 1)
@@ -115,7 +115,7 @@
                                     <div class="relative mb-2">
                                         <div class="absolute -top-3 -right-2 w-8 h-8 bg-gray-300 dark:bg-gray-400 rounded-full flex items-center justify-center text-gray-700 dark:text-gray-800 font-bold shadow-md transform group-hover:scale-110 transition-transform">2</div>
                                         <div class="h-20 w-20 rounded-full overflow-hidden border-4 border-gray-300 dark:border-gray-400 shadow-lg group-hover:shadow-xl transition-shadow">
-                                            <img src="{{ $topUser['profile_photo_url'] }}" alt="{{ $topUser['name'] }}" class="h-full w-full object-cover">
+                                            <img loading="lazy" src="{{ $topUser['profile_photo_url'] }}" alt="{{ $topUser['name'] }}" class="h-full w-full object-cover">
                                         </div>
                                     </div>
                                 @else
@@ -123,7 +123,7 @@
                                     <div class="relative mb-2">
                                         <div class="absolute -top-3 -right-2 w-8 h-8 bg-yellow-700 dark:bg-yellow-800 rounded-full flex items-center justify-center text-white font-bold shadow-md transform group-hover:scale-110 transition-transform">3</div>
                                         <div class="h-20 w-20 rounded-full overflow-hidden border-4 border-yellow-700 dark:border-yellow-800 shadow-lg group-hover:shadow-xl transition-shadow">
-                                            <img src="{{ $topUser['profile_photo_url'] }}" alt="{{ $topUser['name'] }}" class="h-full w-full object-cover">
+                                            <img loading="lazy" src="{{ $topUser['profile_photo_url'] }}" alt="{{ $topUser['name'] }}" class="h-full w-full object-cover">
                                         </div>
                                     </div>
                                 @endif

--- a/resources/views/kassenbuch/index.blade.php
+++ b/resources/views/kassenbuch/index.blade.php
@@ -100,7 +100,7 @@
                                     <td class="px-4 py-3 whitespace-nowrap">
                                         <a href="{{ route('profile.view', $member->id) }}" class="flex items-center">
                                             <div class="h-8 w-8 flex-shrink-0">
-                                                <img class="h-8 w-8 rounded-full" src="{{ $member->profile_photo_url }}" alt="{{ $member->name }}">
+                                                <img loading="lazy" class="h-8 w-8 rounded-full" src="{{ $member->profile_photo_url }}" alt="{{ $member->name }}">
                                             </div>
                                             <div class="ml-3">
                                                 <div class="text-sm font-medium text-gray-900 dark:text-white">{{ $member->name }}</div>

--- a/resources/views/mitglieder/index.blade.php
+++ b/resources/views/mitglieder/index.blade.php
@@ -233,7 +233,7 @@
     <td class="px-4 py-3">
     <a href="{{ route('profile.view', $member->id) }}" class="flex items-center">
     <div class="h-10 w-10 flex-shrink-0">
-    <img class="h-10 w-10 rounded-full" src="{{ $member->profile_photo_url }}" alt="{{ $member->name }}">
+    <img loading="lazy" class="h-10 w-10 rounded-full" src="{{ $member->profile_photo_url }}" alt="{{ $member->name }}">
     </div>
     <div class="ml-4">
     <div class="font-medium text-gray-900 dark:text-gray-100 flex items-center">
@@ -402,7 +402,7 @@
     <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg shadow">
     <a href="{{ route('profile.view', $member->id) }}" class="flex items-center mb-4">
     <div class="h-12 w-12 flex-shrink-0">
-    <img class="h-12 w-12 rounded-full" src="{{ $member->profile_photo_url }}" alt="{{ $member->name }}">
+    <img loading="lazy" class="h-12 w-12 rounded-full" src="{{ $member->profile_photo_url }}" alt="{{ $member->name }}">
     </div>
     <div class="ml-4">
     <div class="font-medium text-gray-900 dark:text-gray-100 flex items-center">

--- a/resources/views/pages/arbeitsgruppen.blade.php
+++ b/resources/views/pages/arbeitsgruppen.blade.php
@@ -5,7 +5,7 @@
         <!-- AG Maddraxikon -->
         <section class="mb-12">
             <h2 class="text-2xl font-semibold mb-4">AG Maddraxikon</h2>
-            <img src="{{ asset('images/ag-maddraxikon.png') }}" alt="Logo der AG Maddraxikon"
+            <img loading="lazy" src="{{ asset('images/ag-maddraxikon.png') }}" alt="Logo der AG Maddraxikon"
                 class="w-full h-auto rounded-lg shadow mb-4 ag-logo">
             <p class="mb-4">Das Maddraxikon ist das umfangreichste und dienstälteste Nachschlagewerk rund um die
                 faszinierende Welt des Maddraxiversums. Ob legendäre Helden, düstere Schauplätze oder spannende
@@ -26,7 +26,7 @@
         <!-- AG EARDRAX -->
         <section class="mb-12">
             <h2 class="text-2xl font-semibold mb-4">AG EARDRAX (Fanhörbücher)</h2>
-            <img src="{{ asset('images/ag-eardrax.png') }}" alt="Logo der AG EARDRAX"
+            <img loading="lazy" src="{{ asset('images/ag-eardrax.png') }}" alt="Logo der AG EARDRAX"
                 class="w-full h-auto rounded-lg shadow mb-4 ag-logo">
             <p class="mb-4">Die AG EARDRAX (Fanhörbücher) ist ein munterer Tummelplatz für alle, die immer schon einmal bei einer Hörbuchproduktion mitmachen wollten.</p>
             <p class="mb-4">EARDRAX ist eine klassische Corona-Idee: als ein (damals noch) kleiner Haufen von Maddrax-Fans auf die Idee kam, die Maddrax Romane ab Band 15 der Heftserie zu vertonen. Die Folgen 1 bis 14 gab es ja schon von Lübbe Audio als klassische, aber gekürzte Hörbuchversionen.</p>
@@ -45,7 +45,7 @@
         <!-- AG Mapdrax -->
         <section class="mb-12">
             <h2 class="text-2xl font-semibold mb-4">AG Mapdrax</h2>
-            <img src="{{ asset('images/ag-mapdrax.png') }}" alt="Logo der AG Mapdrax" class="w-full h-auto rounded-lg shadow mb-4 ag-logo">
+            <img loading="lazy" src="{{ asset('images/ag-mapdrax.png') }}" alt="Logo der AG Mapdrax" class="w-full h-auto rounded-lg shadow mb-4 ag-logo">
             <p class="mb-4">MAPDRAX ist ein Teil des MADDRAXIKON und dient als kartographische Unterstützung des Maddrax-Wikis. Die Idee ist simpel: Es soll die dunkle Zukunft der Erde in Form einer Open-Source-Karte visualisiert werden, auf die über die Wiki-Beiträge zugegriffen werden kann.</p>
             <p class="mb-4">Als Tool verwenden wir die Online-Anwendung INKARNATE. Diese Anwendung ist ein Werkzeug, bei dem Fantasykarten gestaltet werden können. Aktuell arbeiten wir an MAPDRAX V2.</p>
             <p class="mb-4">MAPDRAX kann jede Art von Unterstützung gebrauchen. Wer sich angesprochen fühlt, der kann sich sehr gerne beim Leiter der Arbeitsgruppe MAPDRAX melden.</p>
@@ -59,7 +59,7 @@
         <!-- AG Mapdrax -->
         <section class="mb-12">
             <h2 class="text-2xl font-semibold mb-4">AG Rollenspiel</h2>
-            <img src="{{ asset('images/ag-rollenspiel.png') }}" alt="Logo der AG Rollenspiel" class="w-full h-auto rounded-lg shadow mb-4 ag-logo">
+            <img loading="lazy" src="{{ asset('images/ag-rollenspiel.png') }}" alt="Logo der AG Rollenspiel" class="w-full h-auto rounded-lg shadow mb-4 ag-logo">
             <p class="mb-4">„Na mein Freund, hast du einen schönen Tag gehabt?“ Müde blinzelte Matt zu der Fremden, die sich an seinen Tisch gesellte. Irgendwas an der Frau war seltsam, und warum fühlte er sich so müde? „Magst du noch ein Biir?“ schwafelte die hünenhafte Fremde weiter, und näherte sich dem Nische, in der Matt sein Biir trank. Träge nahm er wahr, dass sich zwei weitere Gestalten näherten, ihn in die Zange nahmen. Irgendwas musste in dem schalen Gesöff gewesen sein, dass der Wirt ihm hingestellt hatte. Wie kam er nur aus dieser Nummer heraus? Die drei in ein Gespräch verwickeln – in der Hoffnung, dass seine Freunde rechtzeitig von ihrer Erkundungstour zurückkamen oder eine rasante Flucht nach vorn, in der Hoffnung die Fremden austricksen zu können. Oder vielleicht eine Ablenkung, mit der Ruf nach einem Mahl?</p>
             <p class="mb-4">Entscheide selbst, wie es weiter geht. Dies ist die Essenz des Rollenspiels: Eine interaktive Geschichte erleben – eine Geschichte in der abenteuerlichen Welt von Matt Drax, Aruula und ihren Freunden! Wenn Du mehr wissen möchtest, oder es spannend findest, die Welt von Maddrax bespielbar zu machen, melde ich einfach!</p>
             <p class="mb-4">

--- a/resources/views/pages/chronik.blade.php
+++ b/resources/views/pages/chronik.blade.php
@@ -6,7 +6,7 @@
                 <div class="absolute -left-[25px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">20. Mai 2023</time>
                 <p class="mt-2">Der Verein <strong>Offizieller MADDRAX Fanclub</strong> wird gegründet. Die erste Version der Satzung wird beschlossen. 14 Gründungsmitglieder unterschreiben das Gründungsprotokoll und die Satzung. Holger wird zum 1. Vorsitzenden und Marko zum 2. Vorsitzenden gewählt. Zum Kassenwart wird Sebastian berufen.</p>
-                <img src="{{ asset('images/chronik/gruendungsversammlung.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Gründungsversammlung in Berlin 2023">
+                <img loading="lazy" src="{{ asset('images/chronik/gruendungsversammlung.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Gründungsversammlung in Berlin 2023">
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
@@ -27,7 +27,7 @@
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">11. Mai 2024</time>
                 <p class="mt-2">Bei der ersten Jahreshauptversammlung wird ein neuer 2. Vorsitzender gewählt. Außerdem wird beschlossen, dass der Verein zukünftig das Fanhörbuch-Projekt EARDRAX übernehmen und unterstützen wird.</p>
-                <img src="{{ asset('images/chronik/jahreshauptversammlung2024.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
+                <img loading="lazy" src="{{ asset('images/chronik/jahreshauptversammlung2024.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
@@ -48,25 +48,25 @@
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">7. Februar 2025</time>
                 <p class="mt-2">In Aachen beginnt die erste MaddraxCon, die durch den Verein organisiert wurde mit einem Icebreaker bei feinstem Absinth</p>
-                <img src="{{ asset('images/chronik/maddraxcon2025-1.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
+                <img loading="lazy" src="{{ asset('images/chronik/maddraxcon2025-1.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">8. Februar 2025</time>
                 <p class="mt-2">Im Jugendhaus St. Hubertus in Aachen, findet der zweite Tag der MaddraxCon zum 25jährigen Jubiläum der Heftserie statt. Gleichzeitig erscheint der <a href="https://de.maddraxikon.com/index.php?title=Quelle:MX654" target="_blank" class="text-blue-600 hover:underline">Jubiläumsband 654 "Metamorphose"</a> von <a href="https://de.maddraxikon.com/index.php?title=Oliver_M%C3%BCller" target="_blank" class="text-blue-600 hover:underline">Oliver Müller</a>, dessen Handlung passend zur Con ebenfalls in Aachen (Aarachne) spielt. An der Con nehmen Chefredakteur Michael "Mad Mike" Schönenbröcher und die Autoren Sascha Vennemann, Michael Edelbrock und Oliver Müller teil. Zeitgleich mit der Premiere auf Youtube wird den Conbesuchern der erste <a href="https://youtu.be/KfEpStNLYuM?si=oqNu66wsEt_ZYfux" target="_blank" class="text-blue-600 hover:underline">Maddrax-Film "Der Kristall"</a> der Kurzfilmschmiede gezeigt.</p>
-                <img src="{{ asset('images/chronik/maddraxcon2025-2.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
+                <img loading="lazy" src="{{ asset('images/chronik/maddraxcon2025-2.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">9. Februar 2025</time>
                 <p class="mt-2">Mit der Jahreshauptversammlung endet die MaddraxCon in Aachen. Der Verein begrüßt die neuen Mitglieder und hat aktuell 34 Vereinsmitglieder. Jo Zybell und Ian Rolf Hill werden als Ehrenmitglieder aufgenommen.</p>
-                <img src="{{ asset('images/chronik/jahreshauptversammlung2025.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
+                <img loading="lazy" src="{{ asset('images/chronik/jahreshauptversammlung2025.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">7. August 2025</time>
                 <p class="mt-2">Der MADDRAX-Regionalstammtisch Berlin-Brandenburg findet zum ersten Mal statt.</p>
-                <img src="{{ asset('images/chronik/regionalstammtischbbb1.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Teilnehmer des ersten MADDRAX-Regionalstammtischs Berlin-Brandenburg 2025">
+                <img loading="lazy" src="{{ asset('images/chronik/regionalstammtischbbb1.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Teilnehmer des ersten MADDRAX-Regionalstammtischs Berlin-Brandenburg 2025">
             </div>
             <!-- Weitere Ereignisse analog ergänzen -->
         </div>

--- a/resources/views/pages/ehrenmitglieder.blade.php
+++ b/resources/views/pages/ehrenmitglieder.blade.php
@@ -12,7 +12,7 @@
                 class="bg-white dark:bg-gray-700 rounded-lg shadow-md overflow-hidden transition-transform hover:scale-105 flex flex-col">
                 <div class="h-80 bg-gray-200 dark:bg-gray-600 flex items-center justify-center overflow-hidden">
                     <!-- Angepasstes Seitenverhältnis für Portraitfotos -->
-                    <img src="{{ asset('images/ehrenmitglieder/michael-edelbrock.jpg') }}" alt="Michael Edelbrock"
+                    <img loading="lazy" src="{{ asset('images/ehrenmitglieder/michael-edelbrock.jpg') }}" alt="Michael Edelbrock"
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
@@ -42,7 +42,7 @@
             <div
                 class="bg-white dark:bg-gray-700 rounded-lg shadow-md overflow-hidden transition-transform hover:scale-105 flex flex-col">
                 <div class="h-80 bg-gray-200 dark:bg-gray-600 flex items-center justify-center overflow-hidden">
-                    <img src="{{ asset('images/ehrenmitglieder/lucy-guth.jpg') }}" alt="Lucy Guth"
+                    <img loading="lazy" src="{{ asset('images/ehrenmitglieder/lucy-guth.jpg') }}" alt="Lucy Guth"
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
@@ -68,7 +68,7 @@
             <div
                 class="bg-white dark:bg-gray-700 rounded-lg shadow-md overflow-hidden transition-transform hover:scale-105 flex flex-col">
                 <div class="h-80 bg-gray-200 dark:bg-gray-600 flex items-center justify-center overflow-hidden">
-                    <img src="{{ asset('images/ehrenmitglieder/ian-rolf-hill.jpg') }}" alt="Ian Rolf Hill"
+                    <img loading="lazy" src="{{ asset('images/ehrenmitglieder/ian-rolf-hill.jpg') }}" alt="Ian Rolf Hill"
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
@@ -93,7 +93,7 @@
             <div
                 class="bg-white dark:bg-gray-700 rounded-lg shadow-md overflow-hidden transition-transform hover:scale-105 flex flex-col">
                 <div class="h-80 bg-gray-200 dark:bg-gray-600 flex items-center justify-center overflow-hidden">
-                    <img src="{{ asset('images/ehrenmitglieder/oliver-mueller.jpg') }}" alt="Oliver Müller"
+                    <img loading="lazy" src="{{ asset('images/ehrenmitglieder/oliver-mueller.jpg') }}" alt="Oliver Müller"
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
@@ -117,7 +117,7 @@
             <div
                 class="bg-white dark:bg-gray-700 rounded-lg shadow-md overflow-hidden transition-transform hover:scale-105 flex flex-col">
                 <div class="h-80 bg-gray-200 dark:bg-gray-600 flex items-center justify-center overflow-hidden">
-                    <img src="{{ asset('images/ehrenmitglieder/michael-schoenenbröcher.jpg') }}"
+                    <img loading="lazy" src="{{ asset('images/ehrenmitglieder/michael-schoenenbröcher.jpg') }}"
                         alt="Michael Schönenbröcher" class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">
@@ -143,7 +143,7 @@
             <div
                 class="bg-white dark:bg-gray-700 rounded-lg shadow-md overflow-hidden transition-transform hover:scale-105 flex flex-col">
                 <div class="h-80 bg-gray-200 dark:bg-gray-600 flex items-center justify-center overflow-hidden">
-                    <img src="{{ asset('images/ehrenmitglieder/jo-zybell.jpg') }}" alt="Jo Zybell"
+                    <img loading="lazy" src="{{ asset('images/ehrenmitglieder/jo-zybell.jpg') }}" alt="Jo Zybell"
                         class="object-cover h-full">
                 </div>
                 <div class="p-4 flex flex-col flex-1">

--- a/resources/views/pages/fotogalerie.blade.php
+++ b/resources/views/pages/fotogalerie.blade.php
@@ -37,7 +37,7 @@
                     <!-- Hauptbild-Container -->
                     <div class="main-image-container h-64 sm:h-80 md:h-96 lg:h-[500px] flex items-center justify-center mb-4 bg-gray-200 dark:bg-gray-700 rounded-lg overflow-hidden">
                         @if(isset($photos[$year]) && count($photos[$year]) > 0)
-                            <img src="{{ $photos[$year][0] }}" alt="Foto {{ $year }}" class="main-image object-contain max-h-full max-w-full">
+                            <img loading="lazy" src="{{ $photos[$year][0] }}" alt="Foto {{ $year }}" class="main-image object-contain max-h-full max-w-full">
                         @else
                             <div class="text-gray-500 dark:text-gray-400">Keine Fotos für {{ $year }} verfügbar</div>
                         @endif
@@ -54,7 +54,7 @@
                 <div class="thumbnails-container flex overflow-x-auto gap-2 pb-2 mt-4">
                     @if(isset($photos[$year]))
                         @foreach($photos[$year] as $index => $photoUrl)
-                            <img 
+                            <img loading="lazy" 
                                 src="{{ $photoUrl }}" 
                                 alt="Thumbnail {{ $index + 1 }}" 
                                 class="thumbnail h-20 w-auto object-cover cursor-pointer rounded {{ $index === 0 ? 'ring-2 ring-[#8B0116] dark:ring-[#ff4b63]' : '' }}"

--- a/resources/views/pages/fotogalerie.blade.php
+++ b/resources/views/pages/fotogalerie.blade.php
@@ -37,7 +37,7 @@
                     <!-- Hauptbild-Container -->
                     <div class="main-image-container h-64 sm:h-80 md:h-96 lg:h-[500px] flex items-center justify-center mb-4 bg-gray-200 dark:bg-gray-700 rounded-lg overflow-hidden">
                         @if(isset($photos[$year]) && count($photos[$year]) > 0)
-                            <img loading="lazy" src="{{ $photos[$year][0] }}" alt="Foto {{ $year }}" class="main-image object-contain max-h-full max-w-full">
+                            <img src="{{ $photos[$year][0] }}" alt="Foto {{ $year }}" class="main-image object-contain max-h-full max-w-full">
                         @else
                             <div class="text-gray-500 dark:text-gray-400">Keine Fotos für {{ $year }} verfügbar</div>
                         @endif
@@ -54,9 +54,9 @@
                 <div class="thumbnails-container flex overflow-x-auto gap-2 pb-2 mt-4">
                     @if(isset($photos[$year]))
                         @foreach($photos[$year] as $index => $photoUrl)
-                            <img loading="lazy" 
-                                src="{{ $photoUrl }}" 
-                                alt="Thumbnail {{ $index + 1 }}" 
+                            <img @if($index > 0) loading="lazy" @endif
+                                src="{{ $photoUrl }}"
+                                alt="Thumbnail {{ $index + 1 }}"
                                 class="thumbnail h-20 w-auto object-cover cursor-pointer rounded {{ $index === 0 ? 'ring-2 ring-[#8B0116] dark:ring-[#ff4b63]' : '' }}"
                                 data-index="{{ $index }}"
                             >

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -7,7 +7,7 @@
             <div class="md:col-span-2 bg-white dark:bg-gray-700 rounded-lg shadow-md overflow-hidden">
                 <div id="gallery" class="relative w-full h-48 sm:h-64 md:h-72">
                     @foreach($galleryImages as $image)
-                        <img src="{{ asset($image) }}" alt="Foto von einem Treffen des Vereins mit einem Teil der Mitglieder"
+                        <img loading="lazy" src="{{ asset($image) }}" alt="Foto von einem Treffen des Vereins mit einem Teil der Mitglieder"
                             class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-1000">
                     @endforeach
                 </div>

--- a/resources/views/pages/spenden.blade.php
+++ b/resources/views/pages/spenden.blade.php
@@ -8,7 +8,7 @@
             <input type="hidden" name="no_recurring" value="0" />
             <input type="hidden" name="currency_code" value="EUR" />
             <input type="image" src="https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donateCC_LG.gif" name="submit" alt="Spenden mit PayPal" class="w-48" />
-            <img loading="lazy" alt="" src="https://www.paypal.com/en_DE/i/scr/pixel.gif" width="1" height="1" />
+            <img alt="" src="https://www.paypal.com/en_DE/i/scr/pixel.gif" width="1" height="1" />
         </form>
     </x-public-page>
 </x-app-layout>

--- a/resources/views/pages/spenden.blade.php
+++ b/resources/views/pages/spenden.blade.php
@@ -8,7 +8,7 @@
             <input type="hidden" name="no_recurring" value="0" />
             <input type="hidden" name="currency_code" value="EUR" />
             <input type="image" src="https://www.paypalobjects.com/de_DE/DE/i/btn/btn_donateCC_LG.gif" name="submit" alt="Spenden mit PayPal" class="w-48" />
-            <img alt="" src="https://www.paypal.com/en_DE/i/scr/pixel.gif" width="1" height="1" />
+            <img loading="lazy" alt="" src="https://www.paypal.com/en_DE/i/scr/pixel.gif" width="1" height="1" />
         </form>
     </x-public-page>
 </x-app-layout>

--- a/resources/views/profile/update-profile-information-form.blade.php
+++ b/resources/views/profile/update-profile-information-form.blade.php
@@ -23,7 +23,7 @@
                 <x-label for="photo" value="{{ __('Foto') }}" />
 
                 <div class="mt-2" x-show="! photoPreview">
-                    <img src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}"
+                    <img loading="lazy" src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}"
                         class="rounded-full size-20 object-cover">
                 </div>
 

--- a/resources/views/profile/view.blade.php
+++ b/resources/views/profile/view.blade.php
@@ -7,7 +7,7 @@
                     <div class="absolute left-8 bottom-0 transform translate-y-1/2">
                         <div
                             class="h-36 w-36 border-4 border-white dark:border-gray-800 rounded-full overflow-hidden shadow-xl">
-                            <img class="h-full w-full object-cover" src="{{ $user->profile_photo_url }}"
+                            <img loading="lazy" class="h-full w-full object-cover" src="{{ $user->profile_photo_url }}"
                                 alt="{{ $user->name }}">
                         </div>
                     </div>
@@ -53,7 +53,7 @@
                                             <div class="flex flex-col items-center">
                                                 <div class="h-20 w-20 mb-2 cursor-pointer hover:opacity-90 transition-opacity"
                                                     onclick="openBadgeModal('{{ $badge['name'] }}', '{{ $badge['description'] }}', '{{ $badge['image'] }}')">
-                                                    <img src="{{ $badge['image'] }}" alt="{{ $badge['name'] }}" class="w-full">
+                                                    <img loading="lazy" src="{{ $badge['image'] }}" alt="{{ $badge['name'] }}" class="w-full">
                                                 </div>
                                                 <h3 class="text-sm font-medium text-gray-800 dark:text-white text-center">
                                                     {{ $badge['name'] }}
@@ -258,7 +258,7 @@
                 <div class="p-6">
                     <div class="flex justify-center mb-6">
                         <div class="w-128 h-128">
-                            <img id="badgeModalImage" src="" alt="Badge" class="w-full h-full object-contain">
+                            <img loading="lazy" id="badgeModalImage" src="" alt="Badge" class="w-full h-full object-contain">
                         </div>
                     </div>
                     <p id="badgeModalDescription" class="text-base text-gray-700 dark:text-gray-300 text-center"></p>

--- a/resources/views/teams/create-team-form.blade.php
+++ b/resources/views/teams/create-team-form.blade.php
@@ -12,7 +12,7 @@
             <x-label value="{{ __('Team Owner') }}" />
 
             <div class="flex items-center mt-2">
-                <img class="size-12 rounded-full object-cover" src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}">
+                <img loading="lazy" class="size-12 rounded-full object-cover" src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}">
 
                 <div class="ms-4 leading-tight">
                     <div class="text-gray-900 dark:text-white">{{ $this->user->name }}</div>

--- a/resources/views/teams/team-member-manager.blade.php
+++ b/resources/views/teams/team-member-manager.blade.php
@@ -133,7 +133,7 @@
                         @foreach ($team->users->sortBy('name') as $user)
                             <div class="flex items-center justify-between">
                             <a href="{{ route('profile.view', $user->id) }}" class="flex items-center">
-                                <img class="size-8 rounded-full object-cover" src="{{ $user->profile_photo_url }}" alt="{{ $user->name }}">
+                                <img loading="lazy" class="size-8 rounded-full object-cover" src="{{ $user->profile_photo_url }}" alt="{{ $user->name }}">
                                 <div class="ms-4 dark:text-white">{{ $user->name }}</div>
                             </a>
 

--- a/resources/views/teams/update-team-name-form.blade.php
+++ b/resources/views/teams/update-team-name-form.blade.php
@@ -13,7 +13,7 @@
             <x-label value="{{ __('Team Owner') }}" />
 
             <div class="flex items-center mt-2">
-                <img class="size-12 rounded-full object-cover" src="{{ $team->owner->profile_photo_url }}" alt="{{ $team->owner->name }}">
+                <img loading="lazy" class="size-12 rounded-full object-cover" src="{{ $team->owner->profile_photo_url }}" alt="{{ $team->owner->name }}">
 
                 <div class="ms-4 leading-tight">
                     <div class="text-gray-900 dark:text-white">{{ $team->owner->name }}</div>


### PR DESCRIPTION
This pull request improves the website's performance and user experience by enabling lazy loading for images across multiple Blade view files. Lazy loading defers the loading of images until they are needed (i.e., when they enter the viewport), which helps reduce initial page load times and bandwidth usage, especially on pages with many images.

**Performance optimization (lazy loading for images):**

* Added the `loading="lazy"` attribute to all user profile images in `dashboard.blade.php`, `kassenbuch/index.blade.php`, and `mitglieder/index.blade.php`, ensuring member and top user images are loaded only when needed. [[1]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324L110-R126) [[2]](diffhunk://#diff-7aa2df5a0e171b930924e672154d21c4cb3a17e8db06c3457b7119a9d20f1e99L103-R103) [[3]](diffhunk://#diff-b66ed4d712d9f70d89687b73abd82ab56302891704f63a17b20b53540cf23a39L236-R236) [[4]](diffhunk://#diff-b66ed4d712d9f70d89687b73abd82ab56302891704f63a17b20b53540cf23a39L405-R405)
* Enabled lazy loading for all Arbeitsgruppen (working group) logos in `pages/arbeitsgruppen.blade.php`, covering Maddraxikon, EARDRAX, Mapdrax, and Rollenspiel sections. [[1]](diffhunk://#diff-abbd27ea037503a88cfe3aeb532cfc36556444c61a30cbe54ba5e3adcb9bbf63L8-R8) [[2]](diffhunk://#diff-abbd27ea037503a88cfe3aeb532cfc36556444c61a30cbe54ba5e3adcb9bbf63L29-R29) [[3]](diffhunk://#diff-abbd27ea037503a88cfe3aeb532cfc36556444c61a30cbe54ba5e3adcb9bbf63L48-R48) [[4]](diffhunk://#diff-abbd27ea037503a88cfe3aeb532cfc36556444c61a30cbe54ba5e3adcb9bbf63L62-R62)
* Updated all event and chronicle images in `pages/chronik.blade.php` to use lazy loading, improving timeline page performance. [[1]](diffhunk://#diff-bb434894e444423fd79f18bf2b83c3f9279cfbbf3e5aa5362f3cd7dc59d2aedfL9-R9) [[2]](diffhunk://#diff-bb434894e444423fd79f18bf2b83c3f9279cfbbf3e5aa5362f3cd7dc59d2aedfL30-R30) [[3]](diffhunk://#diff-bb434894e444423fd79f18bf2b83c3f9279cfbbf3e5aa5362f3cd7dc59d2aedfL51-R69)
* Applied lazy loading to all portrait images of honorary members in `pages/ehrenmitglieder.blade.php`. [[1]](diffhunk://#diff-8abbe673dfbe72e5d81b751766384e0514d2e8ce8ea7ccb6eca124c40621bb6aL15-R15) [[2]](diffhunk://#diff-8abbe673dfbe72e5d81b751766384e0514d2e8ce8ea7ccb6eca124c40621bb6aL45-R45) [[3]](diffhunk://#diff-8abbe673dfbe72e5d81b751766384e0514d2e8ce8ea7ccb6eca124c40621bb6aL71-R71) [[4]](diffhunk://#diff-8abbe673dfbe72e5d81b751766384e0514d2e8ce8ea7ccb6eca124c40621bb6aL96-R96) [[5]](diffhunk://#diff-8abbe673dfbe72e5d81b751766384e0514d2e8ce8ea7ccb6eca124c40621bb6aL120-R120) [[6]](diffhunk://#diff-8abbe673dfbe72e5d81b751766384e0514d2e8ce8ea7ccb6eca124c40621bb6aL146-R146)

These changes are purely presentational and do not affect any backend logic or data handling.