### PR TITLE
feat: show previous speaker hint for audiobook roles

### DIFF
--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -224,18 +224,14 @@ class HoerbuchController extends Controller
     public function previousSpeaker(Request $request): JsonResponse
     {
         $data = $request->validate([
-            'name' => 'nullable|string|max:255',
+            'name' => 'required|string|max:255',
         ]);
-        $name = $data['name'] ?? null;
 
-        $role = null;
-        if ($name) {
-            $role = AudiobookRole::where('name', $name)
-                ->where(fn ($q) => $q->whereNotNull('user_id')->orWhereNotNull('speaker_name'))
-                ->with('user')
-                ->latest('id')
-                ->first();
-        }
+        $role = AudiobookRole::where('name', $data['name'])
+            ->where(fn ($q) => $q->whereNotNull('user_id')->orWhereNotNull('speaker_name'))
+            ->with('user')
+            ->latest('id')
+            ->first();
 
         return response()->json([
             'speaker' => $role?->user?->name ?? $role?->speaker_name,

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -223,7 +223,10 @@ class HoerbuchController extends Controller
      */
     public function previousSpeaker(Request $request): JsonResponse
     {
-        $name = $request->query('name');
+        $data = $request->validate([
+            'name' => 'nullable|string|max:255',
+        ]);
+        $name = $data['name'] ?? null;
 
         $role = null;
         if ($name) {

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -7,6 +7,7 @@ use App\Models\AudiobookRole;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 use App\Rules\ValidReleaseTime;
@@ -215,6 +216,27 @@ class HoerbuchController extends Controller
 
         return redirect()->route('hoerbuecher.index')
             ->with('status', 'Hörbuchfolge wurde aktualisiert.');
+    }
+
+    /**
+     * Gibt den bisherigen Sprecher einer Rolle zurück.
+     */
+    public function previousSpeaker(Request $request): JsonResponse
+    {
+        $name = $request->query('name');
+
+        $role = null;
+        if ($name) {
+            $role = AudiobookRole::where('name', $name)
+                ->where(fn ($q) => $q->whereNotNull('user_id')->orWhereNotNull('speaker_name'))
+                ->with('user')
+                ->latest('id')
+                ->first();
+        }
+
+        return response()->json([
+            'speaker' => $role?->user->name ?? $role?->speaker_name,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -93,11 +93,12 @@ class HoerbuchController extends Controller
             return [];
         }
 
-        return AudiobookRole::whereIn('name', $names)
+        return AudiobookRole::useIndex('audiobook_roles_name_user_speaker_index')
+            ->whereIn('name', $names)
             ->where(fn ($q) => $q->whereNotNull('user_id')->orWhereNotNull('speaker_name'))
             ->with('user')
-            ->orderBy('name')
             ->orderByDesc('id')
+            ->orderBy('name')
             ->get()
             ->groupBy('name')
             ->map(fn ($r) => $r->first()->user?->name ?? $r->first()->speaker_name)

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -96,10 +96,11 @@ class HoerbuchController extends Controller
         return AudiobookRole::whereIn('name', $names)
             ->where(fn ($q) => $q->whereNotNull('user_id')->orWhereNotNull('speaker_name'))
             ->with('user')
-            ->orderBy('id')
+            ->orderBy('name')
+            ->orderByDesc('id')
             ->get()
             ->groupBy('name')
-            ->map(fn ($r) => $r->last()->user?->name ?? $r->last()->speaker_name)
+            ->map(fn ($r) => $r->first()->user?->name ?? $r->first()->speaker_name)
             ->toArray();
     }
 

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -238,7 +238,7 @@ class HoerbuchController extends Controller
         }
 
         return response()->json([
-            'speaker' => $role?->user->name ?? $role?->speaker_name,
+            'speaker' => $role?->user?->name ?? $role?->speaker_name,
         ]);
     }
 

--- a/database/migrations/2025_09_22_000000_add_name_user_speaker_index_to_audiobook_roles_table.php
+++ b/database/migrations/2025_09_22_000000_add_name_user_speaker_index_to_audiobook_roles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('audiobook_roles', function (Blueprint $table) {
+            $table->index(['name', 'user_id', 'speaker_name'], 'audiobook_roles_name_user_speaker_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('audiobook_roles', function (Blueprint $table) {
+            $table->dropIndex('audiobook_roles_name_user_speaker_index');
+        });
+    }
+};

--- a/resources/js/hoerbuch-role-form.js
+++ b/resources/js/hoerbuch-role-form.js
@@ -33,7 +33,9 @@ if (data) {
             }
             controller = new AbortController();
             const token = document.querySelector('meta[name="csrf-token"]')?.content;
-            fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`, {
+            const url = new URL(previousSpeakerUrl, window.location.origin);
+            url.search = new URLSearchParams({ name }).toString();
+            fetch(url, {
                 signal: controller.signal,
                 headers: token ? { 'X-CSRF-TOKEN': token, 'X-Requested-With': 'XMLHttpRequest' } : { 'X-Requested-With': 'XMLHttpRequest' }
             })

--- a/resources/js/hoerbuch-role-form.js
+++ b/resources/js/hoerbuch-role-form.js
@@ -32,7 +32,11 @@ if (data) {
                 return;
             }
             controller = new AbortController();
-            fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`, { signal: controller.signal })
+            const token = document.querySelector('meta[name="csrf-token"]')?.content;
+            fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`, {
+                signal: controller.signal,
+                headers: token ? { 'X-CSRF-TOKEN': token, 'X-Requested-With': 'XMLHttpRequest' } : { 'X-Requested-With': 'XMLHttpRequest' }
+            })
                 .then(r => {
                     if (r.status === 401) throw new Error('unauthorized');
                     if (!r.ok) throw new Error('request-failed');

--- a/resources/js/hoerbuch-role-form.js
+++ b/resources/js/hoerbuch-role-form.js
@@ -1,0 +1,82 @@
+const data = window.roleFormData;
+if (data) {
+    const members = data.members || [];
+    const previousSpeakerUrl = data.previousSpeakerUrl;
+    let roleIndex = data.roleIndex || 0;
+
+    function debounce(fn, delay = 300) {
+        let timeout;
+        return (...args) => {
+            clearTimeout(timeout);
+            timeout = setTimeout(() => fn(...args), delay);
+        };
+    }
+
+    function bindRoleRow(row) {
+        const memberInput = row.querySelector('input[list]');
+        const hidden = row.querySelector('input[type="hidden"]');
+        const roleNameInput = row.querySelector('input[name$="[name]"]');
+        const hint = row.querySelector('.previous-speaker');
+        let controller;
+
+        memberInput.addEventListener('input', e => {
+            const option = members.find(m => m.name === e.target.value);
+            hidden.value = option ? option.id : '';
+        });
+
+        function updateHint() {
+            const name = roleNameInput.value.trim();
+            controller?.abort();
+            if (!name) {
+                hint.textContent = '';
+                return;
+            }
+            controller = new AbortController();
+            fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`, { signal: controller.signal })
+                .then(r => {
+                    if (r.status === 401) throw new Error('unauthorized');
+                    if (!r.ok) throw new Error('request-failed');
+                    return r.json();
+                })
+                .then(data => {
+                    hint.textContent = data.speaker ? `Bisheriger Sprecher: ${data.speaker}` : '';
+                })
+                .catch(err => {
+                    if (err.name === 'AbortError') return;
+                    hint.textContent = err.message === 'unauthorized'
+                        ? 'Nicht berechtigt'
+                        : 'Fehler beim Laden des bisherigen Sprechers';
+                });
+        }
+
+        const debouncedHint = debounce(updateHint);
+        roleNameInput.addEventListener('input', debouncedHint);
+        roleNameInput.addEventListener('blur', updateHint);
+
+        row.querySelector('button').addEventListener('click', () => row.remove());
+        updateHint();
+    }
+
+    function addRole() {
+        const container = document.getElementById('roles_list');
+        const wrapper = document.createElement('div');
+        wrapper.className = 'grid grid-cols-5 gap-2 mb-2 items-start role-row';
+        wrapper.innerHTML = `
+            <input type="text" name="roles[${roleIndex}][name]" placeholder="Rolle" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+            <input type="text" name="roles[${roleIndex}][description]" placeholder="Beschreibung" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+            <input type="number" name="roles[${roleIndex}][takes]" min="0" placeholder="Takes" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+            <div class="col-span-1">
+                <input type="text" name="roles[${roleIndex}][member_name]" list="members" placeholder="Sprecher" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+                <input type="hidden" name="roles[${roleIndex}][member_id]" />
+                <div class="text-xs text-gray-500 mt-1 previous-speaker"></div>
+            </div>
+            <button type="button" class="col-span-1 text-red-600" aria-label="Remove">&times;</button>
+        `;
+        bindRoleRow(wrapper);
+        container.appendChild(wrapper);
+        roleIndex++;
+    }
+
+    document.getElementById('add_role')?.addEventListener('click', addRole);
+    document.querySelectorAll('#roles_list .role-row').forEach(bindRoleRow);
+}

