### PR TITLE
Link challenges in dashboard activity feed

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -170,9 +170,9 @@
                                     Kommentar zu <a href="{{ route('reviews.show', $activity->subject->review->book_id) }}" class="text-blue-600 dark:text-blue-400 hover:underline">{{ $activity->subject->review->title }}</a> von <a href="{{ route('profile.view', $activity->user->id) }}" class="text-[#8B0116] hover:underline">{{ $activity->user->name }}</a>
                                 </span>
                             @elseif($activity->subject_type === \App\Models\Todo::class && $activity->action === 'accepted')
-                                <span class="text-sm">hat die Challenge {{ $activity->subject->title }} angenommen</span>
+                                <span class="text-sm">hat die Challenge <a href="{{ route('todos.show', $activity->subject->id) }}" class="text-blue-600 dark:text-blue-400 hover:underline">{{ $activity->subject->title }}</a> angenommen</span>
                             @elseif($activity->subject_type === \App\Models\Todo::class && $activity->action === 'completed')
-                                <span class="text-sm">hat die Challenge {{ $activity->subject->title }} erfolgreich abgeschlossen</span>
+                                <span class="text-sm">hat die Challenge <a href="{{ route('todos.show', $activity->subject->id) }}" class="text-blue-600 dark:text-blue-400 hover:underline">{{ $activity->subject->title }}</a> erfolgreich abgeschlossen</span>
                             @endif
                         </li>
                     @empty


### PR DESCRIPTION
This pull request improves the user experience on the dashboard by making challenge titles clickable links in activity notifications. Now, when a user accepts or completes a challenge, the challenge name links directly to its details page.

**Dashboard activity UI improvements:**

* Made the challenge title in "accepted" and "completed" activity notifications a clickable link to the corresponding challenge details page in `dashboard.blade.php`.