### PR TITLE
Combine hardcover crawling into crawlnovels command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ Die im Footer angezeigte Versionsnummer wird automatisch aus dem neuesten Git-Ta
 | Romane komplett neu indexieren | `php artisan romane:index --fresh` |
 | Romane & Hardcover importieren | `php artisan books:import` |
 | Rezensionen importieren | `php artisan reviews:import-old --fresh` |
-| Neue Romane crawlen | `php artisan crawlnovels` |
-| Neue Hardcover crawlen | `php artisan crawlhardcovers` |
+| Neue Romane & Hardcover crawlen | `php artisan crawlnovels` |
 | Sitemap generieren | `php artisan sitemap:generate` |
 
 Weitere Befehle lassen sich über `php artisan list` anzeigen.


### PR DESCRIPTION
This pull request refactors and improves the `CrawlNovels` command, primarily to streamline the crawling process for novels and hardcovers and to clean up the code. The most significant change is that the command now automatically triggers the hardcover crawling after finishing novels, reducing manual steps. Several minor code style and formatting improvements have also been made for consistency.

**Crawling process improvements:**

* The `CrawlNovels` command now automatically calls the `CrawlHardcovers` command after successfully updating `maddrax.json`, combining the crawling of novels and hardcovers into a single step.

**Code style and consistency:**

* Reordered and grouped imports in `app/Console/Commands/CrawlNovels.php` for better readability.
* Replaced `new DOMDocument()` with `new DOMDocument` for consistency and removed unnecessary parentheses in object instantiation. [[1]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5L71-R75) [[2]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5L95-R104) [[3]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5L162-R167)
* Added blank lines in several places to improve code readability and separation of logic. [[1]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5R24) [[2]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5R35) [[3]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5R90) [[4]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5R182)

**Documentation update:**

* Updated the `README.md` to reflect that crawling both novels and hardcovers is now done with a single command, simplifying instructions for developers.