### PR TITLE
Show locked statistics in blurred state

### DIFF
--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -68,6 +68,22 @@ function drawCycleChart(canvasId, labels, data) {
 
 /* ── Autostart nach DOM-Load ───────────────────────────────────────────── */
 document.addEventListener('DOMContentLoaded', () => {
+    const userPoints = window.userPoints ?? 0;
+
+    document.querySelectorAll('[data-min-points]').forEach((card) => {
+        const min = parseInt(card.dataset.minPoints, 10);
+        if (userPoints < min) {
+            const overlay = document.createElement('div');
+            overlay.className = 'absolute inset-0 flex items-center justify-center bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm';
+            overlay.innerHTML = `\
+                <p class="text-sm text-gray-600 dark:text-gray-400 text-center">\
+                    Diese Statistik wird ab <strong>${min}</strong> Baxx freigeschaltet.<br>\
+                    Dein aktueller Stand: <span class="font-semibold">${userPoints}</span>.\
+                </p>`;
+            card.appendChild(overlay);
+        }
+    });
+
     const labels = window.authorChartLabels ?? [];
     const values = window.authorChartValues ?? [];
     drawAuthorChart('authorChart', labels, values);

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -8,9 +8,11 @@
                     Statistik
                 </h1>
             </div>
+            <script>
+                window.userPoints = {{ $userPoints }};
+            </script>
             {{-- Card 1 – Balkendiagramm (≥ 2 Bakk) --}}
-            @if ($userPoints >= 2)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="2" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Maddrax-Romane je Autor:in
                     </h2>
@@ -22,10 +24,8 @@
                     window.authorChartLabels = @json($authorCounts->keys());
                     window.authorChartValues = @json($authorCounts->values());
                 </script>
-            @endif
             {{-- Card 2 – Teamplayer-Tabelle (≥ 4 Baxx) --}}
-            @if ($userPoints >= 4)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="4" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Top Teamplayer
                     </h2>
@@ -51,10 +51,8 @@
                         </table>
                     </div>
                 </div>
-            @endif
             {{-- Card 3 – Top 10 Maddrax-Romane (≥ 5 Baxx) --}}
-            @if ($userPoints >= 5)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="5" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Top 10 Maddrax-Romane
                     </h2>
@@ -84,10 +82,8 @@
                         </table>
                     </div>
                 </div>
-            @endif
             {{-- Card 4 – Top-Autor:innen nach Ø‑Bewertung (≥ 7 Baxx) --}}
-            @if ($userPoints >= 7)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="7" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Top 10 Autor:innen nach Ø-Bewertung
                     </h2>
@@ -113,20 +109,8 @@
                         </table>
                     </div>
                 </div>
-            @else
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">
-                        Top 10 Autor:innen nach Ø-Bewertung
-                    </h2>
-                    <p class="text-sm text-gray-600 dark:text-gray-400">
-                        Diese Statistik wird ab <strong>7</strong> Baxx freigeschaltet.<br>
-                        Dein aktueller Stand: <span class="font-semibold">{{ $userPoints }}</span>.
-                    </p>
-                </div>
-            @endif
             {{-- Card 5 – Top-Charaktere nach Auftritten (≥ 10 Baxx) --}}
-            @if ($userPoints >= 10)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="10" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Top 10 Charaktere nach Auftritten
                     </h2>
@@ -152,20 +136,8 @@
                         </table>
                     </div>
                 </div>
-            @else
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
-                        Top 10 Charaktere nach Auftritten
-                    </h2>
-                    <p class="text-sm text-gray-600 dark:text-gray-400">
-                        Diese Statistik wird ab <strong>10</strong> Baxx freigeschaltet.<br>
-                        Dein aktueller Stand: <span class="font-semibold">{{ $userPoints }}</span>.
-                    </p>
-                </div>
-            @endif
             {{-- Card 6 – Bewertungen im Maddraxikon (≥ 11 Baxx) --}}
-            @if ($userPoints >= 11)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6 grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
+                <div data-min-points="11" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6 grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 col-span-1 md:col-span-3">
                         Bewertungen im Maddraxikon
                     </h2>
@@ -190,10 +162,8 @@
                     <div class="text-gray-600 dark:text-gray-400">Ø-Stimmen pro Roman</div>
                     </div>
                 </div>
-            @endif
             {{-- Card 7 – Rezensionen unserer Mitglieder (≥ 12 Baxx) --}}
-            @if ($userPoints >= 12)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="12" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Rezensionen unserer Mitglieder
                     </h2>
@@ -255,10 +225,8 @@
                         @endif
                     </div>
                 </div>
-            @endif
             {{-- Card 8 – Bewertungen des Euree-Zyklus (≥ 13 Baxx) --}}
-            @if ($userPoints >= 13)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="13" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Euree-Zyklus
                     </h2>
@@ -269,11 +237,9 @@
                     window.eureeChartLabels = @json($eureeLabels);
                     window.eureeChartValues = @json($eureeValues);
                 </script>
-            @endif
 
             {{-- Card 9 – Bewertungen des Meeraka-Zyklus (≥ 14 Baxx) --}}
-            @if ($userPoints >= 14)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="14" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Meeraka-Zyklus
                     </h2>
@@ -284,11 +250,9 @@
                     window.meerakaChartLabels = @json($meerakaLabels);
                     window.meerakaChartValues = @json($meerakaValues);
                 </script>
-            @endif
 
             {{-- Card 10 – Bewertungen des Expeditions-Zyklus (≥ 15 Baxx) --}}
-            @if ($userPoints >= 15)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="15" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Expeditions-Zyklus
                     </h2>
@@ -299,11 +263,9 @@
                     window.expeditionChartLabels = @json($expeditionLabels);
                     window.expeditionChartValues = @json($expeditionValues);
                 </script>
-            @endif
 
             {{-- Card 11 – Bewertungen des Kratersee-Zyklus (≥ 16 Baxx) --}}
-            @if ($userPoints >= 16)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="16" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Kratersee-Zyklus
                     </h2>
@@ -314,11 +276,9 @@
                     window.kraterseeChartLabels = @json($kraterseeLabels);
                     window.kraterseeChartValues = @json($kraterseeValues);
                 </script>
-            @endif
 
             {{-- Card 12 – Bewertungen des Daa'muren-Zyklus (≥ 17 Baxx) --}}
-            @if ($userPoints >= 17)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="17" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Daa'muren-Zyklus
                     </h2>
@@ -329,11 +289,9 @@
                     window.daaMurenChartLabels = @json($daaMurenLabels);
                     window.daaMurenChartValues = @json($daaMurenValues);
                 </script>
-            @endif
 
             {{-- Card 13 – Bewertungen des Wandler-Zyklus (≥ 18 Baxx) --}}
-            @if ($userPoints >= 18)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="18" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Wandler-Zyklus
                     </h2>
@@ -344,11 +302,9 @@
                     window.wandlerChartLabels = @json($wandlerLabels);
                     window.wandlerChartValues = @json($wandlerValues);
                 </script>
-            @endif
 
             {{-- Card 14 – Bewertungen des Mars-Zyklus (≥ 19 Baxx) --}}
-            @if ($userPoints >= 19)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="19" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Mars-Zyklus
                     </h2>
@@ -359,11 +315,9 @@
                     window.marsChartLabels = @json($marsLabels);
                     window.marsChartValues = @json($marsValues);
                 </script>
-            @endif
 
             {{-- Card 15 – Bewertungen des Ausala-Zyklus (≥ 20 Baxx) --}}
-            @if ($userPoints >= 20)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="20" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Ausala-Zyklus
                     </h2>
@@ -374,11 +328,9 @@
                     window.ausalaChartLabels = @json($ausalaLabels);
                     window.ausalaChartValues = @json($ausalaValues);
                 </script>
-            @endif
 
             {{-- Card 16 – Bewertungen des Afra-Zyklus (≥ 21 Baxx) --}}
-            @if ($userPoints >= 21)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="21" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Afra-Zyklus
                     </h2>
@@ -389,11 +341,9 @@
                     window.afraChartLabels = @json($afraLabels);
                     window.afraChartValues = @json($afraValues);
                 </script>
-            @endif
 
             {{-- Card 17 – Bewertungen des Antarktis-Zyklus (≥ 22 Baxx) --}}
-            @if ($userPoints >= 22)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="22" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Antarktis-Zyklus
                     </h2>
@@ -404,11 +354,9 @@
                     window.antarktisChartLabels = @json($antarktisLabels);
                     window.antarktisChartValues = @json($antarktisValues);
                 </script>
-            @endif
 
             {{-- Card 18 – Bewertungen des Schatten-Zyklus (≥ 23 Baxx) --}}
-            @if ($userPoints >= 23)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="23" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Schatten-Zyklus
                     </h2>
@@ -419,11 +367,9 @@
                     window.schattenChartLabels = @json($schattenLabels);
                     window.schattenChartValues = @json($schattenValues);
                 </script>
-            @endif
 
             {{-- Card 19 – Bewertungen des Ursprung-Zyklus (≥ 24 Baxx) --}}
-            @if ($userPoints >= 24)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="24" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Ursprung-Zyklus
                     </h2>
@@ -434,11 +380,9 @@
                     window.ursprungChartLabels = @json($ursprungLabels);
                     window.ursprungChartValues = @json($ursprungValues);
                 </script>
-            @endif
 
             {{-- Card 20 – Bewertungen des Streiter-Zyklus (≥ 25 Baxx) --}}
-            @if ($userPoints >= 25)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="25" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Streiter-Zyklus
                     </h2>
@@ -449,11 +393,9 @@
                     window.streiterChartLabels = @json($streiterLabels);
                     window.streiterChartValues = @json($streiterValues);
                 </script>
-            @endif
 
             {{-- Card 21 – Bewertungen des Archivar-Zyklus (≥ 26 Baxx) --}}
-            @if ($userPoints >= 26)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="26" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Archivar-Zyklus
                     </h2>
@@ -464,11 +406,9 @@
                     window.archivarChartLabels = @json($archivarLabels);
                     window.archivarChartValues = @json($archivarValues);
                 </script>
-            @endif
 
             {{-- Card 22 – Bewertungen des Zeitsprung-Zyklus (≥ 27 Baxx) --}}
-            @if ($userPoints >= 27)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="27" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Zeitsprung-Zyklus
                     </h2>
@@ -479,11 +419,9 @@
                     window.zeitsprungChartLabels = @json($zeitsprungLabels);
                     window.zeitsprungChartValues = @json($zeitsprungValues);
                 </script>
-            @endif
 
             {{-- Card 23 – Bewertungen des Fremdwelt-Zyklus (≥ 28 Baxx) --}}
-            @if ($userPoints >= 28)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="28" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Fremdwelt-Zyklus
                     </h2>
@@ -494,11 +432,9 @@
                     window.fremdweltChartLabels = @json($fremdweltLabels);
                     window.fremdweltChartValues = @json($fremdweltValues);
                 </script>
-            @endif
 
             {{-- Card 24 – Bewertungen des Parallelwelt-Zyklus (≥ 29 Baxx) --}}
-            @if ($userPoints >= 29)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="29" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Parallelwelt-Zyklus
                     </h2>
@@ -509,11 +445,9 @@
                     window.parallelweltChartLabels = @json($parallelweltLabels);
                     window.parallelweltChartValues = @json($parallelweltValues);
                 </script>
-            @endif
 
             {{-- Card 25 – Bewertungen des Weltenriss-Zyklus (≥ 30 Baxx) --}}
-            @if ($userPoints >= 30)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="30" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Weltenriss-Zyklus
                     </h2>
@@ -524,11 +458,9 @@
                     window.weltenrissChartLabels = @json($weltenrissLabels);
                     window.weltenrissChartValues = @json($weltenrissValues);
                 </script>
-            @endif
 
             {{-- Card 26 – Bewertungen des Amraka-Zyklus (≥ 31 Baxx) --}}
-            @if ($userPoints >= 31)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="31" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Amraka-Zyklus
                     </h2>
@@ -539,11 +471,9 @@
                     window.amrakaChartLabels = @json($amrakaLabels);
                     window.amrakaChartValues = @json($amrakaValues);
                 </script>
-            @endif
 
             {{-- Card 27 – Bewertungen des Weltrat-Zyklus (≥ 32 Baxx) --}}
-            @if ($userPoints >= 32)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="32" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen des Weltrat-Zyklus
                     </h2>
@@ -554,11 +484,9 @@
                     window.weltratChartLabels = @json($weltratLabels);
                     window.weltratChartValues = @json($weltratValues);
                 </script>
-            @endif
 
             {{-- Card 28 – Bewertungen der Hardcover (≥ 40 Baxx) --}}
-            @if ($userPoints >= 40)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="40" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Bewertungen der Hardcover
                     </h2>
@@ -569,11 +497,9 @@
                     window.hardcoverChartLabels = @json($hardcoverLabels);
                     window.hardcoverChartValues = @json($hardcoverValues);
                 </script>
-            @endif
 
             {{-- Card 29 – Hardcover je Autor:in (≥ 41 Baxx) --}}
-            @if ($userPoints >= 41)
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div data-min-points="41" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Maddrax-Hardcover je Autor:in
                     </h2>
@@ -584,10 +510,7 @@
                     window.hardcoverAuthorChartLabels = @json($hardcoverAuthorCounts->keys());
                     window.hardcoverAuthorChartValues = @json($hardcoverAuthorCounts->values());
                 </script>
-            @endif
 
-            @if ($userPoints >= 1)
                 @vite(['resources/js/statistik.js'])
-            @endif
     </x-member-page>
 </x-app-layout>

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -187,7 +187,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Author2');
     }
 
-    public function test_teamplayer_table_hidden_below_threshold(): void
+    public function test_teamplayer_table_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(1);
@@ -196,7 +196,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Top Teamplayer');
+        $response->assertSee('Top Teamplayer');
+        $response->assertSee('4 Baxx');
     }
 
     public function test_teamplayer_table_limits_to_top_10(): void
@@ -277,7 +278,7 @@ class StatistikTest extends TestCase
         $response->assertSee($viewer->name);
     }
 
-    public function test_review_statistics_hidden_below_threshold(): void
+    public function test_review_statistics_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(11);
@@ -286,7 +287,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Rezensionen unserer Mitglieder');
+        $response->assertSee('Rezensionen unserer Mitglieder');
+        $response->assertSee('12 Baxx');
     }
 
     public function test_afra_cycle_chart_visible_with_enough_points(): void
@@ -301,7 +303,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Afra-Zyklus');
     }
 
