### PR TITLE
Add Vorstand menu for EARDRAX and broaden access control

### DIFF
--- a/app/Http/Middleware/EnsureVorstand.php
+++ b/app/Http/Middleware/EnsureVorstand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureVorstand
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = Auth::user();
+        $team = $user?->currentTeam;
+
+        if (
+            $team && (
+                $team->hasUserWithRole($user, 'Admin') ||
+                $team->hasUserWithRole($user, 'Vorstand') ||
+                $team->hasUserWithRole($user, 'Kassenwart')
+            )
+        ) {
+            return $next($request);
+        }
+
+        abort(403);
+    }
+}

--- a/app/Http/Middleware/EnsureVorstand.php
+++ b/app/Http/Middleware/EnsureVorstand.php
@@ -17,15 +17,8 @@ class EnsureVorstand
     public function handle(Request $request, Closure $next): Response
     {
         $user = Auth::user();
-        $team = $user?->currentTeam;
 
-        if (
-            $team && (
-                $team->hasUserWithRole($user, 'Admin') ||
-                $team->hasUserWithRole($user, 'Vorstand') ||
-                $team->hasUserWithRole($user, 'Kassenwart')
-            )
-        ) {
+        if ($user?->hasVorstandRole()) {
             return $next($request);
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -186,17 +186,6 @@ class User extends Authenticatable
     }
 
     /**
-     * Check if the user has any of the given roles on the current team.
-     *
-     * @param  array<string>  $roles
-     * @return bool
-     */
-    public function hasAnyRole(array $roles): bool
-    {
-        return in_array($this->role(), $roles, true);
-    }
-
-    /**
      * Check if the user has the given role on the current team.
      *
      * @param  string  $role
@@ -212,6 +201,8 @@ class User extends Authenticatable
      */
     public function hasVorstandRole(): bool
     {
-        return $this->hasAnyRole(['Admin', 'Vorstand', 'Kassenwart']);
+        return $this->hasRole('Admin')
+            || $this->hasRole('Vorstand')
+            || $this->hasRole('Kassenwart');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -206,4 +206,12 @@ class User extends Authenticatable
     {
         return $this->role() === $role;
     }
+
+    /**
+     * Determine if the user holds a Vorstand-level role.
+     */
+    public function hasVorstandRole(): bool
+    {
+        return $this->hasAnyRole(['Admin', 'Vorstand', 'Kassenwart']);
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\URL;
@@ -72,5 +73,7 @@ class AppServiceProvider extends ServiceProvider
 
             $view->with('socialImage', $socialImage);
         });
+
+        Blade::if('vorstand', fn () => auth()->check() && auth()->user()->hasVorstandRole());
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,6 +16,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'redirect.if.anwaerter' => \App\Http\Middleware\RedirectIfAnwaerter::class,
             'admin' => \App\Http\Middleware\EnsureAdmin::class,
+            'vorstand' => \App\Http\Middleware\EnsureVorstand::class,
         ]);
         $middleware->appendToGroup('web', \App\Http\Middleware\UpdateLastActivity::class);
         $middleware->appendToGroup('web', \App\Http\Middleware\LogPageVisit::class);

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -58,6 +58,16 @@
                                 <x-dropdown-link href="{{ route('statistik.index') }}">Statistik</x-dropdown-link>
                             </div>
                         </div>
+                        @if(Auth::user()->currentTeam && (Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin') || Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Vorstand') || Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Kassenwart')))
+                        <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
+                            <button id="vorstand-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="vorstand-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                                Vorstand
+                            </button>
+                            <div id="vorstand-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="vorstand-button">
+                                <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
+                            </div>
+                        </div>
+                        @endif
                         @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
                             <button id="admin-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="admin-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
@@ -65,7 +75,6 @@
                             </button>
                             <div id="admin-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="admin-button">
                                 <x-dropdown-link href="{{ route('admin.index') }}">Admin</x-dropdown-link>
-                                <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('arbeitsgruppen.create') }}">Neue AG</x-dropdown-link>
                             </div>
