### PR TITLE
Use MySQL for CI tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -20,7 +20,7 @@ jobs:
     
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:8
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
           MYSQL_ROOT_PASSWORD: password
@@ -28,6 +28,14 @@ jobs:
         ports:
           - 3306/tcp
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    env:
+      DB_CONNECTION: mysql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_DATABASE: laravel_testing
+      DB_USERNAME: root
+      DB_PASSWORD: password
 
     name: PHP ${{ matrix.php-version }} - Feature Tests
     
@@ -77,23 +85,15 @@ jobs:
 
     - name: Directory Permissions
       run: chmod -R 755 storage bootstrap/cache
-
-    - name: Create Database
-      run: |
-        mkdir -p database
-        touch database/database.sqlite
+    - name: Run migrations
+      run: php artisan migrate --force
 
     - name: Execute tests (Feature tests only)
-      env:
-        DB_CONNECTION: sqlite
-        DB_DATABASE: database/database.sqlite
       run: php artisan test tests/Feature
 
     - name: Execute tests with coverage (PHP 8.3 only)
       if: matrix.php-version == '8.3'
       env:
-        DB_CONNECTION: sqlite
-        DB_DATABASE: database/database.sqlite
         XDEBUG_MODE: coverage
       run: php artisan test tests/Feature --coverage-clover=coverage.xml
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,8 +19,12 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="sqlite"/>
-        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_CONNECTION" value="mysql"/>
+        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_PORT" value="3306"/>
+        <env name="DB_USERNAME" value="root"/>
+        <env name="DB_PASSWORD" value="password"/>
+        <env name="DB_DATABASE" value="laravel_testing"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
This pull request updates the test environment configuration to use MySQL instead of SQLite for running feature tests in CI. The changes ensure that both the GitHub Actions workflow and the PHPUnit configuration use consistent MySQL settings, and migrations are run before executing tests.

**Test environment migration to MySQL:**

* Updated the MySQL service image version from `mysql:8.0` to `mysql:8` in `.github/workflows/unittests.yml` for better compatibility and consistency.
* Added environment variables for MySQL connection (`DB_CONNECTION`, `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`) to the workflow configuration, ensuring tests connect to the correct database.

**Test setup changes:**

* Removed steps for creating an SQLite database and switched to running Laravel migrations with MySQL before executing feature tests, aligning the workflow with the new database setup.

**Configuration consistency:**

* Updated `phpunit.xml` to use MySQL environment variables instead of SQLite, ensuring local and CI test runs use the same database configuration.