### PR TITLE
Add hardcover ratings statistics

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -29,6 +29,12 @@ class StatistikController extends Controller
         }
         $romane = collect(json_decode(file_get_contents($jsonPath), true));
 
+        $hardcoverPath = storage_path('app/private/hardcovers.json');
+        $hardcovers = collect();
+        if (is_readable($hardcoverPath)) {
+            $hardcovers = collect(json_decode(file_get_contents($hardcoverPath), true));
+        }
+
         // ── Card 1 – Grundstatistiken ──────────────────────────────────────────────
         $averageRating = round($romane->avg('bewertung'), 2);
         $totalVotes = $romane->sum('stimmen');
@@ -261,6 +267,11 @@ class StatistikController extends Controller
             return $roman['bewertung'] ?? null;
         });
 
+        // ── Card 28 – Bewertungen der Hardcover ───────────────────
+        $hardcoverCycle = $hardcovers->sortBy('nummer')->take(30);
+        $hardcoverLabels = $hardcoverCycle->pluck('nummer');
+        $hardcoverValues = $hardcoverCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -386,6 +397,8 @@ class StatistikController extends Controller
             'amrakaValues' => $amrakaValues,
             'weltratLabels' => $weltratLabels,
             'weltratValues' => $weltratValues,
+            'hardcoverLabels' => $hardcoverLabels,
+            'hardcoverValues' => $hardcoverValues,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -162,6 +162,11 @@ return [
         'points' => 32,
     ],
     [
+        'title' => 'Statistik - Bewertungen der Hardcover',
+        'description' => 'Zeigt Bewertungen der Hardcover aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 40,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -86,9 +86,12 @@ document.addEventListener('DOMContentLoaded', () => {
         drawCycleChart(`${cycle}Chart`, cycleLabels, cycleValues);
     });
 
-    const hardcoverLabels = window.hardcoverChartLabels ?? [];
-    const hardcoverValues = window.hardcoverChartValues ?? [];
-    drawCycleChart('hardcoverChart', hardcoverLabels, hardcoverValues);
+    const hardcoverCanvas = document.getElementById('hardcoverChart');
+    if (hardcoverCanvas) {
+        const hardcoverLabels = window.hardcoverChartLabels ?? [];
+        const hardcoverValues = window.hardcoverChartValues ?? [];
+        drawCycleChart('hardcoverChart', hardcoverLabels, hardcoverValues);
+    }
 
     initRomaneTable();
 });

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka', 'weltrat'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka', 'weltrat', 'hardcover'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -79,12 +79,16 @@ document.addEventListener('DOMContentLoaded', () => {
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka', 'weltrat', 'hardcover'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka', 'weltrat'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];
         drawCycleChart(`${cycle}Chart`, cycleLabels, cycleValues);
     });
+
+    const hardcoverLabels = window.hardcoverChartLabels ?? [];
+    const hardcoverValues = window.hardcoverChartValues ?? [];
+    drawCycleChart('hardcoverChart', hardcoverLabels, hardcoverValues);
 
     initRomaneTable();
 });

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -556,6 +556,21 @@
                 </script>
             @endif
 
+            {{-- Card 28 – Bewertungen der Hardcover (≥ 40 Baxx) --}}
+            @if ($userPoints >= 40)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen der Hardcover
+                    </h2>
+                    <canvas id="hardcoverChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.hardcoverChartLabels = @json($hardcoverLabels);
+                    window.hardcoverChartValues = @json($hardcoverValues);
+                </script>
+            @endif
+
             @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
             @endif

--- a/tests/Feature/RewardControllerTest.php
+++ b/tests/Feature/RewardControllerTest.php
@@ -61,4 +61,15 @@ class RewardControllerTest extends TestCase
         $this->assertEquals(25, $rewards[1]['percentage']);
         $this->assertEquals(25, $rewards[2]['percentage']);
     }
