### PR TITLE
Expose work groups on public site

### DIFF
--- a/app/Http/Controllers/ArbeitsgruppenController.php
+++ b/app/Http/Controllers/ArbeitsgruppenController.php
@@ -25,6 +25,21 @@ class ArbeitsgruppenController extends Controller
     }
 
     /**
+     * Display a listing of the AGs for the public page.
+     */
+    public function publicIndex()
+    {
+        $ags = Team::where('personal_team', false)
+            ->where('name', '!=', 'Mitglieder')
+            ->orderBy('name')
+            ->get();
+
+        return view('pages.arbeitsgruppen', [
+            'ags' => $ags,
+        ]);
+    }
+
+    /**
      * Display form to create a new AG (team).
      */
     public function create()

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -85,6 +85,7 @@
                         <x-nav-link href="{{ route('chronik') }}">Chronik</x-nav-link>
                         <x-nav-link href="{{ route('ehrenmitglieder') }}">Ehrenmitglieder</x-nav-link>
                         <x-nav-link href="{{ route('termine') }}">Termine</x-nav-link>
+                        <x-nav-link href="{{ route('arbeitsgruppen') }}">Arbeitsgruppen</x-nav-link>
                         <x-nav-link href="{{ route('satzung') }}">Satzung</x-nav-link>
                         <x-nav-link href="{{ route('mitglied.werden') }}">Mitglied werden</x-nav-link>
                         <x-nav-link href="{{ route('spenden') }}">Spenden</x-nav-link>
@@ -191,6 +192,7 @@
             <x-responsive-nav-link href="{{ route('chronik') }}">Chronik</x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('ehrenmitglieder') }}">Ehrenmitglieder</x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('termine') }}">Termine</x-responsive-nav-link>
+            <x-responsive-nav-link href="{{ route('arbeitsgruppen') }}">Arbeitsgruppen</x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('satzung') }}">Satzung</x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('mitglied.werden') }}">Mitglied werden</x-responsive-nav-link>
             <x-responsive-nav-link href="{{ route('spenden') }}">Spenden</x-responsive-nav-link>

--- a/resources/views/pages/arbeitsgruppen.blade.php
+++ b/resources/views/pages/arbeitsgruppen.blade.php
@@ -1,0 +1,28 @@
+<x-app-layout title="Arbeitsgruppen – Offizieller MADDRAX Fanclub e. V." description="Überblick über alle Projektteams des Vereins.">
+    <x-public-page>
+        <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Arbeitsgruppen des OMXFC e.V.</h1>
+
+        @foreach($ags as $ag)
+            <section class="mb-12">
+                <h2 class="text-2xl font-semibold mb-4">{{ $ag->name }}</h2>
+                @if($ag->logo_path)
+                    <img loading="lazy" src="{{ asset('storage/' . $ag->logo_path) }}" alt="Logo der {{ $ag->name }}" class="w-full h-auto rounded-lg shadow mb-4 ag-logo">
+                @endif
+                @if($ag->description)
+                    <p class="mb-4">{{ $ag->description }}</p>
+                @endif
+                <p>
+                    @if($ag->owner)
+                        <strong>AG-Leitung:</strong> {{ $ag->owner->name }}<br>
+                    @endif
+                    @if($ag->meeting_schedule)
+                        <strong>Treffen:</strong> {{ $ag->meeting_schedule }}<br>
+                    @endif
+                    @if($ag->email)
+                        <strong>Kontakt:</strong> <a href="mailto:{{ $ag->email }}" class="text-blue-600 hover:underline">{{ $ag->email }}</a>
+                    @endif
+                </p>
+            </section>
+        @endforeach
+    </x-public-page>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ Route::get('/satzung', [PageController::class, 'satzung'])->name('satzung');
 Route::get('/chronik', [PageController::class, 'chronik'])->name('chronik');
 Route::get('/ehrenmitglieder', [PageController::class, 'ehrenmitglieder'])->name('ehrenmitglieder');
 Route::get('/termine', [PageController::class, 'termine'])->name('termine');
+Route::get('/arbeitsgruppen', [ArbeitsgruppenController::class, 'publicIndex'])->name('arbeitsgruppen');
 Route::get('/mitglied-werden', [PageController::class, 'mitgliedWerden'])->name('mitglied.werden');
 Route::get('/impressum', [PageController::class, 'impressum'])->name('impressum');
 Route::get('/datenschutz', [PageController::class, 'datenschutz'])->name('datenschutz');
@@ -117,7 +118,7 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         });
     });
 
-    Route::prefix('arbeitsgruppen')->name('arbeitsgruppen.')->controller(ArbeitsgruppenController::class)->middleware('admin')->group(function () {
+    Route::prefix('admin/arbeitsgruppen')->name('arbeitsgruppen.')->controller(ArbeitsgruppenController::class)->middleware('admin')->group(function () {
         Route::get('/', 'index')->name('index');
         Route::get('erstellen', 'create')->name('create');
         Route::post('/', 'store')->name('store');


### PR DESCRIPTION
This pull request adds a new public-facing page that displays a list of all "Arbeitsgruppen" (project teams) in the club, and integrates it into the site's navigation. It also updates routing to better separate public and admin views for Arbeitsgruppen management.

**Public Arbeitsgruppen page and navigation integration:**

* Added a new controller method `publicIndex` in `ArbeitsgruppenController` to fetch and display non-personal teams for the public page.
* Created a new Blade view `pages/arbeitsgruppen.blade.php` to render the list of Arbeitsgruppen with details such as name, logo, description, lead, meeting schedule, and contact email.
* Registered a new route `/arbeitsgruppen` for the public Arbeitsgruppen page in `routes/web.php`.
* Added navigation links to the new Arbeitsgruppen page in both desktop and responsive menus in `navigation-menu.blade.php`. [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR88) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR195)

**Admin routing update:**

* Changed the admin Arbeitsgruppen route prefix from `arbeitsgruppen` to `admin/arbeitsgruppen` in `routes/web.php` to clarify separation between public and admin pages.