-    public function test_afra_cycle_chart_hidden_below_threshold(): void
+    public function test_afra_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(20);
@@ -310,7 +312,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Afra-Zyklus');
+        $response->assertSee('Bewertungen des Afra-Zyklus');
+        $response->assertSee('21 Baxx');
     }
 
     public function test_antarktis_cycle_chart_visible_with_enough_points(): void
@@ -325,7 +328,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Antarktis-Zyklus');
     }
 
-    public function test_antarktis_cycle_chart_hidden_below_threshold(): void
+    public function test_antarktis_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(21);
@@ -334,7 +337,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Antarktis-Zyklus');
+        $response->assertSee('Bewertungen des Antarktis-Zyklus');
+        $response->assertSee('22 Baxx');
     }
 
     public function test_schatten_cycle_chart_visible_with_enough_points(): void
@@ -349,7 +353,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Schatten-Zyklus');
     }
 
-    public function test_schatten_cycle_chart_hidden_below_threshold(): void
+    public function test_schatten_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(22);
@@ -358,7 +362,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Schatten-Zyklus');
+        $response->assertSee('Bewertungen des Schatten-Zyklus');
+        $response->assertSee('23 Baxx');
     }
 
     public function test_ursprung_cycle_chart_visible_with_enough_points(): void
@@ -373,7 +378,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Ursprung-Zyklus');
     }
 
