### PR TITLE
Show top 10 Maddrax novels in statistics

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -88,23 +88,25 @@ class StatistikController extends Controller
             ->take(10)
             ->values();
 
-        $romaneSorted = $romane->sort(function ($a, $b) {
-            // 1. Kriterium: Ø-Bewertung (absteigend)
-            if ($a['bewertung'] !== $b['bewertung']) {
-                return $b['bewertung'] <=> $a['bewertung'];
-            }
+        $romaneTable = $romane
+            ->filter(fn ($r) => ($r['stimmen'] ?? 0) >= 8)
+            ->sort(function ($a, $b) {
+                // 1. Kriterium: Ø-Bewertung (absteigend)
+                if ($a['bewertung'] !== $b['bewertung']) {
+                    return $b['bewertung'] <=> $a['bewertung'];
+                }
 
-            // 2. Kriterium: Stimmen (absteigend)
-            return $b['stimmen'] <=> $a['stimmen'];
-        });
-
-        $romaneTable = $romaneSorted->map(fn ($r) => [
-            'nummer' => $r['nummer'],
-            'titel' => $r['titel'],
-            'autor' => implode(', ', $r['text']),
-            'bewertung' => $r['bewertung'],
-            'stimmen' => $r['stimmen'],
-        ]);
+                // 2. Kriterium: Stimmen (absteigend)
+                return $b['stimmen'] <=> $a['stimmen'];
+            })
+            ->take(10)
+            ->map(fn ($r) => [
+                'nummer' => $r['nummer'],
+                'titel' => $r['titel'],
+                'autor' => implode(', ', $r['text']),
+                'bewertung' => $r['bewertung'],
+                'stimmen' => $r['stimmen'],
+            ]);
 
         // ── Card 5 – Top-Charaktere nach Auftritten ──────────────────────────
         $topCharacters = $romane

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,5 @@ export default {
   moduleNameMapper: {
     '\\.(css)$': '<rootDir>/tests/Jest/__mocks__/styleMock.js',
     '^chart.js/auto$': '<rootDir>/tests/Jest/__mocks__/chartMock.js',
-    '^simple-datatables$': '<rootDir>/tests/Jest/__mocks__/datatablesMock.js',
   },
 };

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -1,7 +1,5 @@
 /* resources/js/statistik.js */
 import Chart from 'chart.js/auto';
-import { DataTable } from 'simple-datatables';
-import 'simple-datatables/dist/style.css';
 
 /**
  * Rendert ein Balkendiagramm,
@@ -67,23 +65,6 @@ function drawCycleChart(canvasId, labels, data) {
     });
 }
 
-/**
- * Initialisiert die sortier-/paginierbare Romane-Tabelle.
- */
-function initRomaneTable() {
-    const tableEl = document.getElementById('romaneTable');
-    if (!tableEl) return;
-
-    const dt = new DataTable(tableEl, {
-        perPage:       25,
-        perPageSelect: [10, 25, 50, 100],
-        searchable:    true,
-        sortable:      true,
-    });
-
-    // nach Bewertung (Spalte 3) absteigend sortieren
-    dt.sortColumn(3, 'desc');
-}
 
 /* ── Autostart nach DOM-Load ───────────────────────────────────────────── */
 document.addEventListener('DOMContentLoaded', () => {
@@ -109,8 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
         drawCycleChart('hardcoverChart', hardcoverLabels, hardcoverValues);
     }
 
-    initRomaneTable();
 });
 
 /* ── optionale Named-Exports (falls du die Funktionen woanders brauchst) */
-export { drawAuthorChart, drawCycleChart, initRomaneTable };
+export { drawAuthorChart, drawCycleChart };

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -52,15 +52,15 @@
                     </div>
                 </div>
             @endif
-            {{-- Card 3 – Romane-Tabelle (≥ 5 Baxx) --}}
+            {{-- Card 3 – Top 10 Maddrax-Romane (≥ 5 Baxx) --}}
             @if ($userPoints >= 5)
                 <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
-                        Alle Romane
+                        Top 10 Maddrax-Romane
                     </h2>
 
                     <div class="overflow-x-auto">
-                        <table id="romaneTable" class="w-full text-left">
+                        <table class="w-full text-left">
                             <thead>
                                 <tr>
                                     <th>Nr.</th>

