### PR TITLE
Allow AG leaders to manage their groups

### DIFF
--- a/resources/views/arbeitsgruppen/edit.blade.php
+++ b/resources/views/arbeitsgruppen/edit.blade.php
@@ -1,0 +1,69 @@
+<x-app-layout>
+    <x-member-page class="max-w-3xl">
+        <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
+            <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-6">AG bearbeiten</h2>
+
+            <form action="{{ route('arbeitsgruppen.update', $team) }}" method="POST" enctype="multipart/form-data">
+                @csrf
+                @method('PUT')
+
+                <div class="mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name der AG</label>
+                    <input type="text" name="name" id="name" value="{{ old('name', $team->name) }}" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    @error('name')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="leader_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">AG-Leiter</label>
+                    <select name="leader_id" id="leader_id" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                        @foreach($users as $member)
+                            <option value="{{ $member->id }}" {{ old('leader_id', $team->user_id) == $member->id ? 'selected' : '' }}>{{ $member->name }}</option>
+                        @endforeach
+                    </select>
+                    @error('leader_id')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Beschreibung</label>
+                    <textarea name="description" id="description" rows="3" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">{{ old('description', $team->description) }}</textarea>
+                    @error('description')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">E-Mail-Adresse</label>
+                    <input type="email" name="email" id="email" value="{{ old('email', $team->email) }}" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    @error('email')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-4">
+                    <label for="meeting_schedule" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Wiederkehrender Termin</label>
+                    <input type="text" name="meeting_schedule" id="meeting_schedule" value="{{ old('meeting_schedule', $team->meeting_schedule) }}" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    @error('meeting_schedule')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="mb-6">
+                    <label for="logo" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Logo</label>
+                    <input type="file" name="logo" id="logo" accept="image/*" class="w-full text-gray-700 dark:text-gray-300">
+                    @error('logo')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="flex justify-end">
+                    <a href="{{ route('arbeitsgruppen.index') }}" class="mr-3 inline-flex items-center px-4 py-2 bg-gray-300 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-gray-800 dark:text-white hover:bg-gray-400 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">Abbrechen</a>
+                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#8B0116] dark:focus:ring-[#FF6B81]">Speichern</button>
+                </div>
+            </form>
+        </div>
+    </x-member-page>
+</x-app-layout>

--- a/resources/views/arbeitsgruppen/index.blade.php
+++ b/resources/views/arbeitsgruppen/index.blade.php
@@ -1,12 +1,14 @@
-<x-app-layout title="Arbeitsgruppen – Admin – Offizieller MADDRAX Fanclub e. V." description="Tabellarische Übersicht aller Arbeitsgruppen für Administratoren.">
+<x-app-layout title="Arbeitsgruppen – Offizieller MADDRAX Fanclub e. V." description="Tabellarische Übersicht aller Arbeitsgruppen.">
     <x-member-page>
         <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
             <div class="flex justify-between items-center mb-6">
                 <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">Arbeitsgruppen</h2>
-                <a href="{{ route('arbeitsgruppen.create') }}"
-                   class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D]">
-                    AG erstellen
-                </a>
+                @if(Auth::user()->hasRole('Admin'))
+                    <a href="{{ route('arbeitsgruppen.create') }}"
+                       class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D]">
+                        AG erstellen
+                    </a>
+                @endif
             </div>
             <div class="overflow-x-auto">
                 <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
@@ -16,6 +18,7 @@
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Leitung</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">E-Mail</th>
                             <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Termin</th>
+                            <th class="px-4 py-2 text-left text-gray-800 dark:text-gray-200">Aktionen</th>
                         </tr>
                     </thead>
                     <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
@@ -25,10 +28,13 @@
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $ag->owner?->name ?? '-' }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $ag->email ?? '-' }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $ag->meeting_schedule ?? '-' }}</td>
+                                <td class="px-4 py-2">
+                                    <a href="{{ route('arbeitsgruppen.edit', $ag) }}" class="text-[#8B0116] dark:text-[#FF6B81] hover:underline">Bearbeiten</a>
+                                </td>
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="4" class="px-4 py-2 text-center text-gray-700 dark:text-gray-300">Keine Arbeitsgruppen vorhanden.</td>
+                                <td colspan="5" class="px-4 py-2 text-center text-gray-700 dark:text-gray-300">Keine Arbeitsgruppen vorhanden.</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -68,6 +68,9 @@
                             </div>
                         </div>
                         @endvorstand
+                        @if(!Auth::user()->hasRole('Admin') && Auth::user()->ownedTeams()->where('personal_team', false)->exists())
+                            <x-nav-link href="{{ route('arbeitsgruppen.index') }}">Arbeitsgruppen</x-nav-link>
+                        @endif
                         @if(Auth::user()->hasRole('Admin'))
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
                             <button id="admin-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="admin-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
@@ -176,6 +179,9 @@
                 <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
             </div>
             @endvorstand
+            @if(!Auth::user()->hasRole('Admin') && Auth::user()->ownedTeams()->where('personal_team', false)->exists())
+                <x-responsive-nav-link href="{{ route('arbeitsgruppen.index') }}">Arbeitsgruppen</x-responsive-nav-link>
+            @endif
             @if(Auth::user()->hasRole('Admin'))
             <button id="admin-mobile-button" type="button" @click="openMenu = (openMenu === 'admin' ? null : 'admin')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'admin' }" :aria-expanded="openMenu === 'admin'" aria-controls="admin-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')" @keydown.space.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')">
             Admin</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -118,10 +118,12 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         });
     });
 
