### PR TITLE
Wrap profile page content in card container

### DIFF
--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -1,37 +1,46 @@
 <x-app-layout>
     <x-member-page>
-        <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-red-400 mb-6">{{ __('Profil') }}</h1>
-        @if (Laravel\Fortify\Features::canUpdateProfileInformation())
-            @livewire('profile.update-profile-information-form')
+        <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
+            <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-red-400 mb-6">{{ __('Profil') }}</h1>
+
+            @if (Laravel\Fortify\Features::canUpdateProfileInformation())
+                @livewire('profile.update-profile-information-form')
+                <x-section-border />
+            @endif
+
+            {{-- Serienspezifische Daten ergänzen --}}
+            @livewire('profile.update-seriendaten-form')
             <x-section-border />
-        @endif
-        {{-- Serienspezifische Daten ergänzen --}}
-        @livewire('profile.update-seriendaten-form')
-        <x-section-border />
-        @if (Auth::user()->hasRole('Ehrenmitglied'))
-            @livewire('profile.update-review-notification-form')
-            <x-section-border />
-        @endif
-        @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::updatePasswords()))
+
+            @if (Auth::user()->hasRole('Ehrenmitglied'))
+                @livewire('profile.update-review-notification-form')
+                <x-section-border />
+            @endif
+
+            @if (Laravel\Fortify\Features::enabled(Laravel\Fortify\Features::updatePasswords()))
+                <div class="mt-10 sm:mt-0">
+                    @livewire('profile.update-password-form')
+                </div>
+                <x-section-border />
+            @endif
+
+            {{-- @if (Laravel\Fortify\Features::canManageTwoFactorAuthentication())
             <div class="mt-10 sm:mt-0">
-                @livewire('profile.update-password-form')
+                @livewire('profile.two-factor-authentication-form')
             </div>
             <x-section-border />
-        @endif
-        {{-- @if (Laravel\Fortify\Features::canManageTwoFactorAuthentication())
-        <div class="mt-10 sm:mt-0">
-            @livewire('profile.two-factor-authentication-form')
-        </div>
-        <x-section-border />
-        @endif --}}
-        <div class="mt-10 sm:mt-0">
-            @livewire('profile.logout-other-browser-sessions-form')
-        </div>
-        @if (Laravel\Jetstream\Jetstream::hasAccountDeletionFeatures())
-            <x-section-border />
+            @endif --}}
+
             <div class="mt-10 sm:mt-0">
-                @livewire('profile.delete-user-form')
+                @livewire('profile.logout-other-browser-sessions-form')
             </div>
-        @endif
+
+            @if (Laravel\Jetstream\Jetstream::hasAccountDeletionFeatures())
+                <x-section-border />
+                <div class="mt-10 sm:mt-0">
+                    @livewire('profile.delete-user-form')
+                </div>
+            @endif
+        </div>
     </x-member-page>
 </x-app-layout>


### PR DESCRIPTION
This pull request makes a small UI improvement to the profile page by adding a styled container around the profile sections. This enhances the visual appearance and grouping of the profile management forms.

* Wrapped all profile management sections in a `div` with classes for background color, rounded corners, shadow, and padding in `profile/show.blade.php` to improve layout and visual consistency.