### PR TITLE
Combine status and progress columns on hoerbuecher overview

### DIFF
--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -40,11 +40,10 @@
                                     <div
                                         class="mt-1 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4"
                                         role="progressbar"
-                                        aria-label="Fortschritt"
                                         aria-valuenow="{{ $episode->progress }}"
                                         aria-valuemin="0"
                                         aria-valuemax="100"
-                                        aria-describedby="episode-{{ $episode->id }}-status"
+                                        aria-labelledby="episode-{{ $episode->id }}-status"
                                     >
                                         {{-- Map 0–100% progress to a hue range of 0–120 (red → green). --}}
                                         <div class="h-4 rounded-full text-xs font-medium text-center leading-none text-white" style="width: {{ $episode->progress }}%; background-color: hsl({{ $episode->progressHue() }}, 100%, 40%);">

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -19,8 +19,7 @@
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Folge</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Titel</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Ziel-EVT</th>
-                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Status</th>
-                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Fortschritt</th>
+                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Status &amp; Fortschritt</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Rollen</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Bemerkungen</th>
                         </tr>
@@ -36,9 +35,9 @@
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->episode_number }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->planned_release_date }}</td>
-                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->status }}</td>
-                                <td class="px-4 py-2">
-                                    <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4">
+                                <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
+                                    <div>{{ $episode->status }}</div>
+                                    <div class="mt-1 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4">
                                         {{-- Map 0–100% progress to a hue range of 0–120 (red → green). --}}
                                         <div class="h-4 rounded-full text-xs font-medium text-center leading-none text-white" style="width: {{ $episode->progress }}%; background-color: hsl({{ $episode->progressHue() }}, 100%, 40%);">
                                             {{ $episode->progress }}%

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -36,7 +36,7 @@
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->planned_release_date }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
-                                    <span id="episode-{{ $episode->id }}-status" role="status" aria-live="polite">{{ $episode->status }}</span>
+                                    <span id="episode-{{ $episode->id }}-status">{{ $episode->status }}</span>
                                     <div
                                         class="mt-1 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4"
                                         role="progressbar"

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -36,15 +36,14 @@
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->planned_release_date }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
-                                    <span id="episode-{{ $episode->id }}-status">{{ $episode->status }}</span>
+                                    <span>{{ $episode->status }}</span>
                                     <div
                                         class="mt-1 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4"
                                         role="progressbar"
                                         aria-valuenow="{{ $episode->progress }}"
                                         aria-valuemin="0"
                                         aria-valuemax="100"
-                                        aria-labelledby="episode-{{ $episode->id }}-status"
-                                    >
+                                        aria-label="Episode progress: {{ $episode->status }}, {{ $episode->progress }}% complete">
                                         {{-- Map 0–100% progress to a hue range of 0–120 (red → green). --}}
                                         <div class="h-4 rounded-full text-xs font-medium text-center leading-none text-white" style="width: {{ $episode->progress }}%; background-color: hsl({{ $episode->progressHue() }}, 100%, 40%);">
                                             {{ $episode->progress }}%

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -19,7 +19,7 @@
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Folge</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Titel</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Ziel-EVT</th>
-                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Status &amp; Fortschritt</th>
+                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Status & Fortschritt</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Rollen</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Bemerkungen</th>
                         </tr>

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -36,8 +36,16 @@
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->planned_release_date }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
-                                    <div>{{ $episode->status }}</div>
-                                    <div class="mt-1 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4">
+                                    <span id="episode-{{ $episode->id }}-status" role="status" aria-live="polite">{{ $episode->status }}</span>
+                                    <div
+                                        class="mt-1 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4"
+                                        role="progressbar"
+                                        aria-label="Fortschritt"
+                                        aria-valuenow="{{ $episode->progress }}"
+                                        aria-valuemin="0"
+                                        aria-valuemax="100"
+                                        aria-describedby="episode-{{ $episode->id }}-status"
+                                    >
                                         {{-- Map 0–100% progress to a hue range of 0–120 (red → green). --}}
                                         <div class="h-4 rounded-full text-xs font-medium text-center leading-none text-white" style="width: {{ $episode->progress }}%; background-color: hsl({{ $episode->progressHue() }}, 100%, 40%);">
                                             {{ $episode->progress }}%


### PR DESCRIPTION
This pull request updates the episode listing table in `resources/views/hoerbuecher/index.blade.php` to combine the "Status" and "Fortschritt" (progress) columns into a single column, improving clarity and accessibility. The progress bar now appears directly beneath the status text and includes better accessibility attributes.

**Table layout and accessibility improvements:**

* Combined the "Status" and "Fortschritt" columns into a single "Status & Fortschritt" column in the episodes table header.
* Updated the episode row to display the status text and progress bar together, and added accessibility attributes (`role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-label`) to the progress bar for improved screen reader support.