### PR TITLE
Fix CreateNewUserActionTest foreign key handling

### DIFF
--- a/tests/Feature/CreateNewUserActionTest.php
+++ b/tests/Feature/CreateNewUserActionTest.php
@@ -20,7 +20,8 @@ class CreateNewUserActionTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        Schema::drop('users');
+        Schema::disableForeignKeyConstraints();
+        Schema::dropIfExists('users');
         Schema::create('users', function (Blueprint $table) {
             $table->id();
             $table->string('name');
@@ -28,6 +29,7 @@ class CreateNewUserActionTest extends TestCase
             $table->string('password');
             $table->timestamps();
         });
+        Schema::enableForeignKeyConstraints();
     }
 
     public function test_user_is_created_with_personal_team_when_terms_feature_disabled(): void


### PR DESCRIPTION
This pull request makes a small improvement to the test setup in `CreateNewUserActionTest`. The change ensures that foreign key constraints are properly handled when resetting the `users` table before each test run.

* Test setup improvement:
  - In the `setUp` method of `CreateNewUserActionTest`, foreign key constraints are now disabled before dropping the `users` table and re-enabled after recreating it, and `Schema::dropIfExists` is used instead of `Schema::drop` for safer table removal.