--- a/resources/views/hoerbuecher/create.blade.php
+++ b/resources/views/hoerbuecher/create.blade.php
@@ -106,83 +106,11 @@
         </div>
     </x-member-page>
     <script>
-        const members = Array.from(document.querySelectorAll('#members option')).map(o => ({id: o.dataset.id, name: o.value}));
-        const previousSpeakerUrl = "{{ route('hoerbuecher.previous-speaker') }}";
-        let roleIndex = 0;
-
-        function debounce(fn, delay = 300) {
-            let timeout;
-            return (...args) => {
-                clearTimeout(timeout);
-                timeout = setTimeout(() => fn(...args), delay);
-            };
-        }
-
-        function bindRoleRow(row) {
-            const memberInput = row.querySelector('input[list]');
-            const hidden = row.querySelector('input[type="hidden"]');
-            const roleNameInput = row.querySelector('input[name$="[name]"]');
-            const hint = row.querySelector('.previous-speaker');
-            let controller;
-
-            memberInput.addEventListener('input', e => {
-                const option = members.find(m => m.name === e.target.value);
-                hidden.value = option ? option.id : '';
-            });
-
-            function updateHint() {
-                const name = roleNameInput.value.trim();
-                controller?.abort();
-                if (!name) {
-                    hint.textContent = '';
-                    return;
-                }
-                controller = new AbortController();
-                fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`, { signal: controller.signal })
-                    .then(r => {
-                        if (r.status === 401) throw new Error('unauthorized');
-                        if (!r.ok) throw new Error('request-failed');
-                        return r.json();
-                    })
-                    .then(data => {
-                        hint.textContent = data.speaker ? `Bisheriger Sprecher: ${data.speaker}` : '';
-                    })
-                    .catch(err => {
-                        if (err.name === 'AbortError') return;
-                        hint.textContent = err.message === 'unauthorized'
-                            ? 'Nicht berechtigt'
-                            : 'Fehler beim Laden des bisherigen Sprechers';
-                    });
-            }
-
-            const debouncedHint = debounce(updateHint);
-            roleNameInput.addEventListener('input', debouncedHint);
-            roleNameInput.addEventListener('blur', updateHint);
-
-            row.querySelector('button').addEventListener('click', () => row.remove());
-            updateHint();
-        }
-
-        function addRole() {
-            const container = document.getElementById('roles_list');
-            const wrapper = document.createElement('div');
-            wrapper.className = 'grid grid-cols-5 gap-2 mb-2 items-start role-row';
-            wrapper.innerHTML = `
-                <input type="text" name="roles[${roleIndex}][name]" placeholder="Rolle" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                <input type="text" name="roles[${roleIndex}][description]" placeholder="Beschreibung" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                <input type="number" name="roles[${roleIndex}][takes]" min="0" placeholder="Takes" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                <div class="col-span-1">
-                    <input type="text" name="roles[${roleIndex}][member_name]" list="members" placeholder="Sprecher" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                    <input type="hidden" name="roles[${roleIndex}][member_id]" />
-                    <div class="text-xs text-gray-500 mt-1 previous-speaker"></div>
-                </div>
-                <button type="button" class="col-span-1 text-red-600" aria-label="Remove">&times;</button>
-            `;
-            bindRoleRow(wrapper);
-            container.appendChild(wrapper);
-            roleIndex++;
-        }
-
-        document.getElementById('add_role').addEventListener('click', addRole);
+        window.roleFormData = {
+            members: Array.from(document.querySelectorAll('#members option')).map(o => ({ id: o.dataset.id, name: o.value })),
+            previousSpeakerUrl: "{{ route('hoerbuecher.previous-speaker') }}",
+            roleIndex: 0,
+        };
     </script>
+    @vite(['resources/js/hoerbuch-role-form.js'])
 </x-app-layout>

--- a/resources/views/hoerbuecher/create.blade.php
+++ b/resources/views/hoerbuecher/create.blade.php
@@ -128,9 +128,15 @@
                     return;
                 }
                 fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`)
-                    .then(r => r.json())
+                    .then(r => {
+                        if (!r.ok) throw new Error('Request failed');
+                        return r.json();
+                    })
                     .then(data => {
                         hint.textContent = data.speaker ? `Bisheriger Sprecher: ${data.speaker}` : '';
+                    })
+                    .catch(() => {
+                        hint.textContent = 'Fehler beim Laden des bisherigen Sprechers';
                     });
             }
 

