### PR TITLE
Add newsletter test send button

### DIFF
--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -65,11 +65,18 @@ class NewsletterController extends Controller
 
         $recipients = $membersTeam->users()->wherePivotIn('role', $data['roles'])->get();
 
+        if ($request->has('test')) {
+            $recipients = $membersTeam->users()->wherePivot('role', 'Admin')->get();
+        }
+
         foreach ($recipients as $recipient) {
             Mail::to($recipient->email)->queue(new Newsletter($data['subject'], $data['topics']));
         }
 
-        return redirect()->route('newsletter.create')->with('status', 'Newsletter versendet.');
+        return redirect()->route('newsletter.create')->with(
+            'status',
+            $request->has('test') ? 'Newsletter-Test versendet.' : 'Newsletter versendet.'
+        );
     }
 }
 

--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -65,7 +65,7 @@ class NewsletterController extends Controller
 
         $recipients = $membersTeam->users()->wherePivotIn('role', $data['roles'])->get();
 
-        if ($request->has('test')) {
+        if ($request->boolean('test')) {
             $recipients = $membersTeam->users()->wherePivot('role', 'Admin')->get();
 
             if ($recipients->isEmpty()) {
@@ -80,7 +80,7 @@ class NewsletterController extends Controller
 
         return redirect()->route('newsletter.create')->with(
             'status',
-            $request->has('test') ? 'Newsletter-Test versendet.' : 'Newsletter versendet.'
+            $request->boolean('test') ? 'Newsletter-Test versendet.' : 'Newsletter versendet.'
         );
     }
 }

--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -67,6 +67,11 @@ class NewsletterController extends Controller
 
         if ($request->has('test')) {
             $recipients = $membersTeam->users()->wherePivot('role', 'Admin')->get();
+
+            if ($recipients->isEmpty()) {
+                return redirect()->route('newsletter.create')
+                    ->with('status', 'Keine Admin-Empfänger gefunden.');
+            }
         }
 
         foreach ($recipients as $recipient) {

--- a/resources/views/newsletter/versenden.blade.php
+++ b/resources/views/newsletter/versenden.blade.php
@@ -31,6 +31,7 @@
         </template>
         <x-button type="button" class="mt-2" @click="addTopic">Thema hinzufügen</x-button>
         <x-button type="button" class="mt-2 ml-2" @click="confirmSend">Versenden</x-button>
+        <x-button type="submit" name="test" value="1" class="mt-2 ml-2">Newsletter testen</x-button>
 
         <div x-show="showConfirm" class="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-75" x-cloak>
             <div class="bg-white dark:bg-gray-800 p-6 rounded shadow-lg">

--- a/resources/views/newsletter/versenden.blade.php
+++ b/resources/views/newsletter/versenden.blade.php
@@ -30,15 +30,16 @@
             </div>
         </template>
         <x-button type="button" class="mt-2" @click="addTopic">Thema hinzufügen</x-button>
-        <x-button type="button" class="mt-2 ml-2" @click="confirmSend">Versenden</x-button>
-        <x-button type="submit" name="test" value="1" class="mt-2 ml-2">Newsletter testen</x-button>
+        <x-button type="button" class="mt-2 ml-2" @click="confirmSend()">Versenden</x-button>
+        <x-button type="button" class="mt-2 ml-2" @click="confirmSend(true)">Newsletter testen</x-button>
+        <input type="hidden" name="test" value="0" x-ref="test" />
 
         <div x-show="showConfirm" class="fixed inset-0 flex items-center justify-center bg-gray-900 bg-opacity-75" x-cloak>
             <div class="bg-white dark:bg-gray-800 p-6 rounded shadow-lg">
-                <p class="mb-4">Wirklich Newsletter versenden?</p>
+                <p class="mb-4" x-text="pendingTest ? 'Testnewsletter wirklich versenden?' : 'Wirklich Newsletter versenden?'"></p>
                 <div class="flex justify-end">
                     <x-secondary-button type="button" @click="showConfirm = false">Abbrechen</x-secondary-button>
-                    <x-button type="button" class="ml-2" @click="$refs.form.submit()">Ja, versenden</x-button>
+                    <x-button type="button" class="ml-2" @click="submit">Ja, versenden</x-button>
                 </div>
             </div>
         </div>
@@ -50,8 +51,18 @@ function newsletterForm() {
     return {
         topics: [{}],
         showConfirm: false,
+        pendingTest: false,
         addTopic() { this.topics.push({}); },
-        confirmSend() { this.showConfirm = true; }
+        confirmSend(isTest = false) {
+            this.pendingTest = isTest;
+            this.showConfirm = true;
+        },
+        submit() {
+            if (this.pendingTest) {
+                this.$refs.test.value = 1;
+            }
+            this.$refs.form.submit();
+        }
     }
 }
 </script>


### PR DESCRIPTION
This pull request adds a new "Newsletter testen" feature, allowing users to send a test version of the newsletter only to Admins before sending it to all selected roles. The UI and backend logic have been updated to support this workflow, including a confirmation dialog and status messages for test sends.

**Newsletter test send feature:**

* Added a "Newsletter testen" button to `versenden.blade.php`, which triggers a confirmation dialog for sending a test newsletter.
* Updated the Alpine.js `newsletterForm` logic to handle test sends, including tracking test state and setting a hidden form field.

**Backend logic updates:**

* Modified `NewsletterController.php` to send the newsletter only to Admins when the test flag is set, with appropriate status messages for test and regular sends.