### PR TITLE
Add admin-only AG creation

### DIFF
--- a/app/Http/Controllers/ArbeitsgruppenController.php
+++ b/app/Http/Controllers/ArbeitsgruppenController.php
@@ -55,7 +55,7 @@ class ArbeitsgruppenController extends Controller
                 ->where('user_id', $validated['leader_id'])
                 ->first()
             : null;
-        $leaderRole = $membership->role ?? null;
+        $leaderRole = $membership?->role;
 
         $team->users()->attach($validated['leader_id'], ['role' => $leaderRole]);
 

--- a/app/Http/Controllers/ArbeitsgruppenController.php
+++ b/app/Http/Controllers/ArbeitsgruppenController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class ArbeitsgruppenController extends Controller
 {
@@ -48,8 +49,13 @@ class ArbeitsgruppenController extends Controller
 
         // Attach leader to team with existing role if available
         $memberTeam = Team::where('name', 'Mitglieder')->first();
-        $membership = $memberTeam?->users()->where('user_id', $validated['leader_id'])->first();
-        $leaderRole = $membership ? $membership->membership->role : null;
+        $membership = $memberTeam
+            ? DB::table('team_user')
+                ->where('team_id', $memberTeam->id)
+                ->where('user_id', $validated['leader_id'])
+                ->first()
+            : null;
+        $leaderRole = $membership->role ?? null;
 
         $team->users()->attach($validated['leader_id'], ['role' => $leaderRole]);
 

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -35,8 +35,13 @@ class Team extends JetstreamTeam
      * @var array<int, string>
      */
     protected $fillable = [
+        'user_id',
         'name',
         'personal_team',
+        'description',
+        'email',
+        'meeting_schedule',
+        'logo_path',
     ];
 
     /**

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -21,6 +21,10 @@ class TeamFactory extends Factory
             'name' => $this->faker->unique()->company(),
             'user_id' => User::factory(),
             'personal_team' => true,
+            'description' => null,
+            'email' => null,
+            'meeting_schedule' => null,
+            'logo_path' => null,
         ];
     }
 }

--- a/database/migrations/2025_07_30_000000_add_fields_to_teams_table.php
+++ b/database/migrations/2025_07_30_000000_add_fields_to_teams_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->text('description')->nullable();
+            $table->string('email')->nullable();
+            $table->string('meeting_schedule')->nullable();
+            $table->string('logo_path')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropColumn(['description', 'email', 'meeting_schedule', 'logo_path']);
+        });
+    }
+};

--- a/resources/views/arbeitsgruppen/create.blade.php
+++ b/resources/views/arbeitsgruppen/create.blade.php
@@ -53,7 +53,7 @@
 
                 <div class="mb-6">
                     <label for="logo" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Logo</label>
-                    <input type="file" name="logo" id="logo" class="w-full text-gray-700 dark:text-gray-300">
+                    <input type="file" name="logo" id="logo" accept="image/*" class="w-full text-gray-700 dark:text-gray-300">
                     @error('logo')
                         <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                     @enderror

--- a/resources/views/arbeitsgruppen/create.blade.php
+++ b/resources/views/arbeitsgruppen/create.blade.php
@@ -1,0 +1,69 @@
+<x-app-layout>
+    <x-member-page class="max-w-3xl">
+        <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
+            <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-6">Neue AG</h2>
+
+            <form action="{{ route('arbeitsgruppen.store') }}" method="POST" enctype="multipart/form-data">
+                @csrf
+
+                <div class="mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name der AG</label>
+                    <input type="text" name="name" id="name" value="{{ old('name') }}" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    @error('name')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="leader_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">AG-Leiter</label>
+                    <select name="leader_id" id="leader_id" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                        <option value="">-- Mitglied wählen --</option>
+                        @foreach($users as $member)
+                            <option value="{{ $member->id }}" {{ old('leader_id') == $member->id ? 'selected' : '' }}>{{ $member->name }}</option>
+                        @endforeach
+                    </select>
+                    @error('leader_id')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Beschreibung</label>
+                    <textarea name="description" id="description" rows="3" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">{{ old('description') }}</textarea>
+                    @error('description')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">E-Mail-Adresse</label>
+                    <input type="email" name="email" id="email" value="{{ old('email') }}" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    @error('email')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="meeting_schedule" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Wiederkehrender Termin</label>
+                    <input type="text" name="meeting_schedule" id="meeting_schedule" value="{{ old('meeting_schedule') }}" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    @error('meeting_schedule')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-6">
+                    <label for="logo" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Logo</label>
+                    <input type="file" name="logo" id="logo" class="w-full text-gray-700 dark:text-gray-300">
+                    @error('logo')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="flex justify-end">
+                    <a href="{{ route('dashboard') }}" class="mr-3 inline-flex items-center px-4 py-2 bg-gray-300 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-gray-800 dark:text-white hover:bg-gray-400 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">Abbrechen</a>
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#8B0116] dark:focus:ring-[#FF6B81]">Speichern</button>
+                </div>
+            </form>
+        </div>
+    </x-member-page>
+</x-app-layout>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -67,6 +67,7 @@
                                 <x-dropdown-link href="{{ route('admin.index') }}">Admin</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('hoerbuecher.create') }}">Neue Hörbuchfolge</x-dropdown-link>
+                                <x-dropdown-link href="{{ route('arbeitsgruppen.create') }}">Neue AG</x-dropdown-link>
                             </div>
                         </div>
                         @endif
@@ -166,6 +167,7 @@
                 <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('hoerbuecher.create') }}">Neue Hörbuchfolge</x-responsive-nav-link>
+                <x-responsive-nav-link href="{{ route('arbeitsgruppen.create') }}">Neue AG</x-responsive-nav-link>
             </div>
             @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\RomantauschController;
 use App\Http\Controllers\StatistikController;
 use App\Http\Controllers\TodoController;
 use App\Http\Controllers\HoerbuchController;
+use App\Http\Controllers\ArbeitsgruppenController;
 use App\Http\Middleware\RedirectIfAnwaerter;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
@@ -104,6 +105,11 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::get('{episode}/bearbeiten', 'edit')->name('edit');
         Route::put('{episode}', 'update')->name('update');
         Route::delete('{episode}', 'destroy')->name('destroy');
+    });
+
+    Route::prefix('arbeitsgruppen')->name('arbeitsgruppen.')->controller(ArbeitsgruppenController::class)->middleware('admin')->group(function () {
+        Route::get('erstellen', 'create')->name('create');
+        Route::post('/', 'store')->name('store');
     });
 
 


### PR DESCRIPTION
This pull request introduces a new feature for creating "Arbeitsgruppen" (AGs, or workgroups/teams) within the application. It adds backend logic, database support, and frontend forms to allow admins to create new teams with additional metadata (description, email, meeting schedule, logo), and integrates the feature into the navigation. The main changes are grouped below:

### Feature Implementation: Arbeitsgruppen Creation

* Added a new controller `ArbeitsgruppenController` with methods for displaying the creation form and storing new AGs, including validation and file upload for the logo. The logic also attaches the leader to the team with their existing role if available.
* Created a Blade view `arbeitsgruppen/create.blade.php` for the AG creation form, supporting all new fields (name, leader, description, email, meeting schedule, logo).

### Database & Model Changes

* Added a migration to extend the `teams` table with new fields: `description`, `email`, `meeting_schedule`, and `logo_path`.
* Updated the `Team` model to make the new fields mass assignable.
* Updated the `TeamFactory` to include default values for the new fields.

### Navigation & Routing Integration

* Registered new routes for AG creation and storing under the admin middleware, and included the controller in `web.php`. [[1]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR24) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR110-R114)
* Added "Neue AG" (New AG) links to both desktop and mobile navigation menus for easy access. [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR70) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR170)