### PR TITLE
Add Lieblingscover field in user profile

### DIFF
--- a/app/Actions/Fortify/UpdateUserSeriendaten.php
+++ b/app/Actions/Fortify/UpdateUserSeriendaten.php
@@ -21,6 +21,7 @@ class UpdateUserSeriendaten
             'lieblingszyklus' => ['nullable', 'string', 'max:255'],
             'lieblingsthema' => ['nullable', 'string', 'max:255'],
             'lieblingshardcover' => ['nullable', 'string', 'max:255'],
+            'lieblingscover' => ['nullable', 'string', 'max:255'],
         ])->validateWithBag('updateSeriendaten');
 
         $user->forceFill([
@@ -34,6 +35,7 @@ class UpdateUserSeriendaten
             'lieblingszyklus' => $input['lieblingszyklus'] ?? null,
             'lieblingsthema' => $input['lieblingsthema'] ?? null,
             'lieblingshardcover' => $input['lieblingshardcover'] ?? null,
+            'lieblingscover' => $input['lieblingscover'] ?? null,
         ])->save();
     }
 }

--- a/app/Livewire/Profile/UpdateSeriendatenForm.php
+++ b/app/Livewire/Profile/UpdateSeriendatenForm.php
@@ -19,6 +19,7 @@ class UpdateSeriendatenForm extends Component
     public array $schauplaetze = [];
     public array $schlagworte = [];
     public array $hardcover = [];
+    public array $covers = [];
 
     public function mount()
     {
@@ -33,6 +34,7 @@ class UpdateSeriendatenForm extends Component
             'lieblingszyklus',
             'lieblingsthema',
             'lieblingshardcover',
+            'lieblingscover',
         ]);
         $this->autoren = MaddraxDataService::getAutoren();
         $this->zyklen = MaddraxDataService::getZyklen();
@@ -45,6 +47,19 @@ class UpdateSeriendatenForm extends Component
             ->get()
             ->map(fn ($book) => ($book->roman_number ? $book->roman_number.' - ' : '').$book->title)
             ->toArray();
+
+        $romanCoverNumbers = collect($this->romane)
+            ->map(fn ($roman) => 'Roman ' . explode(' - ', $roman)[0])
+            ->toArray();
+
+        $hardcoverCoverNumbers = Book::where('type', BookType::MaddraxHardcover)
+            ->whereNotNull('roman_number')
+            ->orderBy('roman_number')
+            ->pluck('roman_number')
+            ->map(fn ($num) => 'Hardcover ' . $num)
+            ->toArray();
+
+        $this->covers = array_merge($romanCoverNumbers, $hardcoverCoverNumbers);
     }
 
     public function updateSeriendaten(UpdateUserSeriendaten $updater)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,7 @@ use Illuminate\Support\Facades\Schema;
  * @property string|null $lieblingszyklus
  * @property string|null $lieblingsthema
  * @property string|null $lieblingshardcover
+ * @property string|null $lieblingscover
  */
 class User extends Authenticatable
 {
@@ -73,6 +74,7 @@ class User extends Authenticatable
         'lieblingszyklus',
         'lieblingsthema',
         'lieblingshardcover',
+        'lieblingscover',
         'mitglied_seit',
         'bezahlt_bis',
         'notify_new_review',

--- a/database/migrations/2025_09_20_000001_add_lieblingscover_to_users_table.php
+++ b/database/migrations/2025_09_20_000001_add_lieblingscover_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('lieblingscover')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('lieblingscover');
+        });
+    }
+};

