### PR TITLE
Add detail view for audiobook episodes

### DIFF
--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -102,7 +102,7 @@ class HoerbuchController extends Controller
             'notes' => 'nullable|string',
         ]);
 
-        AudiobookEpisode::create($request->only([
+        $data = $request->only([
             'episode_number',
             'title',
             'author',
@@ -111,7 +111,16 @@ class HoerbuchController extends Controller
             'responsible_user_id',
             'progress',
             'notes',
-        ]));
+        ]);
+
+        if (array_key_exists('notes', $data) && $data['notes'] !== null) {
+            $data['notes'] = trim(strip_tags($data['notes']));
+            if ($data['notes'] === '') {
+                $data['notes'] = null;
+            }
+        }
+
+        AudiobookEpisode::create($data);
 
         return redirect()->route('hoerbuecher.index')
             ->with('status', 'Hörbuchfolge wurde gespeichert.');
@@ -168,7 +177,7 @@ class HoerbuchController extends Controller
             'notes' => 'nullable|string',
         ]);
 
-        $episode->update($request->only([
+        $data = $request->only([
             'episode_number',
             'title',
             'author',
@@ -177,7 +186,16 @@ class HoerbuchController extends Controller
             'responsible_user_id',
             'progress',
             'notes',
-        ]));
+        ]);
+
+        if (array_key_exists('notes', $data) && $data['notes'] !== null) {
+            $data['notes'] = trim(strip_tags($data['notes']));
+            if ($data['notes'] === '') {
+                $data['notes'] = null;
+            }
+        }
+
+        $episode->update($data);
 
         return redirect()->route('hoerbuecher.index')
             ->with('status', 'Hörbuchfolge wurde aktualisiert.');

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -69,6 +69,17 @@ class HoerbuchController extends Controller
 
         return null;
     }
+
+    private function sanitizeNotes(?string $notes): ?string
+    {
+        if ($notes === null) {
+            return null;
+        }
+
+        $notes = trim(strip_tags($notes));
+
+        return $notes === '' ? null : $notes;
+    }
     /**
      * Formular zum Erstellen einer neuen Hörbuchfolge.
      */
@@ -113,12 +124,7 @@ class HoerbuchController extends Controller
             'notes',
         ]);
 
-        if (array_key_exists('notes', $data) && $data['notes'] !== null) {
-            $data['notes'] = trim(strip_tags($data['notes']));
-            if ($data['notes'] === '') {
-                $data['notes'] = null;
-            }
-        }
+        $data['notes'] = $this->sanitizeNotes($data['notes'] ?? null);
 
         AudiobookEpisode::create($data);
 
@@ -188,12 +194,7 @@ class HoerbuchController extends Controller
             'notes',
         ]);
 
-        if (array_key_exists('notes', $data) && $data['notes'] !== null) {
-            $data['notes'] = trim(strip_tags($data['notes']));
-            if ($data['notes'] === '') {
-                $data['notes'] = null;
-            }
-        }
+        $data['notes'] = $this->sanitizeNotes($data['notes'] ?? null);
 
         $episode->update($data);
 

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -80,6 +80,24 @@ class HoerbuchController extends Controller
 
         return $notes === '' ? null : $notes;
     }
+
+    private function episodeDataFromRequest(Request $request): array
+    {
+        $data = $request->only([
+            'episode_number',
+            'title',
+            'author',
+            'planned_release_date',
+            'status',
+            'responsible_user_id',
+            'progress',
+            'notes',
+        ]);
+
+        $data['notes'] = $this->sanitizeNotes($data['notes'] ?? null);
+
+        return $data;
+    }
     /**
      * Formular zum Erstellen einer neuen Hörbuchfolge.
      */
@@ -112,21 +130,7 @@ class HoerbuchController extends Controller
             'progress' => 'required|integer|min:0|max:100',
             'notes' => 'nullable|string',
         ]);
-
-        $data = $request->only([
-            'episode_number',
-            'title',
-            'author',
-            'planned_release_date',
-            'status',
-            'responsible_user_id',
-            'progress',
-            'notes',
-        ]);
-
-        $data['notes'] = $this->sanitizeNotes($data['notes'] ?? null);
-
-        AudiobookEpisode::create($data);
+        AudiobookEpisode::create($this->episodeDataFromRequest($request));
 
         return redirect()->route('hoerbuecher.index')
             ->with('status', 'Hörbuchfolge wurde gespeichert.');
@@ -182,21 +186,7 @@ class HoerbuchController extends Controller
             'progress' => 'required|integer|min:0|max:100',
             'notes' => 'nullable|string',
         ]);
