### PR TITLE
Add average line to statistics charts

### DIFF
--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -37,19 +37,31 @@ function drawCycleChart(canvasId, labels, data) {
     const canvas = document.getElementById(canvasId);
     if (!canvas) return;
 
+    const average = data.length ? data.reduce((sum, val) => sum + val, 0) / data.length : 0;
+    const averageData = Array(labels.length).fill(average);
+
     new Chart(canvas.getContext('2d'), {
         type: 'line',
         data: {
             labels,
-            datasets: [{
-                data,
-                borderColor: 'rgba(139, 1, 22, .8)',
-                backgroundColor: 'rgba(139, 1, 22, .3)',
-                tension: 0.3,
-            }],
+            datasets: [
+                {
+                    data,
+                    borderColor: 'rgba(139, 1, 22, .8)',
+                    backgroundColor: 'rgba(139, 1, 22, .3)',
+                    tension: 0.3,
+                },
+                {
+                    data: averageData,
+                    borderColor: 'rgba(54, 162, 235, .8)',
+                    pointRadius: 0,
+                    fill: false,
+                    label: 'Durchschnitt',
+                },
+            ],
         },
         options: {
-            plugins: { legend: { display: false } },
+            plugins: { legend: { display: true } },
             scales:  { y: { beginAtZero: true, ticks: { stepSize: 1 } } },
         },
     });

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -36,15 +36,17 @@ describe('statistik module', () => {
     expect(config.data.datasets[0].data).toEqual([1, 2]);
   });
 
-  test('drawCycleChart renders line chart with given labels', () => {
+  test('drawCycleChart renders line chart with given labels and average line', () => {
     document.body.innerHTML = '<canvas id="cycle"></canvas>';
-    drawCycleChart('cycle', ['X'], [5]);
+    drawCycleChart('cycle', ['X', 'Y'], [4, 6]);
 
     expect(mockChart).toHaveBeenCalledTimes(1);
     const config = mockChart.mock.calls[0][1];
     expect(config.type).toBe('line');
-    expect(config.data.labels).toEqual(['X']);
-    expect(config.data.datasets[0].data).toEqual([5]);
+    expect(config.data.labels).toEqual(['X', 'Y']);
+    expect(config.data.datasets[0].data).toEqual([4, 6]);
+    expect(config.data.datasets[1].data).toEqual([5, 5]);
+    expect(config.options.plugins.legend.display).toBe(true);
   });
 
   test('initRomaneTable initializes DataTable and sorts column', () => {


### PR DESCRIPTION
This pull request updates the cycle chart rendering functionality to visually display the average value as a separate line and ensures that the corresponding tests reflect this new feature. The changes improve both the user experience and test coverage for the chart component.

**Chart rendering improvements:**

* The `drawCycleChart` function in `statistik.js` now calculates the average of the data and adds it as a second dataset, resulting in a new average line on the chart. The chart legend is also enabled for better clarity.

**Test updates:**

* The test for `drawCycleChart` in `statistik.test.js` is updated to verify that the chart includes both the data line and the average line, checks for correct labels and datasets, and ensures the legend is displayed.