### PR TITLE
Add favorite hardcover dropdown to user profiles

### DIFF
--- a/app/Actions/Fortify/UpdateUserSeriendaten.php
+++ b/app/Actions/Fortify/UpdateUserSeriendaten.php
@@ -20,6 +20,7 @@ class UpdateUserSeriendaten
             'lieblingsautor' => ['nullable', 'string', 'max:255'],
             'lieblingszyklus' => ['nullable', 'string', 'max:255'],
             'lieblingsthema' => ['nullable', 'string', 'max:255'],
+            'lieblingshardcover' => ['nullable', 'string', 'max:255'],
         ])->validateWithBag('updateSeriendaten');
 
         $user->forceFill([
@@ -32,6 +33,7 @@ class UpdateUserSeriendaten
             'lieblingsautor' => $input['lieblingsautor'] ?? null,
             'lieblingszyklus' => $input['lieblingszyklus'] ?? null,
             'lieblingsthema' => $input['lieblingsthema'] ?? null,
+            'lieblingshardcover' => $input['lieblingshardcover'] ?? null,
         ])->save();
     }
 }

--- a/app/Livewire/Profile/UpdateSeriendatenForm.php
+++ b/app/Livewire/Profile/UpdateSeriendatenForm.php
@@ -6,6 +6,8 @@ use Livewire\Component;
 use App\Actions\Fortify\UpdateUserSeriendaten;
 use Illuminate\Support\Facades\Auth;
 use App\Services\MaddraxDataService;
+use App\Models\Book;
+use App\Enums\BookType;
 
 class UpdateSeriendatenForm extends Component
 {
@@ -16,6 +18,7 @@ class UpdateSeriendatenForm extends Component
     public array $figuren = [];
     public array $schauplaetze = [];
     public array $schlagworte = [];
+    public array $hardcover = [];
 
     public function mount()
     {
@@ -29,6 +32,7 @@ class UpdateSeriendatenForm extends Component
             'lieblingsautor',
             'lieblingszyklus',
             'lieblingsthema',
+            'lieblingshardcover',
         ]);
         $this->autoren = MaddraxDataService::getAutoren();
         $this->zyklen = MaddraxDataService::getZyklen();
@@ -36,6 +40,11 @@ class UpdateSeriendatenForm extends Component
         $this->figuren = MaddraxDataService::getFiguren();
         $this->schauplaetze = MaddraxDataService::getSchauplaetze();
         $this->schlagworte = MaddraxDataService::getSchlagworte();
+        $this->hardcover = Book::where('type', BookType::MaddraxHardcover)
+            ->orderBy('roman_number')
+            ->get()
+            ->map(fn ($book) => ($book->roman_number ? $book->roman_number.' - ' : '').$book->title)
+            ->toArray();
     }
 
     public function updateSeriendaten(UpdateUserSeriendaten $updater)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -27,6 +27,7 @@ use Carbon\Carbon;
  * @property string|null $lieblingsautor
  * @property string|null $lieblingszyklus
  * @property string|null $lieblingsthema
+ * @property string|null $lieblingshardcover
  */
 class User extends Authenticatable
 {
@@ -67,6 +68,7 @@ class User extends Authenticatable
         'lieblingsautor',
         'lieblingszyklus',
         'lieblingsthema',
+        'lieblingshardcover',
         'mitglied_seit',
         'bezahlt_bis',
         'notify_new_review',

--- a/database/migrations/2025_09_20_000000_add_lieblingshardcover_to_users_table.php
+++ b/database/migrations/2025_09_20_000000_add_lieblingshardcover_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('lieblingshardcover')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('lieblingshardcover');
+        });
+    }
+};

