### PR TITLE
Improve audiobook episode creation flow and date flexibility

### DIFF
--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -61,7 +61,7 @@ class HoerbuchController extends Controller
             'episode_number' => 'required|string|max:10|unique:audiobook_episodes,episode_number',
             'title' => 'required|string|max:255',
             'author' => 'required|string|max:255',
-            'planned_release_date' => 'required|date',
+            'planned_release_date' => ['required', 'string', 'regex:/^(\d{4}-\d{2}-\d{2}|\d{2}\.\d{4}|\d{4})$/'],
             'status' => 'required|in:' . implode(',', AudiobookEpisode::STATUSES),
             'responsible_user_id' => 'nullable|exists:users,id',
             'progress' => 'required|integer|min:0|max:100',
@@ -79,7 +79,7 @@ class HoerbuchController extends Controller
             'notes',
         ]));
 
-        return redirect()->route('hoerbuecher.create')
+        return redirect()->route('hoerbuecher.index')
             ->with('status', 'Hörbuchfolge wurde gespeichert.');
     }
 
@@ -115,7 +115,7 @@ class HoerbuchController extends Controller
             ],
             'title' => 'required|string|max:255',
             'author' => 'required|string|max:255',
-            'planned_release_date' => 'required|date',
+            'planned_release_date' => ['required', 'string', 'regex:/^(\d{4}-\d{2}-\d{2}|\d{2}\.\d{4}|\d{4})$/'],
             'status' => 'required|in:' . implode(',', AudiobookEpisode::STATUSES),
             'responsible_user_id' => 'nullable|exists:users,id',
             'progress' => 'required|integer|min:0|max:100',

--- a/app/Models/AudiobookEpisode.php
+++ b/app/Models/AudiobookEpisode.php
@@ -38,13 +38,6 @@ class AudiobookEpisode extends Model
         'notes',
     ];
 
-    protected function casts(): array
-    {
-        return [
-            'planned_release_date' => 'date',
-        ];
-    }
-
     public function responsible(): BelongsTo
     {
         return $this->belongsTo(User::class, 'responsible_user_id');

--- a/database/migrations/2025_09_16_000000_change_planned_release_date_column_type.php
+++ b/database/migrations/2025_09_16_000000_change_planned_release_date_column_type.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('audiobook_episodes', function (Blueprint $table) {
+            $table->dropColumn('planned_release_date');
+        });
+
+        Schema::table('audiobook_episodes', function (Blueprint $table) {
+            $table->string('planned_release_date')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('audiobook_episodes', function (Blueprint $table) {
+            $table->dropColumn('planned_release_date');
+        });
+
+        Schema::table('audiobook_episodes', function (Blueprint $table) {
+            $table->date('planned_release_date')->nullable();
+        });
+    }
+};
+

--- a/resources/views/hoerbuecher/create.blade.php
+++ b/resources/views/hoerbuecher/create.blade.php
@@ -8,7 +8,7 @@
 
                 <div class="mb-4">
                     <label for="episode_number" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Folgenummer</label>
-                    <input type="text" name="episode_number" id="episode_number" value="{{ old('episode_number') }}" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    <input type="text" name="episode_number" id="episode_number" value="{{ old('episode_number') }}" required class="w-full md:max-w-xs rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                     @error('episode_number')
                         <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                     @enderror
@@ -31,8 +31,8 @@
                 </div>
 
                 <div class="mb-4">
-                    <label for="planned_release_date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Geplantes Veröffentlichungsdatum</label>
-                    <input type="date" name="planned_release_date" id="planned_release_date" value="{{ old('planned_release_date') }}" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    <label for="planned_release_date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Geplanter Veröffentlichungszeitpunkt</label>
+                    <input type="text" name="planned_release_date" id="planned_release_date" value="{{ old('planned_release_date') }}" required placeholder="JJJJ, MM.JJJJ oder JJJJ-MM-TT" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                     @error('planned_release_date')
                         <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                     @enderror

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -9,7 +9,7 @@
 
                 <div class="mb-4">
                     <label for="episode_number" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Folgenummer</label>
-                    <input type="text" name="episode_number" id="episode_number" value="{{ old('episode_number', $episode->episode_number) }}" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    <input type="text" name="episode_number" id="episode_number" value="{{ old('episode_number', $episode->episode_number) }}" required class="w-full md:max-w-xs rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                     @error('episode_number')
                         <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                     @enderror
@@ -32,8 +32,8 @@
                 </div>
 
                 <div class="mb-4">
-                    <label for="planned_release_date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Geplantes Veröffentlichungsdatum</label>
-                    <input type="date" name="planned_release_date" id="planned_release_date" value="{{ old('planned_release_date', $episode->planned_release_date?->format('Y-m-d')) }}" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    <label for="planned_release_date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Geplanter Veröffentlichungszeitpunkt</label>
+                    <input type="text" name="planned_release_date" id="planned_release_date" value="{{ old('planned_release_date', $episode->planned_release_date) }}" required placeholder="JJJJ, MM.JJJJ oder JJJJ-MM-TT" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                     @error('planned_release_date')
                         <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                     @enderror

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -18,7 +18,7 @@
                         <tr>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Folge</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Titel</th>
-                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Ziel-EVT</th>
+                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Geplanter Veröffentlichungszeitpunkt</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Status</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Fortschritt</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Bemerkungen</th>
@@ -31,7 +31,7 @@
                             <tr>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->episode_number }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>
