### PR TITLE
test: expand Jest coverage for maddraxiversum module

### DIFF
--- a/tests/Jest/maddraxiversum.test.js
+++ b/tests/Jest/maddraxiversum.test.js
@@ -65,6 +65,13 @@ describe('maddraxiversum', () => {
     expect(calculateBearing([0, 0], [0, -1])).toBeCloseTo(270);
   });
 
+  test('calculateBearing handles identical points and dateline crossings', () => {
+    const { calculateBearing } = mod;
+    expect(calculateBearing([0, 0], [0, 0])).toBeCloseTo(0);
+    expect(calculateBearing([10, 170], [10, -170])).toBeCloseTo(88.246, 3);
+    expect(calculateBearing([-10, -170], [-10, 170])).toBeCloseTo(268.246, 3);
+  });
+
   test('openMissionModal populates and shows modal', () => {
     const { openMissionModal } = mod;
     const mission = { name: 'Test', description: 'Desc', mission_duration: 10 };
@@ -77,6 +84,16 @@ describe('maddraxiversum', () => {
     const modalEl = document.getElementById('mission-modal');
     expect(modalEl.classList.contains('flex')).toBe(true);
     expect(modalEl.classList.contains('hidden')).toBe(false);
+  });
+
+  test('close button hides mission modal', () => {
+    const { openMissionModal } = mod;
+    const mission = { name: 'Test', description: 'Desc', mission_duration: 10 };
+    openMissionModal(mission);
+    const modalEl = document.getElementById('mission-modal');
+    document.getElementById('close-mission-modal').click();
+    expect(modalEl.classList.contains('hidden')).toBe(true);
+    expect(modalEl.classList.contains('flex')).toBe(false);
   });
 
   test('animateGlider moves marker along path and cleans up', async () => {


### PR DESCRIPTION
This pull request adds new test cases to improve coverage and robustness for the `maddraxiversum` module. The main changes are the addition of tests for edge cases in the `calculateBearing` function and for the mission modal's close button functionality.

**Test coverage improvements:**

* Added tests to `calculateBearing` for handling identical points and dateline crossings, ensuring the function behaves correctly in these edge cases.

**Mission modal functionality:**

* Added a test to verify that clicking the close button on the mission modal properly hides the modal and removes the `flex` class.