### PR TITLE
Filter Matches nach Nutzer und verschiebe Buttons

### DIFF
--- a/resources/views/romantausch/index.blade.php
+++ b/resources/views/romantausch/index.blade.php
@@ -5,20 +5,10 @@
                     {{ session('success') }}
                 </div>
             @endif
-            <!-- Kopfzeile mit Buttons -->
+            <!-- Kopfzeile -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                 <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
                     <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">Romantauschbörse</h1>
-                    <div class="flex gap-2">
-                        <a href="{{ route('romantausch.create-offer') }}"
-                           class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D]">
-                            Angebot erstellen
-                        </a>
-                        <a href="{{ route('romantausch.create-request') }}"
-                           class="inline-flex items-center px-4 py-2 bg-gray-600 dark:bg-gray-500 border border-transparent rounded-md font-semibold text-white hover:bg-gray-700 dark:hover:bg-gray-400">
-                            Gesuch erstellen
-                        </a>
-                    </div>
                 </div>
                 <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
                     Für jedes <strong>zehnte</strong> eingestellte Angebot erhältst du automatisch
@@ -53,7 +43,13 @@
             @endif
             <!-- Angebote -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">Aktuelle Angebote</h2>
+                <div class="flex justify-between items-center mb-4">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">Aktuelle Angebote</h2>
+                    <a href="{{ route('romantausch.create-offer') }}"
+                       class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D]">
+                        Angebot erstellen
+                    </a>
+                </div>
                 @if($offers->isEmpty())
                     <p class="text-gray-600 dark:text-gray-400">Keine Angebote vorhanden.</p>
                 @else
@@ -77,7 +73,13 @@
             </div>
             <!-- Gesuche -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
-                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4">Aktuelle Gesuche</h2>
+                <div class="flex justify-between items-center mb-4">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">Aktuelle Gesuche</h2>
+                    <a href="{{ route('romantausch.create-request') }}"
+                       class="inline-flex items-center px-4 py-2 bg-gray-600 dark:bg-gray-500 border border-transparent rounded-md font-semibold text-white hover:bg-gray-700 dark:hover:bg-gray-400">
+                        Gesuch erstellen
+                    </a>
+                </div>
                 @if($requests->isEmpty())
                     <p class="text-gray-600 dark:text-gray-400">Keine Gesuche vorhanden.</p>
                 @else


### PR DESCRIPTION
This pull request updates the Romantausch (book exchange) feature to improve the user experience and ensure users only see swaps relevant to them. The changes focus on filtering active swaps by user and enhancing the UI by relocating the "create offer/request" buttons for better visibility.

**Backend logic improvements:**

* The `index` method in `RomantauschController.php` now filters `activeSwaps` so users only see swaps where they are involved, either as the offerer or requester.

**User interface improvements:**

* The "create offer" and "create request" buttons were removed from the main header and instead added directly to the respective "Aktuelle Angebote" and "Aktuelle Gesuche" sections, making them more contextually accessible for users. [[1]](diffhunk://#diff-989c06045f97dda4b51981c5158c5f5dba13e2002e7e2bae0dd4bfc86f4bfcd2L8-L21) [[2]](diffhunk://#diff-989c06045f97dda4b51981c5158c5f5dba13e2002e7e2bae0dd4bfc86f4bfcd2L56-R52) [[3]](diffhunk://#diff-989c06045f97dda4b51981c5158c5f5dba13e2002e7e2bae0dd4bfc86f4bfcd2L80-R82)