### PR TITLE
Add role tracking for audiobook episodes

### DIFF
--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -100,6 +100,8 @@ class HoerbuchController extends Controller
             'responsible_user_id' => 'nullable|exists:users,id',
             'progress' => 'required|integer|min:0|max:100',
             'notes' => 'nullable|string',
+            'total_roles' => 'required|integer|min:0',
+            'filled_roles' => 'required|integer|min:0|lte:total_roles',
         ]);
 
         AudiobookEpisode::create($request->only([
@@ -111,6 +113,8 @@ class HoerbuchController extends Controller
             'responsible_user_id',
             'progress',
             'notes',
+            'total_roles',
+            'filled_roles',
         ]));
 
         return redirect()->route('hoerbuecher.index')
@@ -154,6 +158,8 @@ class HoerbuchController extends Controller
             'responsible_user_id' => 'nullable|exists:users,id',
             'progress' => 'required|integer|min:0|max:100',
             'notes' => 'nullable|string',
+            'total_roles' => 'required|integer|min:0',
+            'filled_roles' => 'required|integer|min:0|lte:total_roles',
         ]);
 
         $episode->update($request->only([
@@ -165,6 +171,8 @@ class HoerbuchController extends Controller
             'responsible_user_id',
             'progress',
             'notes',
+            'total_roles',
+            'filled_roles',
         ]));
 
         return redirect()->route('hoerbuecher.index')

--- a/app/Models/AudiobookEpisode.php
+++ b/app/Models/AudiobookEpisode.php
@@ -36,6 +36,8 @@ class AudiobookEpisode extends Model
         'responsible_user_id',
         'progress',
         'notes',
+        'total_roles',
+        'filled_roles',
     ];
 
     public function responsible(): BelongsTo
@@ -49,5 +51,18 @@ class AudiobookEpisode extends Model
     public function progressHue(): float
     {
         return $this->progress * self::PROGRESS_HUE_FACTOR;
+    }
+
+    public function rolesProgress(): float
+    {
+        if (!$this->total_roles) {
+            return 0;
+        }
+        return ($this->filled_roles / $this->total_roles) * 100;
+    }
+
+    public function rolesProgressHue(): float
+    {
+        return $this->rolesProgress() * self::PROGRESS_HUE_FACTOR;
     }
 }

--- a/database/migrations/2025_09_17_000000_add_roles_to_audiobook_episodes_table.php
+++ b/database/migrations/2025_09_17_000000_add_roles_to_audiobook_episodes_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('audiobook_episodes', function (Blueprint $table) {
+            $table->unsignedSmallInteger('total_roles')->default(0);
+            $table->unsignedSmallInteger('filled_roles')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('audiobook_episodes', function (Blueprint $table) {
+            $table->dropColumn(['total_roles', 'filled_roles']);
+        });
+    }
+};

--- a/resources/views/hoerbuecher/create.blade.php
+++ b/resources/views/hoerbuecher/create.blade.php
@@ -76,6 +76,24 @@
                     </div>
                 </div>
 
+                <div class="mb-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label for="total_roles" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Gesamtrollen</label>
+                        <input type="number" name="total_roles" id="total_roles" value="{{ old('total_roles', 0) }}" min="0" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                        @error('total_roles')
+                            <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="filled_roles" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Besetzte Rollen</label>
+                        <input type="number" name="filled_roles" id="filled_roles" value="{{ old('filled_roles', 0) }}" min="0" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                        @error('filled_roles')
+                            <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+                </div>
+
                 <div class="mb-6">
                     <label for="notes" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Anmerkungen</label>
                     <textarea name="notes" id="notes" rows="4" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">{{ old('notes') }}</textarea>

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -77,6 +77,24 @@
                     </div>
                 </div>
 
+                <div class="mb-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label for="total_roles" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Gesamtrollen</label>
+                        <input type="number" name="total_roles" id="total_roles" value="{{ old('total_roles', $episode->total_roles) }}" min="0" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                        @error('total_roles')
+                            <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="filled_roles" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Besetzte Rollen</label>
+                        <input type="number" name="filled_roles" id="filled_roles" value="{{ old('filled_roles', $episode->filled_roles) }}" min="0" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                        @error('filled_roles')
+                            <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+                </div>
+
                 <div class="mb-6">
                     <label for="notes" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Anmerkungen</label>
                     <textarea name="notes" id="notes" rows="4" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">{{ old('notes', $episode->notes) }}</textarea>

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -21,6 +21,7 @@
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Ziel-EVT</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Status</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Fortschritt</th>
+                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Rollen</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Bemerkungen</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Verantwortlich</th>
                             <th class="px-4 py-2 text-center text-gray-800 dark:text-gray-200">Aktionen</th>
@@ -41,16 +42,23 @@
                                       </div>
                                   </div>
                               </td>