-    Route::prefix('admin/arbeitsgruppen')->name('arbeitsgruppen.')->controller(ArbeitsgruppenController::class)->middleware('admin')->group(function () {
+    Route::prefix('admin/arbeitsgruppen')->name('arbeitsgruppen.')->controller(ArbeitsgruppenController::class)->middleware('auth')->group(function () {
         Route::get('/', 'index')->name('index');
         Route::get('erstellen', 'create')->name('create');
         Route::post('/', 'store')->name('store');
+        Route::get('{team}/bearbeiten', 'edit')->name('edit');
+        Route::put('{team}', 'update')->name('update');
     });
 
     Route::get('/belohnungen', [RewardController::class, 'index'])->name('rewards.index');

--- a/tests/Feature/ArbeitsgruppenControllerTest.php
+++ b/tests/Feature/ArbeitsgruppenControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ArbeitsgruppenControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createMemberWithRole(string $role = 'Mitglied'): User
+    {
+        $memberTeam = Team::where('name', 'Mitglieder')->first();
+        $user = User::factory()->create(['current_team_id' => $memberTeam->id]);
+        $memberTeam->users()->attach($user, ['role' => $role]);
+        return $user;
+    }
+
+    public function test_ag_leader_can_update_own_team(): void
+    {
+        $leader = $this->createMemberWithRole();
+        $ag = Team::factory()->create([
+            'user_id' => $leader->id,
+            'personal_team' => false,
+            'name' => 'AG Test',
+        ]);
+        $ag->users()->attach($leader, ['role' => 'Mitglied']);
+
+        $this->actingAs($leader);
+
+        $response = $this->put(route('arbeitsgruppen.update', $ag), [
+            'name' => 'AG Neu',
+            'leader_id' => $leader->id,
+            'description' => 'Desc',
+            'email' => 'ag@example.com',
+            'meeting_schedule' => 'montags',
+        ]);
+
+        $response->assertRedirect(route('arbeitsgruppen.index'));
+        $this->assertDatabaseHas('teams', [
+            'id' => $ag->id,
+            'name' => 'AG Neu',
+            'description' => 'Desc',
+            'email' => 'ag@example.com',
+            'meeting_schedule' => 'montags',
+        ]);
+    }
+
+    public function test_ag_leader_cannot_edit_other_team(): void
+    {
+        $leader = $this->createMemberWithRole();
+        $otherLeader = $this->createMemberWithRole();
+        $ag = Team::factory()->create([
+            'user_id' => $otherLeader->id,
+            'personal_team' => false,
+            'name' => 'Andere AG',
+        ]);
+
+        $this->actingAs($leader);
+
+        $this->get(route('arbeitsgruppen.edit', $ag))->assertForbidden();
+    }
+
+    public function test_admin_can_update_any_team(): void
+    {
+        $admin = $this->createMemberWithRole('Admin');
+        $leader = $this->createMemberWithRole();
+        $ag = Team::factory()->create([
+            'user_id' => $leader->id,
+            'personal_team' => false,
+            'name' => 'AG Test',
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->put(route('arbeitsgruppen.update', $ag), [
+            'name' => 'AG Admin',
+            'leader_id' => $admin->id,
+            'description' => null,
+            'email' => null,
+            'meeting_schedule' => null,
+        ]);
+
+        $response->assertRedirect(route('arbeitsgruppen.index'));
+        $this->assertDatabaseHas('teams', [
+            'id' => $ag->id,
+            'name' => 'AG Admin',
+            'user_id' => $admin->id,
+        ]);
+    }
+}


### PR DESCRIPTION
This pull request introduces editing and updating functionality for Arbeitsgruppen (AGs, or working groups), adds access control for AG management, and updates navigation and views to support these features. It also includes tests to ensure correct permissions for both AG leaders and admins.

**Access control and permissions:**

* Added role-based access checks to AG listing, creation, and storage in `ArbeitsgruppenController`, ensuring only admins can create new AGs and only AG leaders or admins can view/edit their own AGs. [[1]](diffhunk://#diff-16c1c90f92456becebb39bdcfb179196bc4cb0e277f32d70f4d554e36cfa2da7L15-R29) [[2]](diffhunk://#diff-16c1c90f92456becebb39bdcfb179196bc4cb0e277f32d70f4d554e36cfa2da7L45-R57) [[3]](diffhunk://#diff-16c1c90f92456becebb39bdcfb179196bc4cb0e277f32d70f4d554e36cfa2da7R70-R71) [[4]](diffhunk://#diff-16c1c90f92456becebb39bdcfb179196bc4cb0e277f32d70f4d554e36cfa2da7L92-R175)
* Updated route middleware from `admin` to `auth` for AG management routes, allowing both AG leaders and admins to access edit/update actions with proper checks in the controller.

**Editing and updating AGs:**

* Implemented `edit` and `update` methods in `ArbeitsgruppenController` to allow AG leaders to edit their own AGs and admins to edit any AG, including updating leader, description, email, meeting schedule, and logo.
* Added a new Blade view `arbeitsgruppen/edit.blade.php` for the AG editing form.
* Updated AG listing view to include an "Aktionen" column with an edit link for each AG. [[1]](diffhunk://#diff-f61d4839b0a97d605f456365c2ac7a409071ab125c422261f434f9d3af2293f1R21) [[2]](diffhunk://#diff-f61d4839b0a97d605f456365c2ac7a409071ab125c422261f434f9d3af2293f1R31-R37)

**Navigation updates:**

* Modified navigation to show AG management links to AG leaders who are not admins, both in desktop and mobile navigation. [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR71-R73) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dR182-R184)

**Testing:**

* Added feature tests to verify that AG leaders can update their own AGs, cannot edit other AGs, and that admins can update any AG.