### PR TITLE
Rename Vorstand menu to Admin and restrict access

### DIFF
--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -13,24 +13,11 @@ use Carbon\Carbon;
 
 class HoerbuchController extends Controller
 {
-    private function ensureAdminOrVorstand(): void
-    {
-        $user = Auth::user();
-        $memberTeam = Team::where('name', 'Mitglieder')->first();
-        $membership = $memberTeam?->users()->where('user_id', $user->id)->first();
-        $userRole = $membership ? $membership->membership->role : null;
-
-        if (!in_array($userRole, ['Vorstand', 'Admin'], true)) {
-            abort(403);
-        }
-    }
     /**
      * Übersicht aller Hörbuchfolgen.
      */
     public function index()
     {
-        $this->ensureAdminOrVorstand();
-
         $episodes = AudiobookEpisode::all()
             ->sortBy(function ($episode) {
                 return $this->parsePlannedReleaseDate($episode->planned_release_date) ?? Carbon::create(9999, 12, 31);
@@ -105,8 +92,6 @@ class HoerbuchController extends Controller
      */
     public function create()
     {
-        $this->ensureAdminOrVorstand();
-
         $users = User::orderBy('name')->get();
 
         return view('hoerbuecher.create', [
@@ -120,8 +105,6 @@ class HoerbuchController extends Controller
      */
     public function store(Request $request)
     {
-        $this->ensureAdminOrVorstand();
-
         $request->validate([
             'episode_number' => 'required|string|max:10|unique:audiobook_episodes,episode_number',
             'title' => 'required|string|max:255',
@@ -145,8 +128,6 @@ class HoerbuchController extends Controller
      */
     public function show(AudiobookEpisode $episode)
     {
-        $this->ensureAdminOrVorstand();
-
         return view('hoerbuecher.show', [
             'episode' => $episode,
         ]);
@@ -157,8 +138,6 @@ class HoerbuchController extends Controller
      */
     public function edit(AudiobookEpisode $episode)
     {
-        $this->ensureAdminOrVorstand();
-
         $users = User::orderBy('name')->get();
 
         return view('hoerbuecher.edit', [
@@ -173,8 +152,6 @@ class HoerbuchController extends Controller
      */
     public function update(Request $request, AudiobookEpisode $episode)
     {
-        $this->ensureAdminOrVorstand();
-
         $request->validate([
             'episode_number' => [
                 'required',
@@ -203,8 +180,6 @@ class HoerbuchController extends Controller
      */
     public function destroy(AudiobookEpisode $episode)
     {
-        $this->ensureAdminOrVorstand();
-
         $episode->delete();
 
         return redirect()->route('hoerbuecher.index')

--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -28,7 +28,7 @@ class NewsletterController extends Controller
     {
         $user = Auth::user();
         $team = $user?->currentTeam;
-        if (! $team || ! ($team->hasUserWithRole($user, 'Vorstand') || $team->hasUserWithRole($user, 'Admin'))) {
+        if (! $team || ! $team->hasUserWithRole($user, 'Admin')) {
             abort(403);
         }
 
@@ -45,7 +45,7 @@ class NewsletterController extends Controller
     {
         $user = Auth::user();
         $team = $user?->currentTeam;
-        if (! $team || ! ($team->hasUserWithRole($user, 'Vorstand') || $team->hasUserWithRole($user, 'Admin'))) {
+        if (! $team || ! $team->hasUserWithRole($user, 'Admin')) {
             abort(403);
         }
 

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -60,10 +60,10 @@
                         </div>
                         @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
-                            <button id="vorstand-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="vorstand-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
-                                Vorstand
+                            <button id="admin-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="admin-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                                Admin
                             </button>
-                            <div id="vorstand-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="vorstand-button">
+                            <div id="admin-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="admin-button">
                                 <x-dropdown-link href="{{ route('admin.index') }}">Admin</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-dropdown-link>
@@ -161,9 +161,9 @@
                 <x-responsive-nav-link href="{{ route('statistik.index') }}">Statistik</x-responsive-nav-link>
             </div>
             @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
-            <button id="vorstand-mobile-button" type="button" @click="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'vorstand' }" :aria-expanded="openMenu === 'vorstand'" aria-controls="vorstand-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" @keydown.space.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')">
-            Vorstand</button>
-            <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic" aria-labelledby="vorstand-mobile-button">
+            <button id="admin-mobile-button" type="button" @click="openMenu = (openMenu === 'admin' ? null : 'admin')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'admin' }" :aria-expanded="openMenu === 'admin'" aria-controls="admin-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')" @keydown.space.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')">
+            Admin</button>
+            <div id="admin-mobile-menu" x-show="openMenu === 'admin'" x-cloak class="italic" aria-labelledby="admin-mobile-button">
                 <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-responsive-nav-link>

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,7 +67,7 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
 
     Route::get('/fotogalerie', [PhotoGalleryController::class, 'index'])->name('fotogalerie');
 
-    Route::prefix('newsletter')->name('newsletter.')->controller(NewsletterController::class)->group(function () {
+    Route::prefix('newsletter')->name('newsletter.')->controller(NewsletterController::class)->middleware('admin')->group(function () {
         Route::get('versenden', 'create')->name('create');
         Route::post('versenden', 'send')->name('send');
     });
@@ -104,7 +104,7 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::post('{todo}/pruefen', 'verify')->name('verify');
         Route::post('{todo}/freigeben', 'release')->name('release');
     });
-    Route::prefix('hoerbuecher')->name('hoerbuecher.')->controller(HoerbuchController::class)->group(function () {
+    Route::prefix('hoerbuecher')->name('hoerbuecher.')->controller(HoerbuchController::class)->middleware('admin')->group(function () {
         Route::get('/', 'index')->name('index');
         Route::get('erstellen', 'create')->name('create');
         Route::post('/', 'store')->name('store');

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -109,6 +109,14 @@ class HoerbuchControllerTest extends TestCase
             ->assertForbidden();
     }
 
+    public function test_vorstand_cannot_view_create_form(): void
+    {
+        $user = $this->actingMember('Vorstand');
+
+        $this->actingAs($user)->get(route('hoerbuecher.create'))
+            ->assertForbidden();
+    }
+
     public function test_admin_can_view_index_and_episodes(): void
     {
         $user = $this->actingMember('Admin');

--- a/tests/Feature/NewsletterControllerTest.php
+++ b/tests/Feature/NewsletterControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class NewsletterControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingMember(string $role = 'Mitglied'): User
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => $role]);
+        return $user;
+    }
+
+    public function test_admin_can_view_newsletter_form(): void
+    {
+        $user = $this->actingMember('Admin');
+
+        $this->actingAs($user)
+            ->get(route('newsletter.create'))
+            ->assertOk();
+    }
+
+    public function test_vorstand_cannot_view_newsletter_form(): void
+    {
+        $user = $this->actingMember('Vorstand');
+
+        $this->actingAs($user)
+            ->get(route('newsletter.create'))
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
This pull request refactors access control for admin features by restricting certain actions and navigation elements to users with the `Admin` role only. Previously, both `Vorstand` and `Admin` roles had access to these features. The changes affect backend authorization logic, route middleware, navigation UI labels, and tests to ensure only `Admin` users can access relevant functionality.

**Access Control Updates**

* Removed the `ensureAdminOrVorstand` method from `HoerbuchController` and replaced per-action checks with a single `admin` middleware at the route level, ensuring only `Admin` users can access all audiobook episode management actions (`index`, `create`, `store`, `show`, `edit`, `update`, `destroy`) (`[[1]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL16-L33)`, `[[2]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL108-L109)`, `[[3]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL123-L124)`, `[[4]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL148-L149)`, `[[5]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL160-L161)`, `[[6]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL176-L177)`, `[[7]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL206-L207)`, `[[8]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL107-R107)`).
* Updated `NewsletterController` to restrict access to newsletter creation and sending to `Admin` users only, both in controller logic and via `admin` middleware in routes (`[[1]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddL31-R31)`, `[[2]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddL48-R48)`, `[[3]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL70-R70)`).

**Navigation and UI Changes**

* Renamed navigation menu items and button IDs from `Vorstand` to `Admin` in `navigation-menu.blade.php`, reflecting the new role restriction in both desktop and mobile views (`[[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL63-R66)`, `[[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL164-R166)`).

**Testing Updates**

* Added and updated feature tests to verify that only `Admin` users can access newsletter and audiobook management forms, and that `Vorstand` users are now forbidden (`[[1]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1R112-R119)`, `[[2]](diffhunk://#diff-75caeae44fa3a8ca89ab8ee4f92623f9dec8d45bd1030442b5e9bfff078bf3c5R1-R39)`).