-    public function test_ursprung_cycle_chart_hidden_below_threshold(): void
+    public function test_ursprung_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(23);
@@ -382,7 +387,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Ursprung-Zyklus');
+        $response->assertSee('Bewertungen des Ursprung-Zyklus');
+        $response->assertSee('24 Baxx');
     }
 
     public function test_streiter_cycle_chart_visible_with_enough_points(): void
@@ -397,7 +403,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Streiter-Zyklus');
     }
 
-    public function test_streiter_cycle_chart_hidden_below_threshold(): void
+    public function test_streiter_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(24);
@@ -406,7 +412,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Streiter-Zyklus');
+        $response->assertSee('Bewertungen des Streiter-Zyklus');
+        $response->assertSee('25 Baxx');
     }
 
     public function test_archivar_cycle_chart_visible_with_enough_points(): void
@@ -421,7 +428,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Archivar-Zyklus');
     }
 
-    public function test_archivar_cycle_chart_hidden_below_threshold(): void
+    public function test_archivar_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(25);
@@ -430,7 +437,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Archivar-Zyklus');
+        $response->assertSee('Bewertungen des Archivar-Zyklus');
+        $response->assertSee('26 Baxx');
     }
 
     public function test_zeitsprung_cycle_chart_visible_with_enough_points(): void
