### PR TITLE
Increase JavaScript test coverage

### DIFF
--- a/tests/Jest/bootstrap.test.js
+++ b/tests/Jest/bootstrap.test.js
@@ -1,0 +1,15 @@
+import { jest } from '@jest/globals';
+
+describe('bootstrap module', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('sets global axios instance with default header', async () => {
+    const mockAxios = { defaults: { headers: { common: {} } } };
+    await jest.unstable_mockModule('axios', () => ({ default: mockAxios }));
+    await import('../../resources/js/bootstrap.js');
+    expect(window.axios).toBe(mockAxios);
+    expect(mockAxios.defaults.headers.common['X-Requested-With']).toBe('XMLHttpRequest');
+  });
+});

--- a/tests/Jest/bootstrap.test.js
+++ b/tests/Jest/bootstrap.test.js
@@ -1,5 +1,9 @@
 import { jest } from '@jest/globals';
 
+// Using jest.unstable_mockModule because Jest's stable mock API currently
+// lacks full support for mocking ES modules loaded via dynamic import.
+// This enables us to intercept the axios dependency in the bootstrap module.
+
 describe('bootstrap module', () => {
   beforeEach(() => {
     jest.resetModules();

--- a/tests/Jest/changelog.test.js
+++ b/tests/Jest/changelog.test.js
@@ -1,0 +1,44 @@
+import { jest } from '@jest/globals';
+
+describe('changelog module', () => {
+  let domContentLoaded;
+  const originalAdd = document.addEventListener;
+
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '';
+    global.fetch = jest.fn();
+    document.addEventListener = jest.fn((event, cb) => {
+      if (event === 'DOMContentLoaded') domContentLoaded = cb;
+    });
+  });
+
+  afterEach(() => {
+    document.addEventListener = originalAdd;
+  });
+
+  test('renders releases into container', async () => {
+    document.body.innerHTML = '<div id="release-notes"></div>';
+    global.fetch.mockResolvedValue({
+      json: () => Promise.resolve([
+        {
+          version: '1.0.0',
+          pub_date: '2024-01-02',
+          notes: ['[New] Feature added', 'Misc note'],
+        },
+      ]),
+    });
+    await import('../../resources/js/changelog.js');
+    await domContentLoaded();
+    expect(global.fetch).toHaveBeenCalledWith('/changelog.json');
+    const container = document.getElementById('release-notes');
+    expect(container.querySelectorAll('section').length).toBe(1);
+  });
+
+  test('does nothing when container missing', async () => {
+    document.body.innerHTML = '<div id="other"></div>';
+    await import('../../resources/js/changelog.js');
+    await domContentLoaded();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This pull request adds new Jest test suites for the `bootstrap.js` and `changelog.js` modules, improving test coverage and reliability for these critical frontend scripts. The tests ensure that global setup and DOM manipulation behaviors are correctly implemented and verified.

**New test coverage:**

* Added a test suite for `bootstrap.js` to verify that the global `axios` instance is set up with the correct default header (`X-Requested-With: XMLHttpRequest`).

* Added a test suite for `changelog.js` to check that release notes are fetched and rendered into the DOM when the container exists, and that no fetch occurs when the container is missing.