-                              <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->notes }}</td>
-                              <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->responsible?->name }}</td>
-                              <td class="px-4 py-2 text-center">
-                                  <a href="{{ route('hoerbuecher.edit', $episode) }}" class="text-blue-600 dark:text-blue-400 hover:underline">Bearbeiten</a>
-                                      <x-confirm-delete :action="route('hoerbuecher.destroy', $episode)" />
+                                <td class="px-4 py-2">
+                                    <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4">
+                                        <div class="h-4 rounded-full text-xs font-medium text-center leading-none text-white" style="width: {{ $episode->rolesProgress() }}%; background-color: hsl({{ $episode->rolesProgressHue() }}, 100%, 40%);">
+                                            {{ $episode->filled_roles }}/{{ $episode->total_roles }}
+                                        </div>
+                                    </div>
+                                </td>
+                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->notes }}</td>
+                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->responsible?->name }}</td>
+                                <td class="px-4 py-2 text-center">
+                                    <a href="{{ route('hoerbuecher.edit', $episode) }}" class="text-blue-600 dark:text-blue-400 hover:underline">Bearbeiten</a>
+                                        <x-confirm-delete :action="route('hoerbuecher.destroy', $episode)" />
                               </td>
                           </tr>
                       @empty
                             <tr>
-                                <td colspan="8" class="px-4 py-2 text-center text-gray-700 dark:text-gray-300">Keine Hörbuchfolgen vorhanden.</td>
+                                <td colspan="9" class="px-4 py-2 text-center text-gray-700 dark:text-gray-300">Keine Hörbuchfolgen vorhanden.</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -44,6 +44,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => $responsible->id,
             'progress' => 50,
             'notes' => 'Bemerkung',
+            'total_roles' => 10,
+            'filled_roles' => 3,
         ];
 
         $response = $this->actingAs($user)->post(route('hoerbuecher.store'), $data);
@@ -58,6 +60,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => $responsible->id,
             'progress' => 50,
             'notes' => 'Bemerkung',
+            'total_roles' => 10,
+            'filled_roles' => 3,
         ]);
     }
 
@@ -74,6 +78,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 10,
             'notes' => null,
+            'total_roles' => 5,
+            'filled_roles' => 1,
         ]);
 
         $data = [
@@ -85,6 +91,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 20,
             'notes' => null,
+            'total_roles' => 5,
+            'filled_roles' => 2,
         ];
 
         $response = $this->actingAs($user)->post(route('hoerbuecher.store'), $data);
@@ -114,6 +122,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 50,
             'notes' => 'Bemerkung',
+            'total_roles' => 4,
+            'filled_roles' => 2,
         ]);
 
         $this->actingAs($user)
@@ -123,6 +133,7 @@ class HoerbuchControllerTest extends TestCase
             ->assertSee($episode->planned_release_date)
             ->assertSee('Bemerkung')
             ->assertSee('50%')
+            ->assertSee('2/4')
             ->assertSee(route('hoerbuecher.create'));
     }
 
@@ -147,6 +158,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 0,
             'notes' => null,
+            'total_roles' => 0,
+            'filled_roles' => 0,
         ]);
 
         $e2 = AudiobookEpisode::create([
@@ -158,6 +171,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 0,
             'notes' => null,
+            'total_roles' => 0,
+            'filled_roles' => 0,
         ]);
 
         $e3 = AudiobookEpisode::create([
@@ -169,6 +184,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 0,
             'notes' => null,
+            'total_roles' => 0,
+            'filled_roles' => 0,
         ]);
 
         $response = $this->actingAs($user)->get(route('hoerbuecher.index'));
@@ -193,6 +210,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 0,
             'notes' => null,
+            'total_roles' => 5,
+            'filled_roles' => 2,
         ]);
 
         $data = [
@@ -204,6 +223,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 100,
             'notes' => 'Aktualisiert',
+            'total_roles' => 6,
+            'filled_roles' => 6,
         ];
 
         $this->actingAs($user)
@@ -218,6 +239,8 @@ class HoerbuchControllerTest extends TestCase
             'planned_release_date' => '2025',
             'progress' => 100,
             'notes' => 'Aktualisiert',
+            'total_roles' => 6,
+            'filled_roles' => 6,
         ]);
     }
 
@@ -234,6 +257,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 0,
             'notes' => null,
+            'total_roles' => 1,
+            'filled_roles' => 0,
         ]);
 
         $this->actingAs($user)
@@ -261,6 +286,8 @@ class HoerbuchControllerTest extends TestCase
                 'responsible_user_id' => null,
                 'progress' => 0,
                 'notes' => null,
+                'total_roles' => 0,
+                'filled_roles' => 0,
             ];
 
             $response = $this->actingAs($user)->post(route('hoerbuecher.store'), $data);
@@ -282,6 +309,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 0,
             'notes' => null,
+            'total_roles' => 1,
+            'filled_roles' => 0,
         ]);
 
         $this->actingAs($user)


### PR DESCRIPTION
## Summary
- track audiobook roles with `total_roles` and `filled_roles` columns
- collect role counts in episode forms and save them
- display cast progress bar with `x/y` format on audiobook index

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68a071709ddc832ebc185ad8b4dfa5d6