-                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->planned_release_date->format('d.m.Y') }}</td>
+                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->planned_release_date }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->status }}</td>
                                 <td class="px-4 py-2">
                                     <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4">

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -39,7 +39,7 @@ class HoerbuchControllerTest extends TestCase
             'episode_number' => 'F30',
             'title' => 'Test Titel',
             'author' => 'Autor',
-            'planned_release_date' => '2025-12-24',
+            'planned_release_date' => '12.2025',
             'status' => 'Skript wird erstellt',
             'responsible_user_id' => $responsible->id,
             'progress' => 50,
@@ -48,11 +48,12 @@ class HoerbuchControllerTest extends TestCase
 
         $response = $this->actingAs($user)->post(route('hoerbuecher.store'), $data);
 
-        $response->assertRedirect(route('hoerbuecher.create'));
+        $response->assertRedirect(route('hoerbuecher.index'));
         $this->assertDatabaseHas('audiobook_episodes', [
             'episode_number' => 'F30',
             'title' => 'Test Titel',
             'author' => 'Autor',
+            'planned_release_date' => '12.2025',
             'status' => 'Skript wird erstellt',
             'responsible_user_id' => $responsible->id,
             'progress' => 50,
@@ -108,7 +109,7 @@ class HoerbuchControllerTest extends TestCase
             'episode_number' => 'F1',
             'title' => 'Erste Folge',
             'author' => 'Autor',
-            'planned_release_date' => '2025-01-01',
+            'planned_release_date' => '2025',
             'status' => 'Skript wird erstellt',
             'responsible_user_id' => null,
             'progress' => 50,
@@ -119,7 +120,7 @@ class HoerbuchControllerTest extends TestCase
             ->get(route('hoerbuecher.index'))
             ->assertOk()
             ->assertSee('Erste Folge')
-            ->assertSee($episode->planned_release_date->format('d.m.Y'))
+            ->assertSee($episode->planned_release_date)
             ->assertSee('Bemerkung')
             ->assertSee('50%')
             ->assertSee(route('hoerbuecher.create'));
@@ -141,7 +142,7 @@ class HoerbuchControllerTest extends TestCase
             'episode_number' => 'F2',
             'title' => 'Alte Folge',
             'author' => 'Autor',
-            'planned_release_date' => '2025-01-01',
+            'planned_release_date' => '12.2025',
             'status' => 'Skript wird erstellt',
             'responsible_user_id' => null,
             'progress' => 0,
@@ -152,7 +153,7 @@ class HoerbuchControllerTest extends TestCase
             'episode_number' => 'F2',
             'title' => 'Neue Folge',
             'author' => 'Neuer Autor',
-            'planned_release_date' => '2025-02-01',
+            'planned_release_date' => '2025',
             'status' => 'Veröffentlicht',
             'responsible_user_id' => null,
             'progress' => 100,
@@ -168,6 +169,7 @@ class HoerbuchControllerTest extends TestCase
             'title' => 'Neue Folge',
             'author' => 'Neuer Autor',
             'status' => 'Veröffentlicht',
+            'planned_release_date' => '2025',
             'progress' => 100,
             'notes' => 'Aktualisiert',
         ]);


### PR DESCRIPTION
## Summary
- Redirect to the overview after creating a new Hörbuch episode
- Allow flexible release date strings and rename field to "Geplanter Veröffentlichungszeitpunkt"
- Tighten episode number field width and update views to show new release time

## Testing
- `php artisan test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0076972d8832e859ced26588ed11e