--- a/lang/de/profile.php
+++ b/lang/de/profile.php
@@ -6,6 +6,7 @@ return [
     'Lieblingsautor:in (optional)' => 'Lieblingsautor:in (optional)',
     'Lieblingsroman (optional)' => 'Lieblingsroman (optional)',
     'Lieblingshardcover (optional)' => 'Lieblingshardcover (optional)',
+    'Lieblingscover (optional)' => 'Lieblingscover (optional)',
     'Lieblingsthema (optional)' => 'Lieblingsthema (optional)',
     'Persönliche Daten' => 'Persönliche Daten',
     'Hier kannst du ganz einfach deine persönlichen Angaben aktualisieren. Bitte halte diese Informationen möglichst aktuell, damit wir dich erreichen können. Während Namen und Foto für andere sichtbar sind, bleiben deine Adressdaten und dein eingestellter Mitgliedsbeitrag für andere Mitglieder unsichtbar.' => 'Hier kannst du ganz einfach deine persönlichen Angaben aktualisieren. Bitte halte diese Informationen möglichst aktuell, damit wir dich erreichen können. Während Namen und Foto für andere sichtbar sind, bleiben deine Adressdaten und dein eingestellter Mitgliedsbeitrag für andere Mitglieder unsichtbar.',

--- a/resources/views/profile/update-seriendaten-form.blade.php
+++ b/resources/views/profile/update-seriendaten-form.blade.php
@@ -69,6 +69,18 @@
             </select>
             <x-input-error for="lieblingshardcover" class="mt-2" />
         </div>
+        <!-- Lieblingscover Dropdown -->
+        <div class="col-span-6 sm:col-span-4">
+            <x-label for="lieblingscover" value="{{ __('Lieblingscover (optional)') }}" />
+            <select id="lieblingscover" wire:model="state.lieblingscover"
+                class="mt-1 block w-full border-gray-300 dark:border-gray-700 dark:bg-gray-800 rounded-md shadow-sm">
+                <option value="">Cover auswählen</option>
+                @foreach($covers as $cover)
+                    <option value="{{ $cover }}">{{ $cover }}</option>
+                @endforeach
+            </select>
+            <x-input-error for="lieblingscover" class="mt-2" />
+        </div>
         <!-- Lieblingszyklus Dropdown -->
         <div class="col-span-6 sm:col-span-4">
             <x-label for="lieblingszyklus" value="{{ __('Lieblingszyklus (optional)') }}" />

--- a/resources/views/profile/view.blade.php
+++ b/resources/views/profile/view.blade.php
@@ -196,6 +196,13 @@
                                     </div>
                                 @endif
 
+                                @if($user->lieblingscover)
+                                    <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg shadow">
+                                        <h3 class="font-semibold text-gray-800 dark:text-white mb-2">Lieblingscover</h3>
+                                        <p class="text-gray-600 dark:text-gray-300">{{ $user->lieblingscover }}</p>
+                                    </div>
+                                @endif
+
                                 @if($user->lieblingsfigur)
                                     <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg shadow">
                                         <h3 class="font-semibold text-gray-800 dark:text-white mb-2">Lieblingsfigur</h3>

--- a/tests/Feature/UpdateSeriendatenFormTest.php
+++ b/tests/Feature/UpdateSeriendatenFormTest.php
@@ -91,6 +91,7 @@ class UpdateSeriendatenFormTest extends TestCase
             'lieblingszyklus' => 'Z1',
             'lieblingsthema' => 'Thema1',
             'lieblingshardcover' => '1 - Hardcover1',
+            'lieblingscover' => 'Roman 1',
         ])->save();
 
         $this->actingAs($user);
@@ -109,13 +110,15 @@ class UpdateSeriendatenFormTest extends TestCase
             ->assertSet('state.lieblingszyklus', 'Z1')
             ->assertSet('state.lieblingsthema', 'Thema1')
             ->assertSet('state.lieblingshardcover', '1 - Hardcover1')
+            ->assertSet('state.lieblingscover', 'Roman 1')
             ->assertSet('autoren', ['Author1', 'Author2'])
             ->assertSet('zyklen', ['Z1', 'Z2'])
             ->assertSet('romane', ['1 - Roman1', '2 - Roman2'])
             ->assertSet('figuren', ['Figur1', 'Figur2'])
             ->assertSet('schauplaetze', ['Ort1', 'Ort2'])
             ->assertSet('schlagworte', ['Thema1', 'Thema2'])
-            ->assertSet('hardcover', ['1 - Hardcover1', '2 - Hardcover2']);
+            ->assertSet('hardcover', ['1 - Hardcover1', '2 - Hardcover2'])
+            ->assertSet('covers', ['Roman 1', 'Roman 2', 'Hardcover 1', 'Hardcover 2']);
     }
 
     public function test_seriendaten_can_be_updated(): void
@@ -135,6 +138,7 @@ class UpdateSeriendatenFormTest extends TestCase
                 'lieblingszyklus' => 'Z2',
                 'lieblingsthema' => 'Thema2',
                 'lieblingshardcover' => '2 - Hardcover2',
+                'lieblingscover' => 'Hardcover 2',
             ])
             ->call('updateSeriendaten')
             ->assertDispatched('saved');
@@ -151,5 +155,6 @@ class UpdateSeriendatenFormTest extends TestCase
         $this->assertSame('Z2', $user->lieblingszyklus);
         $this->assertSame('Thema2', $user->lieblingsthema);
         $this->assertSame('2 - Hardcover2', $user->lieblingshardcover);
+        $this->assertSame('Hardcover 2', $user->lieblingscover);
     }
 }

--- a/tests/Feature/UpdateSeriendatenTest.php
+++ b/tests/Feature/UpdateSeriendatenTest.php
@@ -25,6 +25,7 @@ class UpdateSeriendatenTest extends TestCase
             'lieblingszyklus' => 'Zyklus',
             'lieblingsthema' => 'Thema',
             'lieblingshardcover' => 'HC',
