### PR TITLE
Add clickable Chronik images with AVIF/WEBP support

### DIFF
--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -45,11 +45,11 @@ class PageController extends Controller
         ];
 
         $galleryImages = [
-            'images/chronik/gruendungsversammlung.jpg',
-            'images/chronik/jahreshauptversammlung2024.jpg',
-            'images/chronik/jahreshauptversammlung2025.jpg',
-            'images/chronik/maddraxcon2025-1.jpg',
-            'images/chronik/maddraxcon2025-2.jpg',
+            'images/chronik/gruendungsversammlung',
+            'images/chronik/jahreshauptversammlung2024',
+            'images/chronik/jahreshauptversammlung2025',
+            'images/chronik/maddraxcon2025-1',
+            'images/chronik/maddraxcon2025-2',
             // Weitere Bilder hier einfügen
         ];
 

--- a/resources/views/pages/chronik.blade.php
+++ b/resources/views/pages/chronik.blade.php
@@ -6,7 +6,13 @@
                 <div class="absolute -left-[25px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">20. Mai 2023</time>
                 <p class="mt-2">Der Verein <strong>Offizieller MADDRAX Fanclub</strong> wird gegründet. Die erste Version der Satzung wird beschlossen. 14 Gründungsmitglieder unterschreiben das Gründungsprotokoll und die Satzung. Holger wird zum 1. Vorsitzenden und Marko zum 2. Vorsitzenden gewählt. Zum Kassenwart wird Sebastian berufen.</p>
-                <img loading="lazy" src="{{ asset('images/chronik/gruendungsversammlung.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Gründungsversammlung in Berlin 2023">
+                <a href="#" class="chronik-image block mt-3 max-w-xs rounded-md shadow cursor-pointer" data-avif="{{ asset('images/chronik/gruendungsversammlung.avif') }}" data-webp="{{ asset('images/chronik/gruendungsversammlung.webp') }}">
+                    <picture>
+                        <source type="image/avif" srcset="{{ asset('images/chronik/gruendungsversammlung.avif') }}">
+                        <source type="image/webp" srcset="{{ asset('images/chronik/gruendungsversammlung.webp') }}">
+                        <img loading="lazy" src="{{ asset('images/chronik/gruendungsversammlung.webp') }}" class="rounded-md" alt="Gründungsversammlung in Berlin 2023">
+                    </picture>
+                </a>
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
@@ -27,7 +33,13 @@
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">11. Mai 2024</time>
                 <p class="mt-2">Bei der ersten Jahreshauptversammlung wird ein neuer 2. Vorsitzender gewählt. Außerdem wird beschlossen, dass der Verein zukünftig das Fanhörbuch-Projekt EARDRAX übernehmen und unterstützen wird.</p>
-                <img loading="lazy" src="{{ asset('images/chronik/jahreshauptversammlung2024.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
+                <a href="#" class="chronik-image block mt-3 max-w-xs rounded-md shadow cursor-pointer" data-avif="{{ asset('images/chronik/jahreshauptversammlung2024.avif') }}" data-webp="{{ asset('images/chronik/jahreshauptversammlung2024.webp') }}">
+                    <picture>
+                        <source type="image/avif" srcset="{{ asset('images/chronik/jahreshauptversammlung2024.avif') }}">
+                        <source type="image/webp" srcset="{{ asset('images/chronik/jahreshauptversammlung2024.webp') }}">
+                        <img loading="lazy" src="{{ asset('images/chronik/jahreshauptversammlung2024.webp') }}" class="rounded-md" alt="Jahreshauptversammlung in Aachen 2025">
+                    </picture>
+                </a>
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
@@ -48,27 +60,93 @@
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">7. Februar 2025</time>
                 <p class="mt-2">In Aachen beginnt die erste MaddraxCon, die durch den Verein organisiert wurde mit einem Icebreaker bei feinstem Absinth</p>
