### PR TITLE
Fix audiobook episode status enum migration

### DIFF
--- a/database/migrations/2025_09_18_000000_update_status_enum_in_audiobook_episodes_table.php
+++ b/database/migrations/2025_09_18_000000_update_status_enum_in_audiobook_episodes_table.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
@@ -11,6 +10,35 @@ return new class extends Migration
      */
     public function up(): void
     {
+        $oldValues = [
+            'Skript wird erstellt',
+            'In Korrekturlesung',
+            'Rollenbesetzung',
+            'Aufnahmen in Arbeit',
+            'Musikerstellung',
+            'Audiobearbeitung gestartet',
+            'Videobearbeitung gestartet',
+            'Cover und Thumbnail in Arbeit',
+            'Veröffentlichung geplant',
+            'Veröffentlicht',
+        ];
+
+        $newValues = [
+            'Skripterstellung',
+            'Korrekturlesung',
+            'Rollenbesetzung',
+            'Aufnahmensammlung',
+            'Musikerstellung',
+            'Audiobearbeitung',
+            'Videobearbeitung',
+            'Grafiken',
+            'Veröffentlichungsplanung',
+            'Veröffentlichung',
+        ];
+
+        $transition = array_unique(array_merge($oldValues, $newValues));
+        DB::statement("ALTER TABLE audiobook_episodes MODIFY `status` ENUM('".implode("','", $transition)."') NOT NULL");
+
         $mapping = [
             'Skript wird erstellt' => 'Skripterstellung',
             'In Korrekturlesung' => 'Korrekturlesung',
@@ -25,6 +53,8 @@ return new class extends Migration
         foreach ($mapping as $old => $new) {
             DB::table('audiobook_episodes')->where('status', $old)->update(['status' => $new]);
         }
+
+        DB::statement("ALTER TABLE audiobook_episodes MODIFY `status` ENUM('".implode("','", $newValues)."') NOT NULL");
     }
 
     /**
@@ -32,12 +62,39 @@ return new class extends Migration
      */
     public function down(): void
     {
+        $oldValues = [
+            'Skript wird erstellt',
+            'In Korrekturlesung',
+            'Rollenbesetzung',
+            'Aufnahmen in Arbeit',
+            'Musikerstellung',
+            'Audiobearbeitung gestartet',
+            'Videobearbeitung gestartet',
+            'Cover und Thumbnail in Arbeit',
+            'Veröffentlichung geplant',
+            'Veröffentlicht',
+        ];
+
+        $newValues = [
+            'Skripterstellung',
+            'Korrekturlesung',
+            'Rollenbesetzung',
+            'Aufnahmensammlung',
+            'Musikerstellung',
+            'Audiobearbeitung',
+            'Videobearbeitung',
+            'Grafiken',
+            'Veröffentlichungsplanung',
+            'Veröffentlichung',
+        ];
+
+        $transition = array_unique(array_merge($oldValues, $newValues));
+        DB::statement("ALTER TABLE audiobook_episodes MODIFY `status` ENUM('".implode("','", $transition)."') NOT NULL");
+
         $mapping = [
             'Skripterstellung' => 'Skript wird erstellt',
             'Korrekturlesung' => 'In Korrekturlesung',
-            'Rollenbesetzung' => 'Aufnahmen in Arbeit',
             'Aufnahmensammlung' => 'Aufnahmen in Arbeit',
-            'Musikerstellung' => 'Audiobearbeitung gestartet',
             'Audiobearbeitung' => 'Audiobearbeitung gestartet',
             'Videobearbeitung' => 'Videobearbeitung gestartet',
             'Grafiken' => 'Cover und Thumbnail in Arbeit',
@@ -48,5 +105,7 @@ return new class extends Migration
         foreach ($mapping as $new => $old) {
             DB::table('audiobook_episodes')->where('status', $new)->update(['status' => $old]);
         }
+
+        DB::statement("ALTER TABLE audiobook_episodes MODIFY `status` ENUM('".implode("','", $oldValues)."') NOT NULL");
     }
 };


### PR DESCRIPTION
## Summary
- Adjust audiobook episode status migration to modify enum before updating values
- Add down migration for status changes

## Testing
- `./vendor/bin/phpunit` *(fails: Test code or tested code did not remove its own exception handlers)*
- `php artisan migrate --pretend` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bebfd528832e814600310f19623e