--- a/resources/views/hoerbuecher/create.blade.php
+++ b/resources/views/hoerbuecher/create.blade.php
@@ -156,6 +156,7 @@
             roleNameInput.addEventListener('blur', updateHint);
 
             row.querySelector('button').addEventListener('click', () => row.remove());
+            updateHint();
         }
 
         function addRole() {

--- a/resources/views/hoerbuecher/create.blade.php
+++ b/resources/views/hoerbuecher/create.blade.php
@@ -137,14 +137,17 @@
                 }
                 fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`)
                     .then(r => {
-                        if (!r.ok) throw new Error('Request failed');
+                        if (r.status === 401) throw new Error('unauthorized');
+                        if (!r.ok) throw new Error('request-failed');
                         return r.json();
                     })
                     .then(data => {
                         hint.textContent = data.speaker ? `Bisheriger Sprecher: ${data.speaker}` : '';
                     })
-                    .catch(() => {
-                        hint.textContent = 'Fehler beim Laden des bisherigen Sprechers';
+                    .catch(err => {
+                        hint.textContent = err.message === 'unauthorized'
+                            ? 'Nicht berechtigt'
+                            : 'Fehler beim Laden des bisherigen Sprechers';
                     });
             }
 

--- a/resources/views/hoerbuecher/create.blade.php
+++ b/resources/views/hoerbuecher/create.blade.php
@@ -110,6 +110,14 @@
         const previousSpeakerUrl = "{{ route('hoerbuecher.previous-speaker') }}";
         let roleIndex = 0;
 
+        function debounce(fn, delay = 300) {
+            let timeout;
+            return (...args) => {
+                clearTimeout(timeout);
+                timeout = setTimeout(() => fn(...args), delay);
+            };
+        }
+
         function bindRoleRow(row) {
             const memberInput = row.querySelector('input[list]');
             const hidden = row.querySelector('input[type="hidden"]');
@@ -140,7 +148,8 @@
                     });
             }
 
-            roleNameInput.addEventListener('change', updateHint);
+            const debouncedHint = debounce(updateHint);
+            roleNameInput.addEventListener('input', debouncedHint);
             roleNameInput.addEventListener('blur', updateHint);
 
             row.querySelector('button').addEventListener('click', () => row.remove());

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -88,7 +88,10 @@
                                 <div class="col-span-1">
                                     <input type="text" name="roles[{{ $i }}][member_name]" value="{{ $role['speaker_name'] ?? ($role['member_name'] ?? '') }}" list="members" placeholder="Sprecher" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
                                     <input type="hidden" name="roles[{{ $i }}][member_id]" value="{{ $role['user_id'] ?? ($role['member_id'] ?? '') }}" />
-                                    <div class="text-xs text-gray-500 mt-1 previous-speaker"></div>
+                                    @php($prev = $previousSpeakers[$role['name'] ?? ''] ?? null)
+                                    <div class="text-xs text-gray-500 mt-1 previous-speaker">
+                                        {{ $prev ? 'Bisheriger Sprecher: ' . $prev : '' }}
+                                    </div>
                                 </div>
                                 <button type="button" class="col-span-1 text-red-600" aria-label="Remove">&times;</button>
                             </div>
@@ -171,6 +174,7 @@
             roleNameInput.addEventListener('blur', updateHint);
 
             row.querySelector('button').addEventListener('click', () => row.remove());
+            updateHint();
         }
 
         document.querySelectorAll('#roles_list .role-row').forEach(bindRoleRow);

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -88,6 +88,7 @@
                                 <div class="col-span-1">
                                     <input type="text" name="roles[{{ $i }}][member_name]" value="{{ $role['speaker_name'] ?? ($role['member_name'] ?? '') }}" list="members" placeholder="Sprecher" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
                                     <input type="hidden" name="roles[{{ $i }}][member_id]" value="{{ $role['user_id'] ?? ($role['member_id'] ?? '') }}" />
+                                    <div class="text-xs text-gray-500 mt-1 previous-speaker"></div>
                                 </div>
                                 <button type="button" class="col-span-1 text-red-600" aria-label="Remove">&times;</button>
                             </div>
@@ -121,19 +122,40 @@
     </x-member-page>
     <script>
         const members = Array.from(document.querySelectorAll('#members option')).map(o => ({id: o.dataset.id, name: o.value}));
+        const previousSpeakerUrl = "{{ route('hoerbuecher.previous-speaker') }}";
         let roleIndex = document.querySelectorAll('#roles_list .role-row').length;
 
-        function bindAutocomplete(row) {
-            const input = row.querySelector('input[list]');
+        function bindRoleRow(row) {
+            const memberInput = row.querySelector('input[list]');
             const hidden = row.querySelector('input[type="hidden"]');
-            input.addEventListener('input', (e) => {
+            const roleNameInput = row.querySelector('input[name$="[name]"]');
+            const hint = row.querySelector('.previous-speaker');
+
+            memberInput.addEventListener('input', e => {
                 const option = members.find(m => m.name === e.target.value);
                 hidden.value = option ? option.id : '';
             });
+
+            function updateHint() {
+                const name = roleNameInput.value.trim();
+                if (!name) {
+                    hint.textContent = '';
+                    return;
+                }
+                fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`)
+                    .then(r => r.json())
+                    .then(data => {
+                        hint.textContent = data.speaker ? `Bisheriger Sprecher: ${data.speaker}` : '';
+                    });
+            }
+
+            roleNameInput.addEventListener('change', updateHint);
+            roleNameInput.addEventListener('blur', updateHint);
+
             row.querySelector('button').addEventListener('click', () => row.remove());
         }
 