@@ -160,12 +169,18 @@
                 <x-responsive-nav-link href="{{ route('kompendium.index') }}">Kompendium</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('statistik.index') }}">Statistik</x-responsive-nav-link>
             </div>
+            @if(Auth::user()->currentTeam && (Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin') || Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Vorstand') || Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Kassenwart')))
+            <button id="vorstand-mobile-button" type="button" @click="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'vorstand' }" :aria-expanded="openMenu === 'vorstand'" aria-controls="vorstand-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" @keydown.space.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')">
+            Vorstand</button>
+            <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic" aria-labelledby="vorstand-mobile-button">
+                <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
+            </div>
+            @endif
             @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
             <button id="admin-mobile-button" type="button" @click="openMenu = (openMenu === 'admin' ? null : 'admin')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'admin' }" :aria-expanded="openMenu === 'admin'" aria-controls="admin-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')" @keydown.space.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')">
             Admin</button>
             <div id="admin-mobile-menu" x-show="openMenu === 'admin'" x-cloak class="italic" aria-labelledby="admin-mobile-button">
                 <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
-                <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('arbeitsgruppen.create') }}">Neue AG</x-responsive-nav-link>
             </div>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -58,7 +58,7 @@
                                 <x-dropdown-link href="{{ route('statistik.index') }}">Statistik</x-dropdown-link>
                             </div>
                         </div>
-                        @if(Auth::user()->currentTeam && (Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin') || Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Vorstand') || Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Kassenwart')))
+                        @vorstand
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
                             <button id="vorstand-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="vorstand-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
                                 Vorstand
@@ -67,8 +67,8 @@
                                 <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
                             </div>
                         </div>
-                        @endif
-                        @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
+                        @endvorstand
+                        @if(Auth::user()->hasRole('Admin'))
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
                             <button id="admin-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="admin-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
                                 Admin
@@ -169,14 +169,14 @@
                 <x-responsive-nav-link href="{{ route('kompendium.index') }}">Kompendium</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('statistik.index') }}">Statistik</x-responsive-nav-link>
             </div>
-            @if(Auth::user()->currentTeam && (Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin') || Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Vorstand') || Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Kassenwart')))
+            @vorstand
             <button id="vorstand-mobile-button" type="button" @click="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'vorstand' }" :aria-expanded="openMenu === 'vorstand'" aria-controls="vorstand-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" @keydown.space.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')">
             Vorstand</button>
             <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic" aria-labelledby="vorstand-mobile-button">
                 <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
             </div>
-            @endif
-            @if(Auth::user()->currentTeam && Auth::user()->currentTeam->hasUserWithRole(Auth::user(), 'Admin'))
+            @endvorstand
+            @if(Auth::user()->hasRole('Admin'))
             <button id="admin-mobile-button" type="button" @click="openMenu = (openMenu === 'admin' ? null : 'admin')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'admin' }" :aria-expanded="openMenu === 'admin'" aria-controls="admin-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')" @keydown.space.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')">
             Admin</button>
             <div id="admin-mobile-menu" x-show="openMenu === 'admin'" x-cloak class="italic" aria-labelledby="admin-mobile-button">

--- a/routes/web.php
+++ b/routes/web.php
@@ -104,14 +104,17 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::post('{todo}/pruefen', 'verify')->name('verify');
         Route::post('{todo}/freigeben', 'release')->name('release');
     });