@@ -445,7 +453,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Zeitsprung-Zyklus');
     }
 
-    public function test_zeitsprung_cycle_chart_hidden_below_threshold(): void
+    public function test_zeitsprung_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(26);
@@ -454,7 +462,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Zeitsprung-Zyklus');
+        $response->assertSee('Bewertungen des Zeitsprung-Zyklus');
+        $response->assertSee('27 Baxx');
     }
 
     public function test_fremdwelt_cycle_chart_visible_with_enough_points(): void
@@ -469,7 +478,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Fremdwelt-Zyklus');
     }
 
-    public function test_fremdwelt_cycle_chart_hidden_below_threshold(): void
+    public function test_fremdwelt_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(27);
@@ -478,7 +487,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Fremdwelt-Zyklus');
+        $response->assertSee('Bewertungen des Fremdwelt-Zyklus');
+        $response->assertSee('28 Baxx');
     }
 
     public function test_parallelwelt_cycle_chart_visible_with_enough_points(): void
@@ -493,7 +503,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Parallelwelt-Zyklus');
     }
 
-    public function test_parallelwelt_cycle_chart_hidden_below_threshold(): void
+    public function test_parallelwelt_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(28);
@@ -502,7 +512,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Parallelwelt-Zyklus');
+        $response->assertSee('Bewertungen des Parallelwelt-Zyklus');
+        $response->assertSee('29 Baxx');
     }
 
     public function test_weltenriss_cycle_chart_visible_with_enough_points(): void
