### PR TITLE
Allow additional profile photo formats and increase size limit

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -28,7 +28,8 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             'telefon' => ['nullable', 'string', 'max:20'],
             'mitgliedsbeitrag' => ['required', 'numeric', 'min:12', 'max:120'],
             'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
-            'photo' => ['nullable', 'mimes:jpg,jpeg,png', 'max:4096'],
+            // Profilfoto: erlaubte Formate erweitern und maximale Größe erhöhen
+            'photo' => ['nullable', 'mimes:jpg,jpeg,png,gif,webp', 'max:8192'],
         ])->validateWithBag('updateProfileInformation');
 
         if (isset($input['photo'])) {

--- a/lang/de/profile.php
+++ b/lang/de/profile.php
@@ -12,5 +12,6 @@ return [
     'Foto' => 'Foto',
     'Neues Foto auswählen' => 'Neues Foto auswählen',
     'Foto entfernen' => 'Foto entfernen',
+    'Erlaubte Dateiformate: jpg, jpeg, png, gif, webp. Max. Größe: 8 MB.' => 'Erlaubte Dateiformate: jpg, jpeg, png, gif, webp. Max. Größe: 8 MB.',
     'Vorname' => 'Vorname'
 ];

--- a/resources/views/profile/update-profile-information-form.blade.php
+++ b/resources/views/profile/update-profile-information-form.blade.php
@@ -21,6 +21,9 @@
                                 " />
 
                 <x-label for="photo" value="{{ __('Foto') }}" />
+                <p class="mt-1 text-sm text-gray-600">
+                    {{ __('Erlaubte Dateiformate: jpg, jpeg, png, gif, webp. Max. Größe: 8 MB.') }}
+                </p>
 
                 <div class="mt-2" x-show="! photoPreview">
                     <img loading="lazy" src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}"


### PR DESCRIPTION
This pull request updates the user profile photo upload functionality to support more file formats and a larger maximum file size. It also improves the user interface by clearly communicating these requirements to users.

**Profile photo upload improvements:**

* Expanded allowed photo formats to include `gif` and `webp`, and increased the maximum file size to 8 MB in the validation rules in `UpdateUserProfileInformation.php`.

**User interface and localization updates:**

* Added a descriptive message about allowed file formats and maximum size to the German localization file `lang/de/profile.php`.
* Displayed the new file format and size requirements as helper text in the profile update form view `update-profile-information-form.blade.php`.