### PR TITLE
Add Maddrax hardcover section to reviews

### DIFF
--- a/app/Http/Controllers/RezensionController.php
+++ b/app/Http/Controllers/RezensionController.php
@@ -57,27 +57,41 @@ class RezensionController extends Controller
         $user = Auth::user();
         $teamId = $this->memberTeam()->id;
 
-        $query = Book::query()->where('type', BookType::MaddraxDieDunkleZukunftDerErde);
+        $applyFilters = function ($query) use ($request) {
+            if ($request->filled('roman_number')) {
+                $query->where('roman_number', $request->integer('roman_number'));
+            }
 
-        if ($request->filled('roman_number')) {
-            $query->where('roman_number', $request->integer('roman_number'));
-        }
+            if ($request->filled('title')) {
+                $query->where('title', 'like', '%' . $request->input('title') . '%');
+            }
 
-        if ($request->filled('title')) {
-            $query->where('title', 'like', '%' . $request->input('title') . '%');
-        }
+            if ($request->filled('author')) {
+                $query->where('author', 'like', '%' . $request->input('author') . '%');
+            }
 
-        if ($request->filled('author')) {
-            $query->where('author', 'like', '%' . $request->input('author') . '%');
-        }
+            if ($request->input('review_status') === 'with') {
+                $query->whereHas('reviews');
+            } elseif ($request->input('review_status') === 'without') {
+                $query->doesntHave('reviews');
+            }
+        };
 
-        if ($request->input('review_status') === 'with') {
-            $query->whereHas('reviews');
-        } elseif ($request->input('review_status') === 'without') {
-            $query->doesntHave('reviews');
-        }
+        $novelsQuery = Book::query()->where('type', BookType::MaddraxDieDunkleZukunftDerErde);
+        $applyFilters($novelsQuery);
 
-        $books = $query->withCount('reviews')
+        $hardcoversQuery = Book::query()->where('type', BookType::MaddraxHardcover);
+        $applyFilters($hardcoversQuery);
+
+        $books = $novelsQuery->withCount('reviews')
+            ->withExists(['reviews as has_review' => function ($query) use ($user, $teamId) {
+                $query->where('team_id', $teamId)
+                    ->where('user_id', $user->id);
+            }])
+            ->orderBy('roman_number')
+            ->get();
+
+        $hardcovers = $hardcoversQuery->withCount('reviews')
             ->withExists(['reviews as has_review' => function ($query) use ($user, $teamId) {
                 $query->where('team_id', $teamId)
                     ->where('user_id', $user->id);
@@ -101,6 +115,7 @@ class RezensionController extends Controller
 
         return view('reviews.index', [
             'booksByCycle' => $booksByCycle,
+            'hardcovers' => $hardcovers,
             'title' => 'Rezensionen – Offizieller MADDRAX Fanclub e. V.',
             'description' => 'Alle Vereinsrezensionen zu den Maddrax-Romanen im Überblick.',
         ]);

--- a/app/Http/Controllers/RezensionController.php
+++ b/app/Http/Controllers/RezensionController.php
@@ -96,7 +96,7 @@ class RezensionController extends Controller
                 $query->where('team_id', $teamId)
                     ->where('user_id', $user->id);
             }])
-            ->orderBy('roman_number')
+            ->orderByDesc('roman_number')
             ->get();
 
         $jsonPath = storage_path('app/private/maddrax.json');

--- a/resources/views/reviews/index.blade.php
+++ b/resources/views/reviews/index.blade.php
@@ -141,6 +141,98 @@
                         </div>
                     </div>
                 @endforeach