@@ -517,7 +528,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Weltenriss-Zyklus');
     }
 
-    public function test_weltenriss_cycle_chart_hidden_below_threshold(): void
+    public function test_weltenriss_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(29);
@@ -526,7 +537,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Weltenriss-Zyklus');
+        $response->assertSee('Bewertungen des Weltenriss-Zyklus');
+        $response->assertSee('30 Baxx');
     }
 
     public function test_amraka_cycle_chart_visible_with_enough_points(): void
@@ -541,7 +553,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Amraka-Zyklus');
     }
 
-    public function test_amraka_cycle_chart_hidden_below_threshold(): void
+    public function test_amraka_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(30);
@@ -550,7 +562,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Amraka-Zyklus');
+        $response->assertSee('Bewertungen des Amraka-Zyklus');
+        $response->assertSee('31 Baxx');
     }
 
     public function test_weltrat_cycle_chart_visible_with_enough_points(): void
@@ -565,7 +578,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen des Weltrat-Zyklus');
     }
 
-    public function test_weltrat_cycle_chart_hidden_below_threshold(): void
+    public function test_weltrat_cycle_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $user = $this->actingMemberWithPoints(31);
@@ -574,7 +587,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen des Weltrat-Zyklus');
+        $response->assertSee('Bewertungen des Weltrat-Zyklus');
+        $response->assertSee('32 Baxx');
     }
 
     public function test_hardcover_chart_visible_with_enough_points(): void
@@ -590,7 +604,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Bewertungen der Hardcover');
     }
 
-    public function test_hardcover_chart_hidden_below_threshold(): void
+    public function test_hardcover_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $this->createHardcoversFile();
@@ -600,7 +614,8 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Bewertungen der Hardcover');
+        $response->assertSee('Bewertungen der Hardcover');
+        $response->assertSee('40 Baxx');
     }
 
     public function test_hardcover_author_chart_visible_with_enough_points(): void
@@ -616,7 +631,7 @@ class StatistikTest extends TestCase
         $response->assertSee('Maddrax-Hardcover je Autor:in');
     }
 
-    public function test_hardcover_author_chart_hidden_below_threshold(): void
+    public function test_hardcover_author_chart_locked_below_threshold(): void
     {
         $this->createDataFile();
         $this->createHardcoversFile();
@@ -626,6 +641,7 @@ class StatistikTest extends TestCase
         $response = $this->get('/statistik');
 
         $response->assertOk();
-        $response->assertDontSee('Maddrax-Hardcover je Autor:in');
+        $response->assertSee('Maddrax-Hardcover je Autor:in');
+        $response->assertSee('41 Baxx');
     }
 }


### PR DESCRIPTION
## Summary
- Always render statistik cards and indicate required Baxx via data-min-points attribute
- Blur locked statistics client-side and display unlock message with required Baxx
- Update feature tests for new locked-card behavior

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [1698] Access denied for user 'root'@'localhost')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8fbe8aa8832e9b0222b9f24ff371