### PR TITLE
Ensure workflow MySQL port mapping for tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -25,7 +25,8 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: laravel_testing
-        ports: ["3306:3306"]
+        ports:
+          - "3306:3306"
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     env:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -25,8 +25,7 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: false
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: laravel_testing
-        ports:
-          - 3306/tcp
+        ports: ["3306:3306"]
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     env:


### PR DESCRIPTION
This pull request makes a small change to the MySQL service configuration in the `.github/workflows/unittests.yml` file. The change updates the port mapping format to ensure the MySQL container exposes port 3306 correctly for unit tests.