### PR TITLE
docs: distinguish JS and PHP coverage badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![Laravel 12](https://img.shields.io/badge/laravel-12-red?logo=laravel&style=flat)
 ![PHP 8.4](https://img.shields.io/badge/php-%5E8.2-blue?logo=php)
 [![Build & Deploy](https://github.com/mcnamara84/omxfc-vereinswebseite/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/mcnamara84/omxfc-vereinswebseite/actions/workflows/deploy.yml)
-![JS Coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/js-coverage.svg)
-![PHP Coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/php-coverage.svg)
+![JS coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/js-coverage.svg)
+![PHP coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/php-coverage.svg)
 [![License](https://img.shields.io/badge/license-GPLv3-green)](https://github.com/mcnamara84/omxfc-vereinswebseite/blob/main/LICENSE)
 
 Eine Laravel 12 Anwendung für die Vereinswebseite des OMFXC.


### PR DESCRIPTION
## Summary
- clarify README coverage badges for JS and PHP

## Testing
- `npm test`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6898a290bca4832e80f68ca54f8fc794