-        document.querySelectorAll('#roles_list .role-row').forEach(bindAutocomplete);
+        document.querySelectorAll('#roles_list .role-row').forEach(bindRoleRow);
 
         function addRole() {
             const container = document.getElementById('roles_list');
@@ -146,10 +168,11 @@
                 <div class="col-span-1">
                     <input type="text" name="roles[${roleIndex}][member_name]" list="members" placeholder="Sprecher" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
                     <input type="hidden" name="roles[${roleIndex}][member_id]" />
+                    <div class="text-xs text-gray-500 mt-1 previous-speaker"></div>
                 </div>
                 <button type="button" class="col-span-1 text-red-600" aria-label="Remove">&times;</button>
             `;
-            bindAutocomplete(wrapper);
+            bindRoleRow(wrapper);
             container.appendChild(wrapper);
             roleIndex++;
         }

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -152,14 +152,17 @@
                 }
                 fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`)
                     .then(r => {
-                        if (!r.ok) throw new Error('Request failed');
+                        if (r.status === 401) throw new Error('unauthorized');
+                        if (!r.ok) throw new Error('request-failed');
                         return r.json();
                     })
                     .then(data => {
                         hint.textContent = data.speaker ? `Bisheriger Sprecher: ${data.speaker}` : '';
                     })
