### PR TITLE
Round days until next audiobook release

### DIFF
--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -40,7 +40,8 @@ class HoerbuchController extends Controller
 
         $daysUntilNextEvt = null;
         if ($nextEpisode?->planned_release_date_parsed) {
-            $daysUntilNextEvt = max(0, Carbon::now()->diffInDays($nextEpisode->planned_release_date_parsed, false));
+            $diff = Carbon::now()->diffInDays($nextEpisode->planned_release_date_parsed, false);
+            $daysUntilNextEvt = (int) max(0, round($diff, 0, PHP_ROUND_HALF_UP));
         }
 
         return view('hoerbuecher.index', [

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -41,7 +41,7 @@ class HoerbuchController extends Controller
         $daysUntilNextEvt = null;
         if ($nextEpisode?->planned_release_date_parsed) {
             $diff = Carbon::now()->diffInDays($nextEpisode->planned_release_date_parsed, false);
-            $daysUntilNextEvt = (int) max(0, round($diff, 0, PHP_ROUND_HALF_UP));
+            $daysUntilNextEvt = (int) max(0, $diff);
         }
 
         return view('hoerbuecher.index', [


### PR DESCRIPTION
This pull request includes a minor update to the calculation of days until the next event in the `index` method of `HoerbuchController.php`. The change ensures the result is explicitly cast to an integer, improving type consistency.

* Explicitly cast the result of `max(0, $diff)` to integer for `$daysUntilNextEvt` assignment in `public function index()` of `HoerbuchController.php`.