-
-        $data = $request->only([
-            'episode_number',
-            'title',
-            'author',
-            'planned_release_date',
-            'status',
-            'responsible_user_id',
-            'progress',
-            'notes',
-        ]);
-
-        $data['notes'] = $this->sanitizeNotes($data['notes'] ?? null);
-
-        $episode->update($data);
+        $episode->update($this->episodeDataFromRequest($request));
 
         return redirect()->route('hoerbuecher.index')
             ->with('status', 'Hörbuchfolge wurde aktualisiert.');

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -118,6 +118,18 @@ class HoerbuchController extends Controller
     }
 
     /**
+     * Detailansicht einer Hörbuchfolge.
+     */
+    public function show(AudiobookEpisode $episode)
+    {
+        $this->ensureAdminOrVorstand();
+
+        return view('hoerbuecher.show', [
+            'episode' => $episode,
+        ]);
+    }
+
+    /**
      * Formular zum Bearbeiten einer Hörbuchfolge.
      */
     public function edit(AudiobookEpisode $episode)

--- a/resources/js/hoerbuecher.js
+++ b/resources/js/hoerbuecher.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('tr[data-href]').forEach(row => {
+        row.addEventListener('click', () => {
+            window.location.href = row.dataset.href;
+        });
+        row.addEventListener('keydown', e => {
+            if (e.key === 'Enter') {
+                window.location.href = row.dataset.href;
+            }
+        });
+    });
+});

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -48,7 +48,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="6" class="px-4 py-2 text-center text-gray-700 dark:text-gray-300">Keine Hörbuchfolgen vorhanden.</td>
+                                <td colspan="5" class="px-4 py-2 text-center text-gray-700 dark:text-gray-300">Keine Hörbuchfolgen vorhanden.</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -26,7 +26,7 @@
                     </thead>
                     <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
                         @forelse($episodes as $episode)
-                            <tr onclick="window.location='{{ route('hoerbuecher.show', $episode) }}'" class="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700">
+                            <tr class="hover:bg-gray-100 dark:hover:bg-gray-700">
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
                                     <a href="{{ route('hoerbuecher.show', $episode) }}" class="block w-full h-full">{{ $episode->episode_number }}</a>
                                 </td>

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -55,17 +55,6 @@
                 </table>
             </div>
         </div>
-        <script>
-            document.querySelectorAll('tr[data-href]').forEach(row => {
-                row.addEventListener('click', () => {
-                    window.location.href = row.dataset.href;
-                });
-                row.addEventListener('keydown', e => {
-                    if (e.key === 'Enter') {
-                        window.location.href = row.dataset.href;
-                    }
-                });
-            });
-        </script>
+        @vite(['resources/js/hoerbuecher.js'])
     </x-member-page>
 </x-app-layout>

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -26,24 +26,28 @@
                     </thead>
                     <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
                         @forelse($episodes as $episode)
-                            <tr class="hover:bg-gray-100 dark:hover:bg-gray-700">
-                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
-                                    <a href="{{ route('hoerbuecher.show', $episode) }}" class="block w-full h-full">{{ $episode->episode_number }}</a>
-                                </td>
+                            <tr
+                                class="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
+                                role="button"
+                                tabindex="0"
+                                onclick="window.location='{{ route('hoerbuecher.show', $episode) }}'"
+                                onkeydown="if(event.key==='Enter'){ window.location='{{ route('hoerbuecher.show', $episode) }}' }"
+                            >
+                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->episode_number }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->planned_release_date }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->status }}</td>
                                 <td class="px-4 py-2">
                                     <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4">
-                                      {{-- Map 0–100% progress to a hue range of 0–120 (red → green). --}}
-                                      <div class="h-4 rounded-full text-xs font-medium text-center leading-none text-white" style="width: {{ $episode->progress }}%; background-color: hsl({{ $episode->progressHue() }}, 100%, 40%);">
-                                          {{ $episode->progress }}%
-                                      </div>
-                                  </div>
-                              </td>
-                              <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->notes }}</td>
-                          </tr>
-                      @empty
+                                        {{-- Map 0–100% progress to a hue range of 0–120 (red → green). --}}
+                                        <div class="h-4 rounded-full text-xs font-medium text-center leading-none text-white" style="width: {{ $episode->progress }}%; background-color: hsl({{ $episode->progressHue() }}, 100%, 40%);">
+                                            {{ $episode->progress }}%
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->notes }}</td>
+                            </tr>
+                        @empty
                             <tr>
                                 <td colspan="6" class="px-4 py-2 text-center text-gray-700 dark:text-gray-300">Keine Hörbuchfolgen vorhanden.</td>
                             </tr>

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -22,14 +22,14 @@
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Status</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Fortschritt</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Bemerkungen</th>
-                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Verantwortlich</th>
-                            <th class="px-4 py-2 text-center text-gray-800 dark:text-gray-200">Aktionen</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
                         @forelse($episodes as $episode)