-                    .catch(() => {
-                        hint.textContent = 'Fehler beim Laden des bisherigen Sprechers';
+                    .catch(err => {
+                        hint.textContent = err.message === 'unauthorized'
+                            ? 'Nicht berechtigt'
+                            : 'Fehler beim Laden des bisherigen Sprechers';
                     });
             }
 

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -143,9 +143,15 @@
                     return;
                 }
                 fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`)
-                    .then(r => r.json())
+                    .then(r => {
+                        if (!r.ok) throw new Error('Request failed');
+                        return r.json();
+                    })
                     .then(data => {
                         hint.textContent = data.speaker ? `Bisheriger Sprecher: ${data.speaker}` : '';
+                    })
+                    .catch(() => {
+                        hint.textContent = 'Fehler beim Laden des bisherigen Sprechers';
                     });
             }
 

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -124,85 +124,11 @@
         </div>
     </x-member-page>
     <script>
-        const members = Array.from(document.querySelectorAll('#members option')).map(o => ({id: o.dataset.id, name: o.value}));
-        const previousSpeakerUrl = "{{ route('hoerbuecher.previous-speaker') }}";
-        let roleIndex = document.querySelectorAll('#roles_list .role-row').length;
-
-        function debounce(fn, delay = 300) {
-            let timeout;
-            return (...args) => {
-                clearTimeout(timeout);
-                timeout = setTimeout(() => fn(...args), delay);
-            };
-        }
-
-        function bindRoleRow(row) {
-            const memberInput = row.querySelector('input[list]');
-            const hidden = row.querySelector('input[type="hidden"]');
-            const roleNameInput = row.querySelector('input[name$="[name]"]');
-            const hint = row.querySelector('.previous-speaker');
-            let controller;
-
-            memberInput.addEventListener('input', e => {
-                const option = members.find(m => m.name === e.target.value);
-                hidden.value = option ? option.id : '';
-            });
-
-            function updateHint() {
-                const name = roleNameInput.value.trim();
-                controller?.abort();
-                if (!name) {
-                    hint.textContent = '';
-                    return;
-                }
-                controller = new AbortController();
-                fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`, { signal: controller.signal })
-                    .then(r => {
-                        if (r.status === 401) throw new Error('unauthorized');
-                        if (!r.ok) throw new Error('request-failed');
-                        return r.json();
-                    })
-                    .then(data => {
-                        hint.textContent = data.speaker ? `Bisheriger Sprecher: ${data.speaker}` : '';
-                    })
-                    .catch(err => {
-                        if (err.name === 'AbortError') return;
-                        hint.textContent = err.message === 'unauthorized'
-                            ? 'Nicht berechtigt'
-                            : 'Fehler beim Laden des bisherigen Sprechers';
-                    });
-            }
-
-            const debouncedHint = debounce(updateHint);
-            roleNameInput.addEventListener('input', debouncedHint);
-            roleNameInput.addEventListener('blur', updateHint);
-
-            row.querySelector('button').addEventListener('click', () => row.remove());
-            updateHint();
-        }
-
-        document.querySelectorAll('#roles_list .role-row').forEach(bindRoleRow);
-
-        function addRole() {
-            const container = document.getElementById('roles_list');
-            const wrapper = document.createElement('div');
-            wrapper.className = 'grid grid-cols-5 gap-2 mb-2 items-start role-row';
-            wrapper.innerHTML = `
-                <input type="text" name="roles[${roleIndex}][name]" placeholder="Rolle" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                <input type="text" name="roles[${roleIndex}][description]" placeholder="Beschreibung" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                <input type="number" name="roles[${roleIndex}][takes]" min="0" placeholder="Takes" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                <div class="col-span-1">
-                    <input type="text" name="roles[${roleIndex}][member_name]" list="members" placeholder="Sprecher" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                    <input type="hidden" name="roles[${roleIndex}][member_id]" />
-                    <div class="text-xs text-gray-500 mt-1 previous-speaker"></div>
-                </div>
-                <button type="button" class="col-span-1 text-red-600" aria-label="Remove">&times;</button>
-            `;
-            bindRoleRow(wrapper);
-            container.appendChild(wrapper);
-            roleIndex++;
-        }
-
-        document.getElementById('add_role').addEventListener('click', addRole);
+        window.roleFormData = {
+            members: Array.from(document.querySelectorAll('#members option')).map(o => ({ id: o.dataset.id, name: o.value })),
+            previousSpeakerUrl: "{{ route('hoerbuecher.previous-speaker') }}",
+            roleIndex: document.querySelectorAll('#roles_list .role-row').length,
+        };
     </script>