+
+    public function test_hardcover_reward_visible(): void
+    {
+        $user = $this->actingMember(40);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $response->assertSee('Statistik - Bewertungen der Hardcover');
+    }
 }

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -74,7 +74,7 @@ class StatistikTest extends TestCase
         $data = [];
         for ($i = 1; $i <= 30; $i++) {
             // Start ratings at 3.1 and increment by 0.1 for each hardcover
-            $rating = 3.0 + ($i * 0.1);
+            $rating = 3.1 + (($i - 1) * 0.1); // subtract 1 because loop starts at 1
             $data[] = [
                 'nummer' => $i,
                 'titel' => 'HC' . $i,

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -73,10 +73,12 @@ class StatistikTest extends TestCase
     {
         $data = [];
         for ($i = 1; $i <= 30; $i++) {
+            // Start ratings at 3.1 and increment by 0.1 for each hardcover
+            $rating = 3.0 + ($i * 0.1);
             $data[] = [
                 'nummer' => $i,
                 'titel' => 'HC' . $i,
-                'bewertung' => 3 + $i / 10,
+                'bewertung' => $rating,
             ];
         }
         $path = storage_path('app/private/hardcovers.json');

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -56,4 +56,24 @@ describe('statistik module', () => {
     const instance = mockDataTable.mock.instances[0];
     expect(instance.sortColumn).toHaveBeenCalledWith(3, 'desc');
   });
+
+  test('DOMContentLoaded draws hardcover chart', async () => {
+    jest.resetModules();
+    const chartModule = await import('chart.js/auto');
+    const datatableModule = await import('simple-datatables');
+    const mockChartLocal = chartModule.default;
+    datatableModule.DataTable.mockClear();
+    mockChartLocal.mockClear();
+
+    document.body.innerHTML = '<canvas id="hardcoverChart"></canvas>';
+    window.hardcoverChartLabels = ['1'];
+    window.hardcoverChartValues = [4];
+
+    await import('../../resources/js/statistik.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(mockChartLocal).toHaveBeenCalled();
+    const config = mockChartLocal.mock.calls[0][1];
+    expect(config.type).toBe('line');
+  });
 });

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -61,9 +61,9 @@ describe('statistik module', () => {
     jest.resetModules();
     const chartModule = await import('chart.js/auto');
     const datatableModule = await import('simple-datatables');
-    const mockChartLocal = chartModule.default;
+    mockChart = chartModule.default;
     datatableModule.DataTable.mockClear();
-    mockChartLocal.mockClear();
+    mockChart.mockClear();
 
     document.body.innerHTML = '<canvas id="hardcoverChart"></canvas>';
     window.hardcoverChartLabels = ['1'];
@@ -72,8 +72,8 @@ describe('statistik module', () => {
     await import('../../resources/js/statistik.js');
     document.dispatchEvent(new Event('DOMContentLoaded'));
 
-    expect(mockChartLocal).toHaveBeenCalled();
-    const config = mockChartLocal.mock.calls[0][1];
+    expect(mockChart).toHaveBeenCalled();
+    const config = mockChart.mock.calls[0][1];
     expect(config.type).toBe('line');
   });
 });


### PR DESCRIPTION
This pull request adds a new feature to display ratings of hardcover books in the statistics section, visible to users with at least 40 points. It introduces backend logic to load and process hardcover data, updates the frontend to render a new chart, and includes reward configuration and comprehensive test coverage for the new functionality.

**Hardcover Ratings Feature**

* Added backend logic in `StatistikController.php` to load hardcover ratings from `hardcovers.json`, process the data, and expose it to the view for chart rendering. [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR32-R37) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR270-R274) [[3]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR400-R401)
* Updated frontend files (`index.blade.php` and `statistik.js`) to render a new "Bewertungen der Hardcover" chart for users with ≥40 points and integrated the chart into the cycle chart system. [[1]](diffhunk://#diff-795a31d8f92444380f7cdd19e6c80df1650a2ea058f5f457e77e5fff9f5127f6R559-R573) [[2]](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L82-R82)

**Rewards System**

* Added a new reward in `config/rewards.php` for unlocking the hardcover ratings chart at 40 points.

**Testing**

* Added feature and unit tests to ensure the hardcover chart and reward are correctly visible/unlocked for users with sufficient points, and hidden otherwise. [[1]](diffhunk://#diff-367775f3775fb00da2c433adc54c91953f314ee73ddf58ce2783b03ddf48bde5R64-R74) [[2]](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R72-R90) [[3]](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R527-R552) [[4]](diffhunk://#diff-c1ab8a789a85144dd6be7dd8a4bf876768b20d25912881d36431f07702eb88ebR59-R78)