-                            <tr>
-                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->episode_number }}</td>
+                            <tr onclick="window.location='{{ route('hoerbuecher.show', $episode) }}'" class="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700">
+                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
+                                    <a href="{{ route('hoerbuecher.show', $episode) }}" class="block w-full h-full">{{ $episode->episode_number }}</a>
+                                </td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->planned_release_date }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->status }}</td>
@@ -42,15 +42,10 @@
                                   </div>
                               </td>
                               <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->notes }}</td>
-                              <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->responsible?->name }}</td>
-                              <td class="px-4 py-2 text-center">
-                                  <a href="{{ route('hoerbuecher.edit', $episode) }}" class="text-blue-600 dark:text-blue-400 hover:underline">Bearbeiten</a>
-                                      <x-confirm-delete :action="route('hoerbuecher.destroy', $episode)" />
-                              </td>
                           </tr>
                       @empty
                             <tr>
-                                <td colspan="8" class="px-4 py-2 text-center text-gray-700 dark:text-gray-300">Keine Hörbuchfolgen vorhanden.</td>
+                                <td colspan="6" class="px-4 py-2 text-center text-gray-700 dark:text-gray-300">Keine Hörbuchfolgen vorhanden.</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -30,8 +30,7 @@
                                 class="cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700"
                                 role="button"
                                 tabindex="0"
-                                onclick="window.location='{{ route('hoerbuecher.show', $episode) }}'"
-                                onkeydown="if(event.key==='Enter'){ window.location='{{ route('hoerbuecher.show', $episode) }}' }"
+                                data-href="{{ route('hoerbuecher.show', $episode) }}"
                             >
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->episode_number }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>
@@ -56,5 +55,17 @@
                 </table>
             </div>
         </div>
+        <script>
+            document.querySelectorAll('tr[data-href]').forEach(row => {
+                row.addEventListener('click', () => {
+                    window.location.href = row.dataset.href;
+                });
+                row.addEventListener('keydown', e => {
+                    if (e.key === 'Enter') {
+                        window.location.href = row.dataset.href;
+                    }
+                });
+            });
+        </script>
     </x-member-page>
 </x-app-layout>

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -1,0 +1,35 @@
+<x-app-layout>
+    <x-member-page class="max-w-3xl">
+        <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
+            <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-6">{{ $episode->title }}</h2>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div><span class="font-medium">Folge:</span> {{ $episode->episode_number }}</div>
+                <div><span class="font-medium">Autor:</span> {{ $episode->author }}</div>
+                <div><span class="font-medium">Ziel-EVT:</span> {{ $episode->planned_release_date }}</div>
+                <div><span class="font-medium">Status:</span> {{ $episode->status }}</div>
+                <div class="md:col-span-2">
+                    <span class="font-medium">Fortschritt:</span>
+                    <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4 mt-1">
+                        <div class="h-4 rounded-full text-xs font-medium text-center leading-none text-white" style="width: {{ $episode->progress }}%; background-color: hsl({{ $episode->progressHue() }}, 100%, 40%);">
+                            {{ $episode->progress }}%
+                        </div>
+                    </div>
+                </div>
+                <div class="md:col-span-2"><span class="font-medium">Verantwortlich:</span> {{ $episode->responsible?->name ?? '-' }}</div>
+                <div class="md:col-span-2">
+                    <span class="font-medium">Anmerkungen:</span>
+                    <p class="mt-1">{{ $episode->notes }}</p>
+                </div>
+            </div>
+
+            <div class="mt-6 flex justify-end space-x-3">
+                <a href="{{ route('hoerbuecher.edit', $episode) }}" class="text-blue-600 dark:text-blue-400 hover:underline">Bearbeiten</a>
+                <x-confirm-delete :action="route('hoerbuecher.destroy', $episode)" />
+            </div>
+            <div class="mt-6">
+                <a href="{{ route('hoerbuecher.index') }}" class="text-gray-600 dark:text-gray-400 hover:underline">&laquo; Zurück zur Übersicht</a>
+            </div>
+        </div>
+    </x-member-page>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,6 +102,7 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::get('/', 'index')->name('index');
         Route::get('erstellen', 'create')->name('create');
         Route::post('/', 'store')->name('store');
+        Route::get('{episode}', 'show')->name('show');
         Route::get('{episode}/bearbeiten', 'edit')->name('edit');
         Route::put('{episode}', 'update')->name('update');
         Route::delete('{episode}', 'destroy')->name('destroy');

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -124,9 +124,11 @@ class HoerbuchControllerTest extends TestCase
             ->assertSee('Bemerkung')
             ->assertSee('50%')
             ->assertSee(route('hoerbuecher.create'))
-            ->assertSee(route('hoerbuecher.show', $episode))
+            ->assertSee('data-href="' . route('hoerbuecher.show', $episode) . '"', false)
             ->assertSee('role="button"', false)