+                @if($hardcovers->isNotEmpty())
+                    @php
+                        $id = 'maddrax-hardcover';
+                        $reviewCount = $hardcovers->sum('reviews_count');
+                    @endphp
+                    <div class="mb-4 border border-gray-200 dark:border-gray-700 rounded-lg">
+                        <h2>
+                            <button type="button" class="w-full flex justify-between items-center bg-gray-100 dark:bg-gray-700 px-4 py-3 rounded-t-lg font-semibold" onclick="toggleAccordion('{{ $id }}')">
+                                Maddrax-Hardcover ({{ $reviewCount }} {{ $reviewCount === 1 ? 'Rezension' : 'Rezensionen' }})
+                                <span id="icon-{{ $id }}">+</span>
+                            </button>
+                        </h2>
+                        <div id="content-{{ $id }}" class="hidden bg-white dark:bg-gray-900 px-4 py-2 rounded-b-lg">
+                            <div class="hidden md:block overflow-x-auto">
+                                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                    <thead>
+                                        <tr>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Nr.</th>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Titel</th>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Autor</th>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Status</th>
+                                            <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-300">Rezensionen</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                                        @foreach($hardcovers->sortByDesc('roman_number') as $book)
+                                            <tr>
+                                                <td class="px-4 py-2">
+                                                    <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline">
+                                                        {{ $book->roman_number }}
+                                                    </a>
+                                                </td>
+                                                <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ $book->title }}</td>
+                                                <td class="px-4 py-2 text-gray-800 dark:text-gray-200">{{ $book->author }}</td>
+                                                <td class="px-4 py-2">
+                                                    @if($book->has_review)
+                                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 00-1.414-1.414L8.5 10.672 5.707 7.879a1 1 0 00-1.414 1.414l3.647 3.647a1 1 0 001.414 0l7.353-7.353z" clip-rule="evenodd" />
+                                                            </svg>
+                                                        </span>
+                                                    @else
+                                                        <a href="{{ route('reviews.create', $book) }}" class="inline-flex items-center p-1 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100 hover:bg-blue-200 dark:hover:bg-blue-700" title="Rezension schreiben">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                                <path d="m2.695 14.762-1.262 3.155a.5.5 0 0 0 .65.65l3.155-1.262a4 4 0 0 0 1.343-.886L17.5 5.501a2.121 2.121 0 0 0-3-3L3.58 13.419a4 4 0 0 0-.885 1.343Z" />
+                                                            </svg>
+                                                        </a>
+                                                    @endif
+                                                </td>
+                                                <td class="px-4 py-2">
+                                                    <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline">
+                                                        {{ $book->reviews_count }} {{ $book->reviews_count === 1 ? 'Rezension' : 'Rezensionen' }}
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        @endforeach
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="md:hidden">
+                                @foreach($hardcovers->sortByDesc('roman_number') as $book)
+                                    <div class="py-2 border-b border-gray-200 dark:border-gray-700 flex justify-between items-start">
+                                        <div>
+                                            <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline font-semibold">
+                                                Nr. {{ $book->roman_number }}: {{ $book->title }}
+                                            </a>
+                                            <p class="text-gray-600 dark:text-gray-400 text-sm">{{ $book->author }}</p>
+                                        </div>
+                                        <div class="text-right">
+                                            @if($book->has_review)
+                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 00-1.414-1.414L8.5 10.672 5.707 7.879a1 1 0 00-1.414 1.414l3.647 3.647a1 1 0 001.414 0l7.353-7.353z" clip-rule="evenodd" />
+                                                    </svg>
+                                                </span>
+                                            @else
+                                                <a href="{{ route('reviews.create', $book) }}" class="inline-flex items-center p-1 rounded-full bg-blue-100 text-blue-800 dark:bg-blue-800 dark:text-blue-100 hover:bg-blue-200 dark:hover:bg-blue-700" title="Rezension schreiben">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                                                        <path d="m2.695 14.762-1.262 3.155a.5.5 0 0 0 .65.65l3.155-1.262a4 4 0 0 0 1.343-.886L17.5 5.501a2.121 2.121 0 0 0-3-3L3.58 13.419a4 4 0 0 0-.885 1.343Z" />
+                                                    </svg>
+                                                </a>
+                                            @endif
+                                            <a href="{{ route('reviews.show', $book) }}" class="block text-[#8B0116] hover:underline text-sm mt-1">
+                                                {{ $book->reviews_count }} {{ $book->reviews_count === 1 ? 'Rezension' : 'Rezensionen' }}
+                                            </a>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    </div>
+                @endif
             </div>
         </div>
     </div>

--- a/resources/views/reviews/index.blade.php
+++ b/resources/views/reviews/index.blade.php
@@ -166,7 +166,7 @@
                                         </tr>
                                     </thead>
                                     <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                                        @foreach($hardcovers->sortByDesc('roman_number') as $book)