--- a/lang/de/profile.php
+++ b/lang/de/profile.php
@@ -5,6 +5,7 @@ return [
     'Aktueller Lesestand (optional)' => 'Aktueller Lesestand (optional)',
     'Lieblingsautor:in (optional)' => 'Lieblingsautor:in (optional)',
     'Lieblingsroman (optional)' => 'Lieblingsroman (optional)',
+    'Lieblingshardcover (optional)' => 'Lieblingshardcover (optional)',
     'Lieblingsthema (optional)' => 'Lieblingsthema (optional)',
     'Persönliche Daten' => 'Persönliche Daten',
     'Hier kannst du ganz einfach deine persönlichen Angaben aktualisieren. Bitte halte diese Informationen möglichst aktuell, damit wir dich erreichen können. Während Namen und Foto für andere sichtbar sind, bleiben deine Adressdaten und dein eingestellter Mitgliedsbeitrag für andere Mitglieder unsichtbar.' => 'Hier kannst du ganz einfach deine persönlichen Angaben aktualisieren. Bitte halte diese Informationen möglichst aktuell, damit wir dich erreichen können. Während Namen und Foto für andere sichtbar sind, bleiben deine Adressdaten und dein eingestellter Mitgliedsbeitrag für andere Mitglieder unsichtbar.',

--- a/resources/views/profile/update-seriendaten-form.blade.php
+++ b/resources/views/profile/update-seriendaten-form.blade.php
@@ -57,6 +57,18 @@
             </select>
             <x-input-error for="lieblingsroman" class="mt-2" />
         </div>
+        <!-- Lieblingshardcover Dropdown -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="lieblingshardcover" value="{{ __('Lieblingshardcover (optional)') }}" />
+            <select id="lieblingshardcover" wire:model="state.lieblingshardcover"
+                class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-800 rounded-md shadow-sm">
+                <option value="">Hardcover auswählen</option>
+                @foreach($hardcover as $hc)
+                    <option value="{{ $hc }}">{{ $hc }}</option>
+                @endforeach
+            </select>
+            <x-input-error for="lieblingshardcover" class="mt-2" />
+        </div>
         <!-- Lieblingszyklus Dropdown -->
         <div class="col-span-6 sm:col-span-4">
             <x-label for="lieblingszyklus" value="{{ __('Lieblingszyklus (optional)') }}" />

--- a/resources/views/profile/view.blade.php
+++ b/resources/views/profile/view.blade.php
@@ -188,6 +188,13 @@
                                     </div>
                                 @endif
 
+                                @if($user->lieblingshardcover)
+                                    <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg shadow">
+                                        <h3 class="font-semibold text-gray-800 dark:text-white mb-2">Lieblingshardcover</h3>
+                                        <p class="text-gray-600 dark:text-gray-300">{{ $user->lieblingshardcover }}</p>
+                                    </div>
+                                @endif
+
                                 @if($user->lieblingsfigur)
                                     <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg shadow">
                                         <h3 class="font-semibold text-gray-800 dark:text-white mb-2">Lieblingsfigur</h3>

--- a/tests/Feature/UpdateSeriendatenFormTest.php
+++ b/tests/Feature/UpdateSeriendatenFormTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature;
 use App\Livewire\Profile\UpdateSeriendatenForm;
 use App\Models\Team;
 use App\Models\User;
+use App\Models\Book;
+use App\Enums\BookType;
 use App\Services\MaddraxDataService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
@@ -55,6 +57,10 @@ class UpdateSeriendatenFormTest extends TestCase
             ],
         ];
         File::put($this->testStoragePath . '/app/private/maddrax.json', json_encode($data));
+
+        // Create some hardcover books
+        Book::create(['roman_number' => 1, 'title' => 'Hardcover1', 'author' => 'Author1', 'type' => BookType::MaddraxHardcover]);
+        Book::create(['roman_number' => 2, 'title' => 'Hardcover2', 'author' => 'Author2', 'type' => BookType::MaddraxHardcover]);
     }
 
     protected function tearDown(): void
@@ -84,6 +90,7 @@ class UpdateSeriendatenFormTest extends TestCase
             'lieblingsautor' => 'Author1',
             'lieblingszyklus' => 'Z1',
             'lieblingsthema' => 'Thema1',
