### PR TITLE
Increase member map cache TTL to 24h

### DIFF
--- a/app/Services/MemberMapCacheService.php
+++ b/app/Services/MemberMapCacheService.php
@@ -60,7 +60,7 @@ class MemberMapCacheService
             'centerLon' => $centerLon,
         ];
 
-        Cache::put($cacheKey, $data, now()->addHours(12));
+        Cache::put($cacheKey, $data, now()->addHours(24));
 
         return $data;
     }


### PR DESCRIPTION
This pull request updates the cache duration for member map data in the `MemberMapCacheService`. The cache for team member map data is now set to expire after 24 hours instead of 12 hours.

* Increased cache expiration for member map data from 12 hours to 24 hours in the `getMemberMapData` method of `MemberMapCacheService.php`