--- a/tests/Jest/__mocks__/datatablesMock.js
+++ b/tests/Jest/__mocks__/datatablesMock.js
@@ -1,5 +1,0 @@
-import { jest } from '@jest/globals';
-
-export const DataTable = jest.fn(function () {
-  this.sortColumn = jest.fn();
-});

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -3,24 +3,17 @@ import { jest } from '@jest/globals';
 describe('statistik module', () => {
   let drawAuthorChart;
   let drawCycleChart;
-  let initRomaneTable;
   let mockChart;
-  let mockDataTable;
 
   beforeEach(async () => {
     jest.resetModules();
     const chartModule = await import('chart.js/auto');
-    const datatableModule = await import('simple-datatables');
     mockChart = chartModule.default;
-    mockDataTable = datatableModule.DataTable;
-
     mockChart.mockClear();
-    mockDataTable.mockClear();
 
     const mod = await import('../../resources/js/statistik.js');
     drawAuthorChart = mod.drawAuthorChart;
     drawCycleChart = mod.drawCycleChart;
-    initRomaneTable = mod.initRomaneTable;
 
     HTMLCanvasElement.prototype.getContext = jest.fn(() => ({}));
   });
@@ -49,22 +42,10 @@ describe('statistik module', () => {
     expect(config.options.plugins.legend.display).toBe(true);
   });
 
-  test('initRomaneTable initializes DataTable and sorts column', () => {
-    document.body.innerHTML = '<table id="romaneTable"></table>';
-    initRomaneTable();
-
-    expect(mockDataTable).toHaveBeenCalledTimes(1);
-    expect(mockDataTable.mock.calls[0][0].id).toBe('romaneTable');
-    const instance = mockDataTable.mock.instances[0];
-    expect(instance.sortColumn).toHaveBeenCalledWith(3, 'desc');
-  });
-
   test('DOMContentLoaded draws hardcover chart', async () => {
     jest.resetModules();
     const chartModule = await import('chart.js/auto');
-    const datatableModule = await import('simple-datatables');
     mockChart = chartModule.default;
-    datatableModule.DataTable.mockClear();
     mockChart.mockClear();
 
     document.body.innerHTML = '<canvas id="hardcoverChart"></canvas>';
@@ -82,9 +63,7 @@ describe('statistik module', () => {
   test('DOMContentLoaded draws hardcover author chart', async () => {
     jest.resetModules();
     const chartModule = await import('chart.js/auto');
-    const datatableModule = await import('simple-datatables');
     mockChart = chartModule.default;
-    datatableModule.DataTable.mockClear();
     mockChart.mockClear();
 
     document.body.innerHTML = '<canvas id="hardcoverAuthorChart"></canvas>';


### PR DESCRIPTION
This pull request refactors how the top Maddrax novels are displayed on the statistics page by removing the sortable/paginable DataTable feature from both the frontend JavaScript and related tests, and updating the backend logic to show only the top 10 novels meeting a minimum vote threshold. The table is now a static display of the top 10, and all code and tests related to DataTable have been cleaned up.

**Frontend and UI changes:**

* Removed the DataTable integration and initialization from `resources/js/statistik.js`, making the novels table static and no longer sortable/paginable. [[1]](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L3-L4) [[2]](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L70-L86) [[3]](diffhunk://#diff-7fc2a191b7798f499315abfa63932571c74b7831002ec2603b46756d54a410d2L112-R96)
* Updated the table heading and description in `resources/views/statistik/index.blade.php` to clarify that only the top 10 Maddrax novels (with at least 5 Baxx) are shown, and removed the `id` attribute used for DataTable initialization.

**Backend logic changes:**

* Changed the backend logic in `StatistikController.php` to filter novels with at least 8 votes, sort them by rating and votes, and limit the output to the top 10 for the table.

**Testing and mocks cleanup:**

* Removed the DataTable mock and all related test cases from `tests/Jest/statistik.test.js` and deleted the mock file itself, since DataTable is no longer used. [[1]](diffhunk://#diff-d062553c329819bad4e9f5b60b07059b46d04b0b76bd383cd444e492c0f5cf29L1-L5) [[2]](diffhunk://#diff-c1ab8a789a85144dd6be7dd8a4bf876768b20d25912881d36431f07702eb88ebL6-L23) [[3]](diffhunk://#diff-c1ab8a789a85144dd6be7dd8a4bf876768b20d25912881d36431f07702eb88ebL52-L67) [[4]](diffhunk://#diff-c1ab8a789a85144dd6be7dd8a4bf876768b20d25912881d36431f07702eb88ebL85-L87)