### PR TITLE
Fix Weltrat cycle average calculation

### DIFF
--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -43,8 +43,8 @@ function drawCycleChart(canvasId, labels, data) {
     if (userPoints < min) {
         values = data.map(() => +(Math.random() * 6).toFixed(2));
     }
-
-    const average = values.length ? values.reduce((sum, val) => sum + val, 0) / values.length : 0;
+    const validValues = values.filter((val) => Number.isFinite(val));
+    const average = validValues.length ? validValues.reduce((sum, val) => sum + val, 0) / validValues.length : 0;
     const averageData = Array(labels.length).fill(average);
 
     new Chart(canvas.getContext('2d'), {

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -44,6 +44,15 @@ describe('statistik module', () => {
     expect(config.options.plugins.legend.display).toBe(true);
   });
 
+  test('drawCycleChart ignores null values when calculating average', () => {
+    document.body.innerHTML = '<canvas id="cycle"></canvas>';
+    drawCycleChart('cycle', ['A', 'B', 'C'], [4, null, 6]);
+
+    const config = mockChart.mock.calls[0][1];
+    expect(config.data.datasets[0].data).toEqual([4, null, 6]);
+    expect(config.data.datasets[1].data).toEqual([5, 5, 5]);
+  });
+
   test('DOMContentLoaded draws hardcover chart', async () => {
     jest.resetModules();
     const chartModule = await import('chart.js/auto');


### PR DESCRIPTION
## Summary
- ignore missing ratings when computing cycle chart average
- cover null ratings in cycle chart Jest tests

## Testing
- `npm test`
- `DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test` *(fails: SQLSTATE[HY000] [14] unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_68aae20e14b8832eb21ecba778a00006