+                                        @foreach($hardcovers as $book)
                                             <tr>
                                                 <td class="px-4 py-2">
                                                     <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline">
@@ -201,7 +201,7 @@
                                 </table>
                             </div>
                             <div class="md:hidden">
-                                @foreach($hardcovers->sortByDesc('roman_number') as $book)
+                                @foreach($hardcovers as $book)
                                     <div class="py-2 border-b border-gray-200 dark:border-gray-700 flex justify-between items-start">
                                         <div>
                                             <a href="{{ route('reviews.show', $book) }}" class="text-[#8B0116] hover:underline font-semibold">

--- a/tests/Feature/ReviewCreationTest.php
+++ b/tests/Feature/ReviewCreationTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Models\Book;
 use Illuminate\Support\Facades\Mail;
 use App\Models\Review;
+use App\Enums\BookType;
 
 class ReviewCreationTest extends TestCase
 {
@@ -45,6 +46,35 @@ class ReviewCreationTest extends TestCase
             'book_id' => $book->id,
             'user_id' => $user->id,
             'title' => 'Tolles Buch',
+        ]);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_member_can_store_hardcover_review(): void
+    {
+        Mail::fake();
+
+        $book = Book::create([
+            'roman_number' => 1,
+            'title' => 'Hardcover1',
+            'author' => 'Author One',
+            'type' => BookType::MaddraxHardcover,
+        ]);
+
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $response = $this->post("/rezensionen/{$book->id}", [
+            'title' => 'Tolles Hardcover',
+            'content' => str_repeat('A', 150),
+        ]);
+
+        $response->assertRedirect(route('reviews.show', $book));
+        $this->assertDatabaseHas('reviews', [
+            'book_id' => $book->id,
+            'user_id' => $user->id,
+            'title' => 'Tolles Hardcover',
         ]);
 
         Mail::assertNothingSent();

--- a/tests/Feature/RezensionControllerTest.php
+++ b/tests/Feature/RezensionControllerTest.php
@@ -140,7 +140,7 @@ class RezensionControllerTest extends TestCase
             ->assertSee('(2 Rezensionen)');
     }
 
-    public function test_index_hides_hardcover_books(): void
+    public function test_index_shows_hardcover_books(): void
     {
         Storage::fake('private');
         Storage::disk('private')->put('maddrax.json', json_encode([
@@ -162,7 +162,7 @@ class RezensionControllerTest extends TestCase
         $this->get('/rezensionen')
             ->assertOk()
             ->assertSee($book->title)
-            ->assertDontSee('Hardcover Beta');
+            ->assertSee('Hardcover Beta');
     }
 
     public function test_show_redirects_when_user_has_no_permission(): void


### PR DESCRIPTION
This pull request adds support for displaying and reviewing Maddrax hardcover books alongside the existing novels in the reviews section. The main changes include updating the backend to fetch and filter hardcover books, updating the view to display them, and adding tests to ensure hardcovers are correctly handled.

**Backend changes to support hardcovers:**

* Refactored the `index` method in `RezensionController.php` to separately query and filter both novels and hardcovers, using a shared filtering logic, and passing both to the view. [[1]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L60-R60) [[2]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004R78-R94) [[3]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004R118)

**Frontend changes to display hardcovers:**

* Updated `reviews/index.blade.php` to add an accordion section for Maddrax hardcovers, showing review counts and allowing users to write or view reviews for each hardcover.

**Test coverage for hardcovers:**

* Added a feature test to ensure members can create reviews for hardcover books, verifying database changes and mail handling. [[1]](diffhunk://#diff-51667080898febb5184181d6062dd89dda9631a20f23e7343a62212e08401aa3R12) [[2]](diffhunk://#diff-51667080898febb5184181d6062dd89dda9631a20f23e7343a62212e08401aa3R54-R82)
* Updated controller tests to check that hardcovers are now displayed in the index view, instead of being hidden. [[1]](diffhunk://#diff-c6cb5de1de52446d6a7697a615d2b09851d53cc2bb3c9f9ba83dafa323ff5355L143-R143) [[2]](diffhunk://#diff-c6cb5de1de52446d6a7697a615d2b09851d53cc2bb3c9f9ba83dafa323ff5355L165-R165)