+    @vite(['resources/js/hoerbuch-role-form.js'])
 </x-app-layout>

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -141,6 +141,7 @@
             const hidden = row.querySelector('input[type="hidden"]');
             const roleNameInput = row.querySelector('input[name$="[name]"]');
             const hint = row.querySelector('.previous-speaker');
+            let controller;
 
             memberInput.addEventListener('input', e => {
                 const option = members.find(m => m.name === e.target.value);
@@ -149,11 +150,13 @@
 
             function updateHint() {
                 const name = roleNameInput.value.trim();
+                controller?.abort();
                 if (!name) {
                     hint.textContent = '';
                     return;
                 }
-                fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`)
+                controller = new AbortController();
+                fetch(`${previousSpeakerUrl}?name=${encodeURIComponent(name)}`, { signal: controller.signal })
                     .then(r => {
                         if (r.status === 401) throw new Error('unauthorized');
                         if (!r.ok) throw new Error('request-failed');
@@ -163,6 +166,7 @@
                         hint.textContent = data.speaker ? `Bisheriger Sprecher: ${data.speaker}` : '';
                     })
                     .catch(err => {
+                        if (err.name === 'AbortError') return;
                         hint.textContent = err.message === 'unauthorized'
                             ? 'Nicht berechtigt'
                             : 'Fehler beim Laden des bisherigen Sprechers';

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -125,6 +125,14 @@
         const previousSpeakerUrl = "{{ route('hoerbuecher.previous-speaker') }}";
         let roleIndex = document.querySelectorAll('#roles_list .role-row').length;
 
+        function debounce(fn, delay = 300) {
+            let timeout;
+            return (...args) => {
+                clearTimeout(timeout);
+                timeout = setTimeout(() => fn(...args), delay);
+            };
+        }
+
         function bindRoleRow(row) {
             const memberInput = row.querySelector('input[list]');
             const hidden = row.querySelector('input[type="hidden"]');
@@ -155,7 +163,8 @@
                     });
             }
 
-            roleNameInput.addEventListener('change', updateHint);
+            const debouncedHint = debounce(updateHint);
+            roleNameInput.addEventListener('input', debouncedHint);
             roleNameInput.addEventListener('blur', updateHint);
 
             row.querySelector('button').addEventListener('click', () => row.remove());

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -43,7 +43,13 @@
                                     <td class="px-2 py-1">{{ $role->name }}</td>
                                     <td class="px-2 py-1">{{ $role->description }}</td>
                                     <td class="px-2 py-1">{{ $role->takes }}</td>
-                                    <td class="px-2 py-1">{{ $role->user?->name ?? $role->speaker_name ?? '-' }}</td>
+                                    <td class="px-2 py-1">
+                                        {{ $role->user?->name ?? $role->speaker_name ?? '-' }}
+                                        @php($prev = $previousSpeakers[$role->name] ?? null)
+                                        @if($prev)
+                                            <div class="text-xs text-gray-500">Bisheriger Sprecher: {{ $prev }}</div>
+                                        @endif
+                                    </td>
                                 </tr>
                                 @endforeach
                             </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -110,6 +110,7 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::middleware('admin')->group(function () {
             Route::get('erstellen', 'create')->name('create');
             Route::post('/', 'store')->name('store');
+            Route::get('previous-speaker', 'previousSpeaker')->name('previous-speaker');
             Route::get('{episode}', 'show')->name('show');
             Route::get('{episode}/bearbeiten', 'edit')->name('edit');
             Route::put('{episode}', 'update')->name('update');

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -204,6 +204,98 @@ class HoerbuchControllerTest extends TestCase
             ->assertSee(route('hoerbuecher.edit', $episode));
     }
 
+    public function test_episode_show_displays_previous_speaker_hint(): void
+    {
+        $user = $this->actingMember('Admin');
+        $actor = $this->actingMember();
+
+        $earlier = AudiobookEpisode::create([
+            'episode_number' => 'F29',
+            'title' => 'Frühere',
+            'author' => 'Autor',
+            'planned_release_date' => '2024',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+        $earlier->roles()->create([
+            'name' => 'Matthew Drax',
+            'takes' => 1,
+            'user_id' => $actor->id,
+        ]);
+
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F30',
+            'title' => 'Aktuelle',
+            'author' => 'Autor',
+            'planned_release_date' => '2025',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'roles_total' => 1,
+            'roles_filled' => 0,
+            'notes' => null,
+        ]);
+        $episode->roles()->create([
+            'name' => 'Matthew Drax',
+            'takes' => 1,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertSee('Bisheriger Sprecher: ' . $actor->name);
+    }
+
+    public function test_edit_form_displays_previous_speaker_hint(): void
+    {
+        $user = $this->actingMember('Admin');
+        $actor = $this->actingMember();
+
+        $earlier = AudiobookEpisode::create([
+            'episode_number' => 'F29',
+            'title' => 'Frühere',
+            'author' => 'Autor',
+            'planned_release_date' => '2024',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+        $earlier->roles()->create([
+            'name' => 'Matthew Drax',
+            'takes' => 1,
+            'user_id' => $actor->id,
+        ]);
+
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F30',
+            'title' => 'Aktuelle',
+            'author' => 'Autor',
+            'planned_release_date' => '2025',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'roles_total' => 1,
+            'roles_filled' => 0,
+            'notes' => null,
+        ]);
+        $episode->roles()->create([
+            'name' => 'Matthew Drax',
+            'takes' => 1,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('hoerbuecher.edit', $episode))
+            ->assertOk()
+            ->assertSee('Bisheriger Sprecher: ' . $actor->name);
+    }
+
     public function test_notes_are_sanitized_and_escaped_in_views(): void
     {
         $user = $this->actingMember('Admin');

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -7,6 +7,7 @@ use Tests\TestCase;
 use App\Models\User;
 use App\Models\Team;
 use App\Models\AudiobookEpisode;
+use App\Models\AudiobookRole;
 use Carbon\Carbon;
 
 class HoerbuchControllerTest extends TestCase
@@ -514,6 +515,55 @@ class HoerbuchControllerTest extends TestCase
 
         $this->actingAs($user)->get(route('hoerbuecher.index'))
             ->assertOk();
+    }
+
+    public function test_previous_speaker_endpoint_returns_last_assigned_member(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $speaker1 = $this->actingMember();
+        $speaker2 = $this->actingMember();
+
+        $episode1 = AudiobookEpisode::create([
+            'episode_number' => 'F29',
+            'title' => 'Ep1',
+            'author' => 'Autor',
+            'planned_release_date' => '24.12.2025',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+        AudiobookRole::create([
+            'episode_id' => $episode1->id,
+            'name' => 'Matthew Drax',
+            'takes' => 0,
+            'user_id' => $speaker1->id,
+        ]);
+
+        $episode2 = AudiobookEpisode::create([
+            'episode_number' => 'F30',
+            'title' => 'Ep2',
+            'author' => 'Autor',
+            'planned_release_date' => '25.12.2025',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+        AudiobookRole::create([
+            'episode_id' => $episode2->id,
+            'name' => 'Matthew Drax',
+            'takes' => 0,
+            'user_id' => $speaker2->id,
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('hoerbuecher.previous-speaker', ['name' => 'Matthew Drax']))
+            ->assertJson(['speaker' => $speaker2->name]);
     }
 
     protected function tearDown(): void

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -577,6 +577,16 @@ class HoerbuchControllerTest extends TestCase
             ->assertJsonValidationErrors('name');
     }
 
+    public function test_previous_speaker_endpoint_requires_name(): void
+    {
+        $admin = $this->actingMember('Admin');
+
+        $this->actingAs($admin)
+            ->getJson(route('hoerbuecher.previous-speaker'))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('name');
+    }
+
     protected function tearDown(): void
     {
         Carbon::setTestNow();

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -566,6 +566,17 @@ class HoerbuchControllerTest extends TestCase
             ->assertJson(['speaker' => $speaker2->name]);
     }
 
+    public function test_previous_speaker_endpoint_validates_name(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $longName = str_repeat('a', 300);
+
+        $this->actingAs($admin)
+            ->getJson(route('hoerbuecher.previous-speaker', ['name' => $longName]))
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('name');
+    }
+
     protected function tearDown(): void
     {
         Carbon::setTestNow();

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
                 'resources/js/statistik.js',
                 'resources/js/changelog.js',
                 'resources/js/hoerbuecher.js',
+                'resources/js/hoerbuch-role-form.js',
             ],
             refresh: true,
             // Explizit den public-Pfad setzen


### PR DESCRIPTION
This pull request adds a feature that displays the previous speaker for each audiobook role when viewing or editing an episode, both in the UI and via a new API endpoint. It refactors the role form JavaScript to centralize logic and provide real-time hints about previous speakers, and introduces a supporting database index for efficient lookup. Comprehensive tests are included to verify correct display of previous speaker hints.

**Feature: Previous Speaker Hint for Roles**
* Added backend logic in `HoerbuchController` to determine and provide the most recent speaker for each role, used in both show and edit views (`latestSpeakersForNames`, `previousSpeakersForEpisode`).
* Updated views (`show`, `edit`) to display a "Bisheriger Sprecher" hint for each role, using the new backend data [[1]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdR178-R182) [[2]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdR193-R200) [[3]](diffhunk://#diff-8e28b6fec934859bc265eb37fcf51b3b26984bef31410eadc5a951785e27c6e7R91-R94) [[4]](diffhunk://#diff-3a89ef24b9c79efccdef51ca4d7a67fab3d01dd6e100d6b08f8b821b8334ffcfL46-R52).

**API and Routing**
* Introduced a new route and controller method (`previousSpeaker`) to fetch the previous speaker for a given role name via AJAX, returning a JSON response [[1]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdR253-R268) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR113).

**Frontend Refactor**
* Replaced inline role form JavaScript with a shared module (`resources/js/hoerbuch-role-form.js`) that handles member selection and dynamically fetches previous speaker hints as users type or edit roles [[1]](diffhunk://#diff-d9ce304b18849e9a13782d40fb59316ee62ef3d87b192a32ec912c0d977242e3R1-R88) [[2]](diffhunk://#diff-13cfb60cd8d7ae7c6a2bab580893097dc1b200140291c0b66fa258f153adb28bL109-R115) [[3]](diffhunk://#diff-8e28b6fec934859bc265eb37fcf51b3b26984bef31410eadc5a951785e27c6e7L123-R133).

**Database Optimization**
* Added a migration to create a composite index on `audiobook_roles` for efficient lookup by role name, user, and speaker name.

**Testing**
* Added feature tests to ensure previous speaker hints are correctly shown in both the episode detail and edit forms.

These changes collectively improve the user experience for managing audiobook roles, making it easier to assign consistent speakers and verify role history.