### PR TITLE
Move profile photo format hint below management buttons

### DIFF
--- a/resources/views/profile/update-profile-information-form.blade.php
+++ b/resources/views/profile/update-profile-information-form.blade.php
@@ -21,9 +21,6 @@
                                 " />
 
                 <x-label for="photo" value="{{ __('Foto') }}" />
-                <p class="mt-1 text-sm text-gray-600">
-                    {{ __('Erlaubte Dateiformate: jpg, jpeg, png, gif, webp. Max. Größe: 8 MB.') }}
-                </p>
 
                 <div class="mt-2" x-show="! photoPreview">
                     <img loading="lazy" src="{{ $this->user->profile_photo_url }}" alt="{{ $this->user->name }}"
@@ -44,6 +41,10 @@
                         {{ __('Foto entfernen') }}
                     </x-secondary-button>
                 @endif
+
+                <p class="mt-2 text-sm text-gray-600">
+                    {{ __('Erlaubte Dateiformate: jpg, jpeg, png, gif, webp. Max. Größe: 8 MB.') }}
+                </p>
 
                 <x-input-error for="photo" class="mt-2" />
             </div>


### PR DESCRIPTION
## Summary
- show profile photo format hint below photo management buttons on profile page

## Testing
- `npm test`
- `vendor/bin/phpunit` *(fails: SQLSTATE[HY000] [1698] Access denied for user 'root'@'localhost')*

------
https://chatgpt.com/codex/tasks/task_e_68aa8b62da88832e9040b4f6a81676d4