-                <img loading="lazy" src="{{ asset('images/chronik/maddraxcon2025-1.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
+                <a href="#" class="chronik-image block mt-3 max-w-xs rounded-md shadow cursor-pointer" data-avif="{{ asset('images/chronik/maddraxcon2025-1.avif') }}" data-webp="{{ asset('images/chronik/maddraxcon2025-1.webp') }}">
+                    <picture>
+                        <source type="image/avif" srcset="{{ asset('images/chronik/maddraxcon2025-1.avif') }}">
+                        <source type="image/webp" srcset="{{ asset('images/chronik/maddraxcon2025-1.webp') }}">
+                        <img loading="lazy" src="{{ asset('images/chronik/maddraxcon2025-1.webp') }}" class="rounded-md" alt="Jahreshauptversammlung in Aachen 2025">
+                    </picture>
+                </a>
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">8. Februar 2025</time>
                 <p class="mt-2">Im Jugendhaus St. Hubertus in Aachen, findet der zweite Tag der MaddraxCon zum 25jährigen Jubiläum der Heftserie statt. Gleichzeitig erscheint der <a href="https://de.maddraxikon.com/index.php?title=Quelle:MX654" target="_blank" class="text-blue-600 hover:underline">Jubiläumsband 654 "Metamorphose"</a> von <a href="https://de.maddraxikon.com/index.php?title=Oliver_M%C3%BCller" target="_blank" class="text-blue-600 hover:underline">Oliver Müller</a>, dessen Handlung passend zur Con ebenfalls in Aachen (Aarachne) spielt. An der Con nehmen Chefredakteur Michael "Mad Mike" Schönenbröcher und die Autoren Sascha Vennemann, Michael Edelbrock und Oliver Müller teil. Zeitgleich mit der Premiere auf Youtube wird den Conbesuchern der erste <a href="https://youtu.be/KfEpStNLYuM?si=oqNu66wsEt_ZYfux" target="_blank" class="text-blue-600 hover:underline">Maddrax-Film "Der Kristall"</a> der Kurzfilmschmiede gezeigt.</p>
-                <img loading="lazy" src="{{ asset('images/chronik/maddraxcon2025-2.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
+                <a href="#" class="chronik-image block mt-3 max-w-xs rounded-md shadow cursor-pointer" data-avif="{{ asset('images/chronik/maddraxcon2025-2.avif') }}" data-webp="{{ asset('images/chronik/maddraxcon2025-2.webp') }}">
+                    <picture>
+                        <source type="image/avif" srcset="{{ asset('images/chronik/maddraxcon2025-2.avif') }}">
+                        <source type="image/webp" srcset="{{ asset('images/chronik/maddraxcon2025-2.webp') }}">
+                        <img loading="lazy" src="{{ asset('images/chronik/maddraxcon2025-2.webp') }}" class="rounded-md" alt="Jahreshauptversammlung in Aachen 2025">
+                    </picture>
+                </a>
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">9. Februar 2025</time>
                 <p class="mt-2">Mit der Jahreshauptversammlung endet die MaddraxCon in Aachen. Der Verein begrüßt die neuen Mitglieder und hat aktuell 34 Vereinsmitglieder. Jo Zybell und Ian Rolf Hill werden als Ehrenmitglieder aufgenommen.</p>
-                <img loading="lazy" src="{{ asset('images/chronik/jahreshauptversammlung2025.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Jahreshauptversammlung in Aachen 2025">
+                <a href="#" class="chronik-image block mt-3 max-w-xs rounded-md shadow cursor-pointer" data-avif="{{ asset('images/chronik/jahreshauptversammlung2025.avif') }}" data-webp="{{ asset('images/chronik/jahreshauptversammlung2025.webp') }}">
+                    <picture>
+                        <source type="image/avif" srcset="{{ asset('images/chronik/jahreshauptversammlung2025.avif') }}">
+                        <source type="image/webp" srcset="{{ asset('images/chronik/jahreshauptversammlung2025.webp') }}">
+                        <img loading="lazy" src="{{ asset('images/chronik/jahreshauptversammlung2025.webp') }}" class="rounded-md" alt="Jahreshauptversammlung in Aachen 2025">
+                    </picture>
+                </a>
             </div>
             <div class="relative">
                 <div class="absolute -left-[20px] top-2 bg-[#8B0116] dark:bg-[#ff4b63] rounded-full w-3 h-3"></div>
                 <time class="font-semibold text-lg">7. August 2025</time>
                 <p class="mt-2">Der MADDRAX-Regionalstammtisch Berlin-Brandenburg findet zum ersten Mal statt.</p>