+            'lieblingscover' => 'Roman 1',
         ]));
 
         $component = Livewire::test(UpdateSeriendatenForm::class);
@@ -39,6 +40,7 @@ class UpdateSeriendatenTest extends TestCase
         $this->assertSame('Zyklus', $component->get('state.lieblingszyklus'));
         $this->assertSame('Thema', $component->get('state.lieblingsthema'));
         $this->assertSame('HC', $component->get('state.lieblingshardcover'));
+        $this->assertSame('Roman 1', $component->get('state.lieblingscover'));
     }
 
     public function test_seriendaten_can_be_updated(): void
@@ -57,6 +59,7 @@ class UpdateSeriendatenTest extends TestCase
                 'lieblingszyklus' => 'H',
                 'lieblingsthema' => 'I',
                 'lieblingshardcover' => 'J',
+                'lieblingscover' => 'K',
             ])
             ->call('updateSeriendaten');
 
@@ -72,6 +75,7 @@ class UpdateSeriendatenTest extends TestCase
         $this->assertSame('H', $user->lieblingszyklus);
         $this->assertSame('I', $user->lieblingsthema);
         $this->assertSame('J', $user->lieblingshardcover);
+        $this->assertSame('K', $user->lieblingscover);
     }
 
     public function test_validation_fails_for_too_long_values(): void


### PR DESCRIPTION
This pull request introduces support for a new user profile field, `lieblingscover` ("favorite cover"), allowing users to select and save their favorite book or hardcover cover. The implementation includes backend model and migration changes, updates to the profile form and view, and comprehensive test coverage to ensure correct behavior.

**Feature Addition: Lieblingscover Field**

* Added a new nullable string column `lieblingscover` to the `users` table via migration.
* Updated the `User` model and related validation logic to support the new `lieblingscover` field, including fillable attributes and property annotations. [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR33) [[2]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR77) [[3]](diffhunk://#diff-2c91a5acbaae159d3c7703fbd36ddeae5939a6f58cc2b30e729f15d077f0573aR24) [[4]](diffhunk://#diff-2c91a5acbaae159d3c7703fbd36ddeae5939a6f58cc2b30e729f15d077f0573aR38)

**Profile Form and UI Updates**

* Extended the profile update form (`UpdateSeriendatenForm` and Blade view) to include a dropdown for selecting the favorite cover, with the options generated from available roman and hardcover numbers. [[1]](diffhunk://#diff-f0c82d7ea9149bbb3e2797cb528ccbd375225cbf69290484682e0ad3a880a93cR22) [[2]](diffhunk://#diff-f0c82d7ea9149bbb3e2797cb528ccbd375225cbf69290484682e0ad3a880a93cR37) [[3]](diffhunk://#diff-f0c82d7ea9149bbb3e2797cb528ccbd375225cbf69290484682e0ad3a880a93cR50-R62) [[4]](diffhunk://#diff-09475e2ca5006d4e997f46fb70c6164013ec6bfeec57bcf7f0272e9de95ea817R72-R83)
* Updated the profile view to display the selected favorite cover if set.
* Added translation string for "Lieblingscover (optional)" in the German language file.

**Testing Enhancements**

* Added and updated feature tests to verify the correct handling of the new `lieblingscover` field, including initial state, update functionality, and validation. [[1]](diffhunk://#diff-3d5b7f9447233b70270e48873e01df376acf1134ec7fc6bc5e85b27d50d9ee75R94) [[2]](diffhunk://#diff-3d5b7f9447233b70270e48873e01df376acf1134ec7fc6bc5e85b27d50d9ee75R113-R121) [[3]](diffhunk://#diff-3d5b7f9447233b70270e48873e01df376acf1134ec7fc6bc5e85b27d50d9ee75R141) [[4]](diffhunk://#diff-3d5b7f9447233b70270e48873e01df376acf1134ec7fc6bc5e85b27d50d9ee75R158) [[5]](diffhunk://#diff-090df499a8798a4ffc41db1f85a11cd2f7aecefc2e07e8c8b9bc3ce908a424a8R28) [[6]](diffhunk://#diff-090df499a8798a4ffc41db1f85a11cd2f7aecefc2e07e8c8b9bc3ce908a424a8R43) [[7]](diffhunk://#diff-090df499a8798a4ffc41db1f85a11cd2f7aecefc2e07e8c8b9bc3ce908a424a8R62) [[8]](diffhunk://#diff-090df499a8798a4ffc41db1f85a11cd2f7aecefc2e07e8c8b9bc3ce908a424a8R78)