### PR TITLE
Remove Hörbuch create menu and sort by Ziel-EVT

### DIFF
--- a/resources/views/hoerbuecher/create.blade.php
+++ b/resources/views/hoerbuecher/create.blade.php
@@ -37,7 +37,7 @@
                     </div>
 
                     <div>
-                        <label for="planned_release_date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Geplanter Veröffentlichungszeitpunkt</label>
+                        <label for="planned_release_date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Ziel-EVT</label>
                         <input type="text" name="planned_release_date" id="planned_release_date" value="{{ old('planned_release_date') }}" required placeholder="JJJJ, MM.JJJJ oder TT.MM.JJJJ" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                         @error('planned_release_date')
                             <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -38,7 +38,7 @@
                     </div>
 
                     <div>
-                        <label for="planned_release_date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Geplanter Veröffentlichungszeitpunkt</label>
+                        <label for="planned_release_date" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Ziel-EVT</label>
                         <input type="text" name="planned_release_date" id="planned_release_date" value="{{ old('planned_release_date', $episode->planned_release_date) }}" required placeholder="JJJJ, MM.JJJJ oder TT.MM.JJJJ" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                         @error('planned_release_date')
                             <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -18,7 +18,7 @@
                         <tr>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Folge</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Titel</th>
-                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Geplanter Veröffentlichungszeitpunkt</th>
+                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Ziel-EVT</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Status</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Fortschritt</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Bemerkungen</th>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -66,7 +66,6 @@
                             <div id="vorstand-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="vorstand-button">
                                 <x-dropdown-link href="{{ route('admin.index') }}">Admin</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
-                                <x-dropdown-link href="{{ route('hoerbuecher.create') }}">Neue Hörbuchfolge</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('arbeitsgruppen.create') }}">Neue AG</x-dropdown-link>
                             </div>
                         </div>
@@ -166,7 +165,6 @@
             <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic" aria-labelledby="vorstand-mobile-button">
                 <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
-                <x-responsive-nav-link href="{{ route('hoerbuecher.create') }}">Neue Hörbuchfolge</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('arbeitsgruppen.create') }}">Neue AG</x-responsive-nav-link>
             </div>
             @endif

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -134,6 +134,52 @@ class HoerbuchControllerTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_index_sorts_by_planned_release_date(): void
+    {
+        $user = $this->actingMember('Admin');
+
+        $e1 = AudiobookEpisode::create([
+            'episode_number' => 'F1',
+            'title' => 'Späteste',
+            'author' => 'Autor',
+            'planned_release_date' => '2025',
+            'status' => 'Skript wird erstellt',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'notes' => null,
+        ]);
+
+        $e2 = AudiobookEpisode::create([
+            'episode_number' => 'F2',
+            'title' => 'Monat',
+            'author' => 'Autor',
+            'planned_release_date' => '05.2024',
+            'status' => 'Skript wird erstellt',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'notes' => null,
+        ]);
+
+        $e3 = AudiobookEpisode::create([
+            'episode_number' => 'F3',
+            'title' => 'Tag',
+            'author' => 'Autor',
+            'planned_release_date' => '15.03.2024',
+            'status' => 'Skript wird erstellt',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'notes' => null,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('hoerbuecher.index'));
+
+        $episodes = $response->viewData('episodes');
+
+        $this->assertEquals([
+            'F3', 'F2', 'F1',
+        ], $episodes->pluck('episode_number')->toArray());
+    }
+
     public function test_admin_can_update_episode(): void
     {
         $user = $this->actingMember('Admin');

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -48,15 +48,14 @@ class NavigationMenuTest extends TestCase
 
         $response->assertDontSee(route('admin.index'));
     }
-    public function test_admin_users_see_hoerbuch_create_link_in_navigation_menu(): void
+    public function test_admin_users_do_not_see_hoerbuch_create_link_in_navigation_menu(): void
     {
         $team = Team::where('name', 'Mitglieder')->first();
         $user = User::factory()->create(['current_team_id' => $team->id]);
         $team->users()->attach($user, ['role' => 'Admin']);
 
         $response = $this->actingAs($user)->get('/');
-
-        $response->assertSee(route('hoerbuecher.create'));
+        $response->assertDontSee(route('hoerbuecher.create'));
     }
 
     public function test_non_admin_users_do_not_see_hoerbuch_create_link(): void


### PR DESCRIPTION
## Summary
- drop obsolete "Neue Hörbuchfolge" entry from Vorstand menu
- rename planned release column to "Ziel-EVT" and update forms
- sort Hörbuch episodes by parsed Ziel-EVT date

## Testing
- `php artisan test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03648904c832ea391c77e72533248