### PR TITLE
Feature: Add Weltrat-Kritiker badge for full cycle reviews

### DIFF
--- a/tests/Feature/ProfileViewControllerTest.php
+++ b/tests/Feature/ProfileViewControllerTest.php
@@ -16,6 +16,8 @@ use App\Models\Review;
 use App\Models\BookOffer;
 use App\Models\BookRequest;
 use App\Models\BookSwap;
+use App\Services\MaddraxDataService;
+use Illuminate\Support\Facades\File;
 
 class ProfileViewControllerTest extends TestCase
 {
@@ -266,6 +268,61 @@ class ProfileViewControllerTest extends TestCase
         $badges = $response->viewData('badges');
         $this->assertCount(1, $badges);
         $this->assertEquals('Händler (Stufe 4)', $badges[0]['name']);
+    }
+
+    public function test_weltrat_kritiker_badge_for_full_cycle(): void
+    {
+        $admin = $this->createMember('Admin');
+        $member = $this->createMember();
+
+        $testStoragePath = base_path('storage/testing-weltrat');
+        $originalStoragePath = $this->app->storagePath();
+        $this->app->useStoragePath($testStoragePath);
+        File::ensureDirectoryExists($testStoragePath . '/app/private');
+        $originalLocalRoot = config('filesystems.disks.local.root');
+        config(['filesystems.disks.local.root' => $testStoragePath . '/app/private']);
+
+        $ref = new \ReflectionClass(MaddraxDataService::class);
+        $property = $ref->getProperty('data');
+        $property->setAccessible(true);
+        $property->setValue(null, null);
+
+        $data = [
+            ['nummer' => 1, 'zyklus' => 'Weltrat-Zyklus', 'titel' => 'Roman1', 'text' => []],
+            ['nummer' => 2, 'zyklus' => 'Weltrat-Zyklus', 'titel' => 'Roman2', 'text' => []],
+        ];
+        File::put($testStoragePath . '/app/private/maddrax.json', json_encode($data));
+
+        $book1 = Book::create(['roman_number' => 1, 'title' => 'Roman1', 'author' => 'Author']);
+        $book2 = Book::create(['roman_number' => 2, 'title' => 'Roman2', 'author' => 'Author']);
+
+        Review::create([
+            'team_id' => $member->currentTeam->id,
+            'user_id' => $member->id,
+            'book_id' => $book1->id,
+            'title' => 'R1',
+            'content' => str_repeat('A', 140),
+        ]);
+
+        Review::create([
+            'team_id' => $member->currentTeam->id,
+            'user_id' => $member->id,
+            'book_id' => $book2->id,
+            'title' => 'R2',
+            'content' => str_repeat('A', 140),
+        ]);
+
+        $this->actingAs($admin);
+        $response = $this->get("/profil/{$member->id}");
+
+        $response->assertOk();
+        $badges = $response->viewData('badges');
+        $this->assertCount(1, $badges);
+        $this->assertEquals('Weltrat-Kritiker', $badges[0]['name']);
+
+        File::deleteDirectory($testStoragePath);
+        $this->app->useStoragePath($originalStoragePath);
+        config(['filesystems.disks.local.root' => $originalLocalRoot]);
     }
 
     public function test_online_status_is_true_for_recent_activity(): void


### PR DESCRIPTION
This pull request introduces a new badge, "Weltrat-Kritiker", which is awarded to users who have reviewed every book in the Weltrat cycle. The implementation includes both backend logic for badge assignment and a comprehensive feature test to ensure correct behavior.

### New badge logic

* Added code in `ProfileViewController` to check if a user has reviewed all books in the Weltrat cycle, using `MaddraxDataService` to load relevant data, and awards the "Weltrat-Kritiker" badge if the condition is met.

### Test coverage

* Added a feature test `test_weltrat_kritiker_badge_for_full_cycle` in `ProfileViewControllerTest.php` that sets up test data for the Weltrat cycle, creates reviews for all relevant books, and verifies that the badge is correctly awarded.

### Supporting changes

* Imported `MaddraxDataService` and other necessary classes in both controller and test files to support the new badge logic and testing. [[1]](diffhunk://#diff-0088162d823e0e586b60dacd5b8ac2e1354881980c4cae22fba0331e8ba3d689R14-R15) [[2]](diffhunk://#diff-0ca56e7d7d9b61622c23ae1f77fb89151e6369919fdf72d1651c081a65c4ce38R19-R20)