### PR TITLE
Admin-Menü aufgeräumt: AG-Erstellung als Button

### DIFF
--- a/resources/views/arbeitsgruppen/index.blade.php
+++ b/resources/views/arbeitsgruppen/index.blade.php
@@ -1,7 +1,13 @@
 <x-app-layout title="Arbeitsgruppen – Admin – Offizieller MADDRAX Fanclub e. V." description="Tabellarische Übersicht aller Arbeitsgruppen für Administratoren.">
     <x-member-page>
         <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
-            <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-6">Arbeitsgruppen</h2>
+            <div class="flex justify-between items-center mb-6">
+                <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">Arbeitsgruppen</h2>
+                <a href="{{ route('arbeitsgruppen.create') }}"
+                   class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D]">
+                    AG erstellen
+                </a>
+            </div>
             <div class="overflow-x-auto">
                 <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                     <thead>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -77,7 +77,6 @@
                                 <x-dropdown-link href="{{ route('admin.index') }}">Admin</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('arbeitsgruppen.index') }}">Arbeitsgruppen</x-dropdown-link>
-                                <x-dropdown-link href="{{ route('arbeitsgruppen.create') }}">Neue AG</x-dropdown-link>
                             </div>
                         </div>
                         @endif
@@ -183,7 +182,6 @@
                 <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('arbeitsgruppen.index') }}">Arbeitsgruppen</x-responsive-nav-link>
-                <x-responsive-nav-link href="{{ route('arbeitsgruppen.create') }}">Neue AG</x-responsive-nav-link>
             </div>
             @endif
 


### PR DESCRIPTION
This pull request updates the user interface for managing "Arbeitsgruppen" (working groups) in the admin section. The main improvement is the relocation of the "Neue AG" (Create New Working Group) action from the navigation menu directly into the page header of the Arbeitsgruppen index view, streamlining the workflow and reducing redundancy.

**UI/UX Improvements:**

* Added a prominent "AG erstellen" (Create Working Group) button to the header section of the `arbeitsgruppen/index.blade.php` page for easier access to group creation.

**Navigation Cleanup:**

* Removed the "Neue AG" link from both the desktop and mobile navigation menus in `navigation-menu.blade.php` to avoid duplication and keep navigation concise. [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL80) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL186)