-            ->assertSee('tabindex="0"', false);
+            ->assertSee('tabindex="0"', false)
+            ->assertDontSee('onclick="window.location', false)
+            ->assertDontSee('onkeydown', false);
     }
 
     public function test_admin_can_view_episode_details(): void

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -152,6 +152,33 @@ class HoerbuchControllerTest extends TestCase
             ->assertSee(route('hoerbuecher.edit', $episode));
     }
 
+    public function test_notes_are_escaped_in_views(): void
+    {
+        $user = $this->actingMember('Admin');
+        $malicious = '<script>alert("xss")</script>';
+
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F5',
+            'title' => 'XSS Test',
+            'author' => 'Autor',
+            'planned_release_date' => '2025',
+            'status' => 'Skript wird erstellt',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'notes' => $malicious,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('hoerbuecher.index'))
+            ->assertDontSee($malicious, false)
+            ->assertSee($malicious);
+
+        $this->actingAs($user)
+            ->get(route('hoerbuecher.show', $episode))
+            ->assertDontSee($malicious, false)
+            ->assertSee($malicious);
+    }
+
     public function test_member_cannot_view_index(): void
     {
         $user = $this->actingMember('Mitglied');

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -123,7 +123,33 @@ class HoerbuchControllerTest extends TestCase
             ->assertSee($episode->planned_release_date)
             ->assertSee('Bemerkung')
             ->assertSee('50%')
-            ->assertSee(route('hoerbuecher.create'));
+            ->assertSee(route('hoerbuecher.create'))
+            ->assertSee(route('hoerbuecher.show', $episode));
+    }
+
+    public function test_admin_can_view_episode_details(): void
+    {
+        $user = $this->actingMember('Admin');
+        $responsible = $this->actingMember();
+
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F9',
+            'title' => 'Detailfolge',
+            'author' => 'Autor',
+            'planned_release_date' => '2025',
+            'status' => 'Skript wird erstellt',
+            'responsible_user_id' => $responsible->id,
+            'progress' => 40,
+            'notes' => 'Notiz',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertSee('Detailfolge')
+            ->assertSee($responsible->name)
+            ->assertSee('Notiz')
+            ->assertSee(route('hoerbuecher.edit', $episode));
     }
 
     public function test_member_cannot_view_index(): void

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -124,7 +124,9 @@ class HoerbuchControllerTest extends TestCase
             ->assertSee('Bemerkung')
             ->assertSee('50%')
             ->assertSee(route('hoerbuecher.create'))
-            ->assertSee(route('hoerbuecher.show', $episode));
+            ->assertSee(route('hoerbuecher.show', $episode))
+            ->assertSee('role="button"', false)
+            ->assertSee('tabindex="0"', false);
     }
 
     public function test_admin_can_view_episode_details(): void

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
                 'resources/js/maddraxiversum.js',
                 'resources/js/statistik.js',
                 'resources/js/changelog.js',
+                'resources/js/hoerbuecher.js',
             ],
             refresh: true,
             // Explizit den public-Pfad setzen


### PR DESCRIPTION
This pull request adds a detailed view for individual audiobook episodes and improves both the user experience and data handling on the audiobook episodes index page. It introduces a clickable row interface for easier navigation, sanitizes user input for notes to prevent XSS, and updates tests to cover these new features.

**Feature additions:**

* Added a new route, controller method, and Blade view (`hoerbuecher.show`) to display detailed information about a single audiobook episode, including progress, responsible user, and notes. [[1]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR105) [[2]](diffhunk://#diff-3a89ef24b9c79efccdef51ca4d7a67fab3d01dd6e100d6b08f8b821b8334ffcfR1-R35) [[3]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL114-R140)

**User interface improvements:**

* Updated the index Blade view (`hoerbuecher/index.blade.php`) so each episode row is clickable and keyboard-accessible, leading to the episode detail page. Removed action buttons from the index view and included the new JS for row navigation. [[1]](diffhunk://#diff-62028215bf1b51ad419e1ba1ed5fc53eac5411544afb5da3fd5718deb40c541fL25-R34) [[2]](diffhunk://#diff-62028215bf1b51ad419e1ba1ed5fc53eac5411544afb5da3fd5718deb40c541fL45-R58) [[3]](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26R14) [[4]](diffhunk://#diff-5046ec5ab2d0da1fc73fe9b3c505a5fd4836575443481948ebb0b44c83c75ecfR1-R12)

**Data handling and security:**

* Sanitized the `notes` field in both creation and update flows by stripping HTML tags and trimming whitespace, ensuring empty notes are stored as null. [[1]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL105-R105) [[2]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL159-R180) [[3]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL168-R198)

**Testing improvements:**

* Added feature tests to verify the new detail view, clickable row navigation, and proper sanitization/escaping of notes in views and database.