-    Route::prefix('hoerbuecher')->name('hoerbuecher.')->controller(HoerbuchController::class)->middleware('admin')->group(function () {
-        Route::get('/', 'index')->name('index');
-        Route::get('erstellen', 'create')->name('create');
-        Route::post('/', 'store')->name('store');
-        Route::get('{episode}', 'show')->name('show');
-        Route::get('{episode}/bearbeiten', 'edit')->name('edit');
-        Route::put('{episode}', 'update')->name('update');
-        Route::delete('{episode}', 'destroy')->name('destroy');
+    Route::prefix('hoerbuecher')->name('hoerbuecher.')->controller(HoerbuchController::class)->group(function () {
+        Route::get('/', 'index')->name('index')->middleware('vorstand');
+
+        Route::middleware('admin')->group(function () {
+            Route::get('erstellen', 'create')->name('create');
+            Route::post('/', 'store')->name('store');
+            Route::get('{episode}', 'show')->name('show');
+            Route::get('{episode}/bearbeiten', 'edit')->name('edit');
+            Route::put('{episode}', 'update')->name('update');
+            Route::delete('{episode}', 'destroy')->name('destroy');
+        });
     });
 
     Route::prefix('arbeitsgruppen')->name('arbeitsgruppen.')->controller(ArbeitsgruppenController::class)->middleware('admin')->group(function () {

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -408,4 +408,47 @@ class HoerbuchControllerTest extends TestCase
             ->get(route('dashboard'))
             ->assertSee('EARDRAX Dashboard');
     }
+
+    public function test_vorstand_sees_eardrax_dashboard_link_in_navigation(): void
+    {
+        $user = $this->actingMember('Vorstand');
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertSee('EARDRAX Dashboard');
+    }
+
+    public function test_kassenwart_sees_eardrax_dashboard_link_in_navigation(): void
+    {
+        $user = $this->actingMember('Kassenwart');
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertSee('EARDRAX Dashboard');
+    }
+
+    public function test_member_does_not_see_eardrax_dashboard_link_in_navigation(): void
+    {
+        $user = $this->actingMember('Mitglied');
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertDontSee('EARDRAX Dashboard');
+    }
+
+    public function test_vorstand_can_view_index(): void
+    {
+        $user = $this->actingMember('Vorstand');
+
+        $this->actingAs($user)->get(route('hoerbuecher.index'))
+            ->assertOk();
+    }
+
+    public function test_kassenwart_can_view_index(): void
+    {
+        $user = $this->actingMember('Kassenwart');
+
+        $this->actingAs($user)->get(route('hoerbuecher.index'))
+            ->assertOk();
+    }
 }


### PR DESCRIPTION
This pull request introduces a new "Vorstand" role group and refines role-based access control throughout the application. The main changes include adding middleware and Blade directives for the Vorstand group, updating navigation to show Vorstand-specific links, and adjusting route protection. Comprehensive tests were also added to ensure correct visibility and access for Vorstand, Kassenwart, Admin, and regular members.

**Role and Middleware Enhancements**

* Added a new `EnsureVorstand` middleware to restrict access to certain routes to users with Vorstand-level roles (`Admin`, `Vorstand`, or `Kassenwart`). (`app/Http/Middleware/EnsureVorstand.php`)
* Updated the `User` model to support the new Vorstand role group with the `hasVorstandRole()` method and refactored role checks for clarity and maintainability. (`app/Models/User.php`)
* Registered the new middleware alias `vorstand` in the application bootstrap. (`bootstrap/app.php`)

**Blade & Navigation Updates**

* Introduced a custom Blade directive `@vorstand` for conditional rendering based on Vorstand-level roles. (`app/Providers/AppServiceProvider.php`) [[1]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR5) [[2]](diffhunk://#diff-3f9cb162826c97814fdb7396bf74ebd40cdab174ba6f3e308cbc9a368393e48eR76-R77)
* Updated navigation menus to show the "EARDRAX Dashboard" link for Vorstand roles and removed duplicate links from the Admin menu. (`resources/views/navigation-menu.blade.php`) [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL61-L68) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL163-L168)

**Route Protection**

* Changed the route protection for the `hoerbuecher.index` route to use the new Vorstand middleware, allowing Vorstand, Kassenwart, and Admin users access, while restricting other actions to Admins only. (`routes/web.php`)

**Testing**

* Added feature tests to verify that only Vorstand-level users see the EARDRAX Dashboard link and can access the dashboard, while regular members cannot. (`tests/Feature/HoerbuchControllerTest.php`)