-                <img loading="lazy" src="{{ asset('images/chronik/regionalstammtischbbb1.jpg') }}" class="mt-3 rounded-md shadow max-w-xs" alt="Teilnehmer des ersten MADDRAX-Regionalstammtischs Berlin-Brandenburg 2025">
+                <a href="#" class="chronik-image block mt-3 max-w-xs rounded-md shadow cursor-pointer" data-avif="{{ asset('images/chronik/regionalstammtischbbb1.avif') }}" data-webp="{{ asset('images/chronik/regionalstammtischbbb1.webp') }}">
+                    <picture>
+                        <source type="image/avif" srcset="{{ asset('images/chronik/regionalstammtischbbb1.avif') }}">
+                        <source type="image/webp" srcset="{{ asset('images/chronik/regionalstammtischbbb1.webp') }}">
+                        <img loading="lazy" src="{{ asset('images/chronik/regionalstammtischbbb1.webp') }}" class="rounded-md" alt="Teilnehmer des ersten MADDRAX-Regionalstammtischs Berlin-Brandenburg 2025">
+                    </picture>
+                </a>
             </div>
             <!-- Weitere Ereignisse analog ergänzen -->
         </div>
+        <div id="chronik-modal" class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 hidden">
+            <div class="relative">
+                <button id="chronik-modal-close" class="absolute top-2 right-2 text-white text-2xl">&times;</button>
+                <picture>
+                    <source id="chronik-modal-avif" type="image/avif" />
+                    <source id="chronik-modal-webp" type="image/webp" />
+                    <img id="chronik-modal-img" src="" alt="" class="max-w-full max-h-screen rounded-md shadow-lg" />
+                </picture>
+            </div>
+        </div>
+        <script>
+            document.querySelectorAll('.chronik-image').forEach(el => {
+                el.addEventListener('click', e => {
+                    e.preventDefault();
+                    const modal = document.getElementById('chronik-modal');
+                    const img = document.getElementById('chronik-modal-img');
+                    const srcAvif = document.getElementById('chronik-modal-avif');
+                    const srcWebp = document.getElementById('chronik-modal-webp');
+                    srcAvif.srcset = el.dataset.avif;
+                    srcWebp.srcset = el.dataset.webp;
+                    img.src = el.dataset.webp;
+                    img.alt = el.querySelector('img').alt;
+                    modal.classList.remove('hidden');
+                });
+            });
+
+            const modal = document.getElementById('chronik-modal');
+            const closeBtn = document.getElementById('chronik-modal-close');
+            closeBtn.addEventListener('click', () => {
+                modal.classList.add('hidden');
+            });
+            modal.addEventListener('click', e => {
+                if (e.target === modal) {
+                    modal.classList.add('hidden');
+                }
+            });
+            document.addEventListener('keydown', e => {
+                if (e.key === 'Escape') {
+                    modal.classList.add('hidden');
+                }
+            });
+        </script>
     </x-public-page>
 </x-app-layout>

--- a/resources/views/pages/home.blade.php
+++ b/resources/views/pages/home.blade.php
@@ -7,8 +7,12 @@
             <div class="md:col-span-2 bg-white dark:bg-gray-700 rounded-lg shadow-md overflow-hidden">
                 <div id="gallery" class="relative w-full h-48 sm:h-64 md:h-72">
                     @foreach($galleryImages as $image)
-                        <img loading="lazy" src="{{ asset($image) }}" alt="Foto von einem Treffen des Vereins mit einem Teil der Mitglieder"
-                            class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-1000">
+                        <picture>
+                            <source type="image/avif" srcset="{{ asset($image . '.avif') }}" />
+                            <source type="image/webp" srcset="{{ asset($image . '.webp') }}" />
+                            <img loading="lazy" src="{{ asset($image . '.webp') }}" alt="Foto von einem Treffen des Vereins mit einem Teil der Mitglieder"
+                                class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-1000">
+                        </picture>
                     @endforeach
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Serve Chronik and home gallery photos via `<picture>` elements with AVIF and WEBP sources
- Make Chronik timeline photos expandable in a modal overlay

## Testing
- `npm test`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68996da970c0832eae3caf9494635248