### PR TITLE
feat: add member map refresh service and scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,14 @@ Die Datei wird unter `public/sitemap.xml` abgelegt und sollte regelmäßig aktua
 
 Stellen Sie sicher, dass `APP_URL` in der `.env`-Datei auf eine gültige, öffentlich erreichbare URL gesetzt ist.
 
+## Scheduler in Produktion
+
+Damit geplante Aufgaben ausgeführt werden können, muss auf dem Produktionsserver der Laravel Scheduler laufen.
+Richten Sie dazu einen Cronjob ein, der den Scheduler jede Minute aufruft:
+
+```bash
+* * * * * php /path/to/artisan schedule:run >> /dev/null 2>&1
+```
+
+Der Scheduler führt stündlich das Kommando `member-map:refresh` aus und aktualisiert so den Cache der Mitgliederkarte.
+

--- a/app/Console/Commands/RefreshMemberMap.php
+++ b/app/Console/Commands/RefreshMemberMap.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Team;
+use App\Services\MemberMapCacheService;
+
+class RefreshMemberMap extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'member-map:refresh';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Refresh cached member map data for all teams.';
+
+    public function __construct(protected MemberMapCacheService $service)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $teams = Team::all();
+
+        foreach ($teams as $team) {
+            $this->service->refresh($team);
+            $this->info("Refreshed member map for team {$team->id}");
+        }
+
+        return self::SUCCESS;
+    }
+}
+

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        $schedule->command('member-map:refresh')->hourly();
+    }
+}
+

--- a/app/Http/Controllers/MitgliederKarteController.php
+++ b/app/Http/Controllers/MitgliederKarteController.php
@@ -5,11 +5,14 @@ namespace App\Http\Controllers;
 use App\Models\Team;
 use App\Models\UserPoint;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
+use App\Services\MemberMapCacheService;
 
 class MitgliederKarteController extends Controller
 {
+    public function __construct(protected MemberMapCacheService $memberMapCacheService)
+    {
+    }
+
     public function index()
     {
         $user = Auth::user();
@@ -33,67 +36,10 @@ class MitgliederKarteController extends Controller
             return view('mitglieder.karte-locked');
         }
 
-        // Cache-Key für die Kartendaten erstellen
-        $cacheKey = "member_map_data_team_{$team->id}";
-
-        // Kartendaten aus dem Cache holen, falls vorhanden
-        if (Cache::has($cacheKey)) {
-            $cached = Cache::get($cacheKey);
-            $memberData = $cached['memberData'];
-            $centerLat = $cached['centerLat'];
-            $centerLon = $cached['centerLon'];
-        } else {
-            // Nur Nutzer mit Rollen außer "Anwärter" anzeigen
-            $members = $team->users()
-                ->select('users.id', 'users.name', 'users.plz', 'users.land', 'users.stadt')
-                ->withPivot('role')
-                ->wherePivotNotIn('role', ['Anwärter'])
-                ->get();
-
-            // Geodaten für die Mitglieder sammeln
-            $memberData = [];
-            $totalLat = 0;
-            $totalLon = 0;
-            $memberCount = 0;
-
-            foreach ($members as $member) {
-                // Nur Mitglieder mit PLZ berücksichtigen
-                if (! empty($member->plz)) {
-                    // Koordinaten für die PLZ abrufen (mit Caching)
-                    $coordinates = $this->getCoordinatesForPostalCode($member->plz, $member->land);
-
-                    if ($coordinates) {
-                        // Kleine zufällige Verschiebung hinzufügen (max 500m)
-
-                        // Mittelpunktberechnung (ohne Jitter für Genauigkeit)
-                        $totalLat += $coordinates['lat'];
-                        $totalLon += $coordinates['lon'];
-                        $memberCount++;
-
-                        $jitter = $this->addJitter($coordinates['lat'], $coordinates['lon']);
-
-                        $memberData[] = [
-                            'name' => $member->name,
-                            'city' => $member->stadt,
-                            'role' => $member->membership->role,
-                            'lat' => $jitter['lat'],
-                            'lon' => $jitter['lon'],
-                            'profile_url' => route('profile.view', $member->id),
-                        ];
-                    }
-                }
-            }
-
-            $centerLat = $memberCount > 0 ? $totalLat / $memberCount : 51.1657;
-            $centerLon = $memberCount > 0 ? $totalLon / $memberCount : 10.4515;
-
-            // Kartendaten im Cache speichern (12 Stunden)
-            Cache::put($cacheKey, [
-                'memberData' => $memberData,
-                'centerLat' => $centerLat,
-                'centerLon' => $centerLon,
-            ], now()->addHours(12));
-        }
+        $mapData = $this->memberMapCacheService->getMemberMapData($team);
+        $memberData = $mapData['memberData'];
+        $centerLat = $mapData['centerLat'];
+        $centerLon = $mapData['centerLon'];
 
         // Regionalstammtische definieren
         $stammtischData = [
@@ -130,56 +76,4 @@ class MitgliederKarteController extends Controller
         ]);
     }
 