+            'lieblingshardcover' => '1 - Hardcover1',
         ])->save();
 
         $this->actingAs($user);
@@ -101,12 +108,14 @@ class UpdateSeriendatenFormTest extends TestCase
             ->assertSet('state.lieblingsautor', 'Author1')
             ->assertSet('state.lieblingszyklus', 'Z1')
             ->assertSet('state.lieblingsthema', 'Thema1')
+            ->assertSet('state.lieblingshardcover', '1 - Hardcover1')
             ->assertSet('autoren', ['Author1', 'Author2'])
             ->assertSet('zyklen', ['Z1', 'Z2'])
             ->assertSet('romane', ['1 - Roman1', '2 - Roman2'])
             ->assertSet('figuren', ['Figur1', 'Figur2'])
             ->assertSet('schauplaetze', ['Ort1', 'Ort2'])
-            ->assertSet('schlagworte', ['Thema1', 'Thema2']);
+            ->assertSet('schlagworte', ['Thema1', 'Thema2'])
+            ->assertSet('hardcover', ['1 - Hardcover1', '2 - Hardcover2']);
     }
 
     public function test_seriendaten_can_be_updated(): void
@@ -125,6 +134,7 @@ class UpdateSeriendatenFormTest extends TestCase
                 'lieblingsautor' => 'Author2',
                 'lieblingszyklus' => 'Z2',
                 'lieblingsthema' => 'Thema2',
+                'lieblingshardcover' => '2 - Hardcover2',
             ])
             ->call('updateSeriendaten')
             ->assertDispatched('saved');
@@ -140,5 +150,6 @@ class UpdateSeriendatenFormTest extends TestCase
         $this->assertSame('Author2', $user->lieblingsautor);
         $this->assertSame('Z2', $user->lieblingszyklus);
         $this->assertSame('Thema2', $user->lieblingsthema);
+        $this->assertSame('2 - Hardcover2', $user->lieblingshardcover);
     }
 }

--- a/tests/Feature/UpdateSeriendatenTest.php
+++ b/tests/Feature/UpdateSeriendatenTest.php
@@ -24,6 +24,7 @@ class UpdateSeriendatenTest extends TestCase
             'lieblingsautor' => 'Autor',
             'lieblingszyklus' => 'Zyklus',
             'lieblingsthema' => 'Thema',
+            'lieblingshardcover' => 'HC',
         ]));
 
         $component = Livewire::test(UpdateSeriendatenForm::class);
@@ -37,6 +38,7 @@ class UpdateSeriendatenTest extends TestCase
         $this->assertSame('Autor', $component->get('state.lieblingsautor'));
         $this->assertSame('Zyklus', $component->get('state.lieblingszyklus'));
         $this->assertSame('Thema', $component->get('state.lieblingsthema'));
+        $this->assertSame('HC', $component->get('state.lieblingshardcover'));
     }
 
     public function test_seriendaten_can_be_updated(): void
@@ -54,6 +56,7 @@ class UpdateSeriendatenTest extends TestCase
                 'lieblingsautor' => 'G',
                 'lieblingszyklus' => 'H',
                 'lieblingsthema' => 'I',
+                'lieblingshardcover' => 'J',
             ])
             ->call('updateSeriendaten');
 
@@ -68,6 +71,7 @@ class UpdateSeriendatenTest extends TestCase
         $this->assertSame('G', $user->lieblingsautor);
         $this->assertSame('H', $user->lieblingszyklus);
         $this->assertSame('I', $user->lieblingsthema);
+        $this->assertSame('J', $user->lieblingshardcover);
     }
 
     public function test_validation_fails_for_too_long_values(): void


### PR DESCRIPTION
## Summary
- allow members to select a favorite Maddrax hardcover in their profile
- store the chosen hardcover on the user model and show it on profile pages
- cover the new field with tests and translations

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a3df2004b4832eaed3240dc87c10c2