### PR TITLE
Fix undefined legend entry for cycle charts

### DIFF
--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -57,6 +57,7 @@ function drawCycleChart(canvasId, labels, data) {
                     borderColor: 'rgba(139, 1, 22, .8)',
                     backgroundColor: 'rgba(139, 1, 22, .3)',
                     tension: 0.3,
+                    label: '⌀ Bewertung',
                 },
                 {
                     data: averageData,

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -38,7 +38,9 @@ describe('statistik module', () => {
     expect(config.type).toBe('line');
     expect(config.data.labels).toEqual(['X', 'Y']);
     expect(config.data.datasets[0].data).toEqual([4, 6]);
+    expect(config.data.datasets[0].label).toBe('⌀ Bewertung');
     expect(config.data.datasets[1].data).toEqual([5, 5]);
+    expect(config.data.datasets[1].label).toBe('Durchschnitt');
     expect(config.options.plugins.legend.display).toBe(true);
   });
 


### PR DESCRIPTION
This pull request introduces a minor enhancement to the charting functionality and its associated test coverage. The most important change is the addition of descriptive labels for chart datasets, improving clarity for users and ensuring the test suite validates their presence.

Chart display improvements:

* Added the label `'⌀ Bewertung'` to the main dataset in the chart generated by `drawCycleChart` in `statistik.js`, making the chart legend more informative.

Test coverage improvements:

* Updated the test in `statistik.test.js` to assert that the main dataset label is `'⌀ Bewertung'` and the average dataset label is `'Durchschnitt'`, ensuring that the labels are correctly set and displayed.