-    /**
-     * Fügt eine kleine zufällige Verschiebung hinzu, um Datenschutz zu erhöhen
-     */
-    private function addJitter($lat, $lon)
-    {
-        // Zufällige Verschiebung zwischen -0.005 und 0.005 Grad (ca. 300-500m)
-        $latJitter = (mt_rand(-50, 50) / 10000);
-        $lonJitter = (mt_rand(-50, 50) / 10000);
-
-        return [
-            'lat' => $lat + $latJitter,
-            'lon' => $lon + $lonJitter,
-        ];
-    }
-
-    /**
-     * Ruft die Koordinaten für eine PLZ ab mit Caching
-     */
-    private function getCoordinatesForPostalCode($postalCode, $country = 'Deutschland')
-    {
-        // Cache-Key erstellen
-        $cacheKey = 'postal_code_'.$country.'_'.$postalCode;
-
-        // Prüfen, ob die Daten bereits im Cache sind (30 Tage gültig)
-        if (Cache::has($cacheKey)) {
-            return Cache::get($cacheKey);
-        }
-
-        // Nominatim API nutzen (OpenStreetMap Geocoding)
-        $response = Http::get('https://nominatim.openstreetmap.org/search', [
-            'postalcode' => $postalCode,
-            'country' => $country,
-            'format' => 'json',
-            'limit' => 1,
-            'email' => config('app.url'),
-        ]);
-
-        if ($response->successful() && count($response->json()) > 0) {
-            $data = $response->json()[0];
-            $result = [
-                'lat' => (float) $data['lat'],
-                'lon' => (float) $data['lon'],
-            ];
-
-            // Ergebnis im Cache speichern (30 Tage)
-            Cache::put($cacheKey, $result, now()->addDays(30));
-
-            return $result;
-        }
-
-        return null;
-    }
 }

--- a/app/Services/MemberMapCacheService.php
+++ b/app/Services/MemberMapCacheService.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Team;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+class MemberMapCacheService
+{
+    public function getMemberMapData(Team $team): array
+    {
+        $cacheKey = "member_map_data_team_{$team->id}";
+
+        if (Cache::has($cacheKey)) {
+            return Cache::get($cacheKey);
+        }
+
+        $members = $team->users()
+            ->select('users.id', 'users.name', 'users.plz', 'users.land', 'users.stadt')
+            ->withPivot('role')
+            ->wherePivotNotIn('role', ['Anwärter'])
+            ->get();
+
+        $memberData = [];
+        $totalLat = 0;
+        $totalLon = 0;
+        $memberCount = 0;
+
+        foreach ($members as $member) {
+            if (! empty($member->plz)) {
+                $coordinates = $this->getCoordinatesForPostalCode($member->plz, $member->land);
+
+                if ($coordinates) {
+                    $totalLat += $coordinates['lat'];
+                    $totalLon += $coordinates['lon'];
+                    $memberCount++;
+
+                    $jitter = $this->addJitter($coordinates['lat'], $coordinates['lon']);
+
+                    $memberData[] = [
+                        'name' => $member->name,
+                        'city' => $member->stadt,
+                        'role' => $member->membership->role,
+                        'lat' => $jitter['lat'],
+                        'lon' => $jitter['lon'],
+                        'profile_url' => route('profile.view', $member->id),
+                    ];
+                }
+            }
+        }
+
+        $centerLat = $memberCount > 0 ? $totalLat / $memberCount : 51.1657;
+        $centerLon = $memberCount > 0 ? $totalLon / $memberCount : 10.4515;
+
+        $data = [
+            'memberData' => $memberData,
+            'centerLat' => $centerLat,
+            'centerLon' => $centerLon,
+        ];
+
+        Cache::put($cacheKey, $data, now()->addHours(12));
+
+        return $data;
+    }
+
+    public function refresh(Team $team): array
+    {
+        Cache::forget("member_map_data_team_{$team->id}");
+
+        return $this->getMemberMapData($team);
+    }
+
+    private function addJitter($lat, $lon): array
+    {
+        $latJitter = (mt_rand(-50, 50) / 10000);
+        $lonJitter = (mt_rand(-50, 50) / 10000);
+
+        return [
+            'lat' => $lat + $latJitter,
+            'lon' => $lon + $lonJitter,
+        ];
+    }
+
+    private function getCoordinatesForPostalCode($postalCode, $country = 'Deutschland')
+    {
+        $cacheKey = 'postal_code_'.$country.'_'.$postalCode;
+
+        if (Cache::has($cacheKey)) {
+            return Cache::get($cacheKey);
+        }
+
+        $response = Http::get('https://nominatim.openstreetmap.org/search', [
+            'postalcode' => $postalCode,
+            'country' => $country,
+            'format' => 'json',
+            'limit' => 1,
+            'email' => config('app.url'),
+        ]);
+
+        if ($response->successful() && count($response->json()) > 0) {
+            $data = $response->json()[0];
+            $result = [
+                'lat' => (float) $data['lat'],
+                'lon' => (float) $data['lon'],
+            ];
+
+            Cache::put($cacheKey, $result, now()->addDays(30));
+
+            return $result;
+        }
+
+        return null;
+    }
+}
+


### PR DESCRIPTION
## Summary
- extract member map caching logic into MemberMapCacheService
- add refresh-member-map command and schedule hourly
- document scheduler setup for production

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68a06fcb8f9c832eb89ac815cc3f23ee