### PR TITLE
Chore: Add PHP 8.5 to unit test matrix

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
     
     services:
       mysql:


### PR DESCRIPTION
This pull request updates the PHP version matrix in the unit test workflow configuration to include the upcoming PHP 8.5 release. This ensures that our tests will run against the latest PHP version and helps us proactively catch compatibility issues.Updated the GitHub Actions workflow to include PHP 8.5 in the test matrix, ensuring compatibility and coverage for the latest PHP pre-release version.