### PR TITLE
Add hardcover author statistic and rename novel chart

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -49,6 +49,15 @@ class StatistikController extends Controller
             ->countBy()                // Anzahl pro Autor
             ->sortDesc();              // nach Häufigkeit absteigend
 
+        // ── Card 29 – Hardcover je Autor (inkl. Co-Autor:innen) ────────────────
+        $hardcoverAuthorCounts = $hardcovers
+            ->pluck('text')
+            ->flatten()
+            ->map(fn($a) => trim($a))
+            ->filter()
+            ->countBy()
+            ->sortDesc();
+
         // ── Card 3 – Top Teamplayer ─────────────────────────────────────────
         $teamplayerTable = $romane
             ->filter(fn($r) => collect($r['text'])->filter()->count() > 1)
@@ -399,6 +408,7 @@ class StatistikController extends Controller
             'weltratValues' => $weltratValues,
             'hardcoverLabels' => $hardcoverLabels,
             'hardcoverValues' => $hardcoverValues,
+            'hardcoverAuthorCounts' => $hardcoverAuthorCounts,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -7,8 +7,8 @@ return [
         'points' => 1,
     ],
     [
-        'title' => 'Statistik - Anzahl Romane je Autor:in',
-        'description' => 'Balkendiagramm mit der Anzahl Romane je Autor:in.',
+        'title' => 'Statistik - Maddrax-Romane je Autor:in',
+        'description' => 'Balkendiagramm mit der Anzahl Maddrax-Romane je Autor:in.',
         'points' => 2,
     ],
     [
@@ -165,6 +165,11 @@ return [
         'title' => 'Statistik - Bewertungen der Hardcover',
         'description' => 'Zeigt Bewertungen der Hardcover aus dem Maddraxikon in einem Liniendiagramm.',
         'points' => 40,
+    ],
+    [
+        'title' => 'Statistik - Maddrax-Hardcover je Autor:in',
+        'description' => 'Balkendiagramm mit der Anzahl der Maddrax-Hardcover je Autor:in.',
+        'points' => 41,
     ],
     [
         'title' => 'Kompendium-Suche',

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -4,7 +4,7 @@ import { DataTable } from 'simple-datatables';
 import 'simple-datatables/dist/style.css';
 
 /**
- * Rendert das Balkendiagramm „Romane je Autor:in“,
+ * Rendert ein Balkendiagramm,
  * wenn das Canvas existiert.
  */
 function drawAuthorChart(canvasId, labels, data) {
@@ -78,6 +78,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const labels = window.authorChartLabels ?? [];
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);
+
+    const hcAuthorLabels = window.hardcoverAuthorChartLabels ?? [];
+    const hcAuthorValues = window.hardcoverAuthorChartValues ?? [];
+    drawAuthorChart('hardcoverAuthorChart', hcAuthorLabels, hcAuthorValues);
 
     const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka', 'weltrat'];
     cycles.forEach((cycle) => {

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -12,7 +12,7 @@
             @if ($userPoints >= 2)
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
-                        Romane je Autor:in
+                        Maddrax-Romane je Autor:in
                     </h2>
                     <canvas id="authorChart" height="140"></canvas>
                 </div>
@@ -568,6 +568,21 @@
                 <script>
                     window.hardcoverChartLabels = @json($hardcoverLabels);
                     window.hardcoverChartValues = @json($hardcoverValues);
+                </script>
+            @endif
+
+            {{-- Card 29 – Hardcover je Autor:in (≥ 41 Baxx) --}}
+            @if ($userPoints >= 41)
+                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Maddrax-Hardcover je Autor:in
+                    </h2>
+                    <canvas id="hardcoverAuthorChart" height="140"></canvas>
+                </div>
+
+                <script>
+                    window.hardcoverAuthorChartLabels = @json($hardcoverAuthorCounts->keys());
+                    window.hardcoverAuthorChartValues = @json($hardcoverAuthorCounts->values());
                 </script>
             @endif
 

--- a/tests/Feature/RewardControllerTest.php
+++ b/tests/Feature/RewardControllerTest.php
@@ -72,4 +72,15 @@ class RewardControllerTest extends TestCase
         $response->assertOk();
         $response->assertSee('Statistik - Bewertungen der Hardcover');
     }
+
+    public function test_hardcover_author_reward_visible(): void
+    {
+        $user = $this->actingMember(41);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $response->assertSee('Statistik - Maddrax-Hardcover je Autor:in');
+    }
 }

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -79,6 +79,7 @@ class StatistikTest extends TestCase
                 'nummer' => $i,
                 'titel' => 'HC' . $i,
                 'bewertung' => $rating,
+                'text' => ['HC Author' . (($i % 2) + 1)],
             ];
         }
         $path = storage_path('app/private/hardcovers.json');
@@ -549,5 +550,31 @@ class StatistikTest extends TestCase
 
         $response->assertOk();
         $response->assertDontSee('Bewertungen der Hardcover');
+    }
+
+    public function test_hardcover_author_chart_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $this->createHardcoversFile();
+        $user = $this->actingMemberWithPoints(41);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('Maddrax-Hardcover je Autor:in');
+    }
+
+    public function test_hardcover_author_chart_hidden_below_threshold(): void
+    {
+        $this->createDataFile();
+        $this->createHardcoversFile();
+        $user = $this->actingMemberWithPoints(40);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertDontSee('Maddrax-Hardcover je Autor:in');
     }
 }

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -76,4 +76,24 @@ describe('statistik module', () => {
     const config = mockChart.mock.calls[0][1];
     expect(config.type).toBe('line');
   });
+
+  test('DOMContentLoaded draws hardcover author chart', async () => {
+    jest.resetModules();
+    const chartModule = await import('chart.js/auto');
+    const datatableModule = await import('simple-datatables');
+    mockChart = chartModule.default;
+    datatableModule.DataTable.mockClear();
+    mockChart.mockClear();
+
+    document.body.innerHTML = '<canvas id="hardcoverAuthorChart"></canvas>';
+    window.hardcoverAuthorChartLabels = ['A'];
+    window.hardcoverAuthorChartValues = [2];
+
+    await import('../../resources/js/statistik.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(mockChart).toHaveBeenCalled();
+    const config = mockChart.mock.calls[0][1];
+    expect(config.type).toBe('bar');
+  });
 });


### PR DESCRIPTION
## Summary
- rename "Romane je Autor:in" to "Maddrax-Romane je Autor:in"
- add bar chart for "Maddrax-Hardcover je Autor:in" with 41 Baxx reward
- expose new reward entry and tests for hardcover author stats

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=:memory: php artisan test` *(fails: QueryException)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e1ef1ad8832e84c55cb32fe65943