### PR TITLE
Add TOP20 Maddrax-Themen statistic

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -121,6 +121,22 @@ class StatistikController extends Controller
             ])
             ->values();
 
+        // ── Card 30 – TOP20 Maddrax-Themen ─────────────────────────────
+        $topThemes = $romane
+            ->flatMap(fn ($r) => collect($r['schlagworte'] ?? [])->map(fn ($s) => [
+                'keyword' => trim($s),
+                'rating' => $r['bewertung'],
+            ]))
+            ->filter(fn ($row) => $row['keyword'] !== '')
+            ->groupBy('keyword')
+            ->map(fn ($rows, $keyword) => [
+                'keyword' => $keyword,
+                'average' => round(collect($rows)->avg('rating'), 2),
+            ])
+            ->sortByDesc('average')
+            ->take(20)
+            ->values();
+
         // ── Card 8 – Bewertungen des Euree-Zyklus ───────────────────────
         $eureeCycle = $romane
             ->filter(fn ($r) => ($r['nummer'] ?? 0) >= 1 && ($r['nummer'] ?? 0) <= 24)
@@ -369,6 +385,7 @@ class StatistikController extends Controller
             'teamplayerTable' => $teamplayerTable,
             'topAuthorRatings' => $topAuthorRatings,
             'topCharacters' => $topCharacters,
+            'topThemes' => $topThemes,
             'userPoints' => $userPoints,
             'romaneTable' => $romaneTable,
             'eureeLabels' => $eureeLabels,

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -4,6 +4,7 @@
     "pub_date": "2025-08-24",
     "notes": [
       "[New] Zwei Statistiken zu Hardcovern ergänzt",
+      "[New] Neue Statistik zu TOP20 Maddrax-Themen ab 42 Baxx",
       "[New] EARDRAX Dashboard mit Übersicht über EARDRAX-Projekt für Vorstand und Rollenverwaltung",
       "[New] Hardcover tauschen in der Romantauschbörse",
       "[New] Hardcover rezensieren",

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -624,6 +624,37 @@
                     window.hardcoverAuthorChartLabels = @json($hardcoverAuthorCounts->keys());
                     window.hardcoverAuthorChartValues = @json($hardcoverAuthorCounts->values());
                 </script>
+            {{-- Card 30 – TOP20 Maddrax-Themen (≥ 42 Baxx) --}}
+                @php($min = 42)
+                <div data-min-points="{{ $min }}" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        TOP20 Maddrax-Themen
+                    </h2>
+
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-left">
+                            <thead>
+                                <tr>
+                                    <th>Rang</th>
+                                    <th>Schlagwort</th>
+                                    <th>Ø&nbsp;Bewertung</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($topThemes as $i => $row)
+                                    <tr>
+                                        <td>{{ $i + 1 }}</td>
+                                        <td>{{ $row['keyword'] }}</td>
+                                        <td>{{ number_format($row['average'], 2, ',', '.') }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    @if($userPoints < $min)
+                        @include('statistik.lock-message', ['min' => $min, 'userPoints' => $userPoints])
+                    @endif
+                </div>
 
                 @vite(['resources/js/statistik.js'])
     </x-member-page>

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -53,6 +53,7 @@ class StatistikTest extends TestCase
                 'bewertung' => 4.0,
                 'stimmen' => 10,
                 'personen' => ['Char1', 'Char2'],
+                'schlagworte' => ['Thema1', 'Thema2'],
             ],
             [
                 'nummer' => 2,
@@ -61,6 +62,7 @@ class StatistikTest extends TestCase
                 'bewertung' => 5.0,
                 'stimmen' => 20,
                 'personen' => ['Char2', 'Char3'],
+                'schlagworte' => ['Thema2', 'Thema3'],
             ],
         ];
         $path = storage_path('app/private/maddrax.json');
@@ -643,5 +645,30 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertSee('Maddrax-Hardcover je Autor:in');
         $response->assertSee('41 Baxx');
+    }
+
+    public function test_top_themes_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(42);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('TOP20 Maddrax-Themen');
+    }
+
+    public function test_top_themes_locked_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(41);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('TOP20 Maddrax-Themen');
+        $response->assertSee('42 Baxx');
     }
 }


### PR DESCRIPTION
This pull request introduces a new statistics feature for displaying the TOP20 Maddrax themes based on user ratings, available to users with at least 42 Baxx points. The implementation includes backend data aggregation, frontend display, changelog updates, and new tests to ensure correct visibility based on user points.

**New Feature: TOP20 Maddrax-Themen Statistics**
- Added logic in `StatistikController.php` to aggregate and calculate the top 20 themes (keywords) from Maddrax novels, sorted by average rating, and made available as `$topThemes` for the view.
- Updated the statistics dashboard view (`statistik/index.blade.php`) to display a new card for the TOP20 Maddrax themes, including ranking, keyword, and average rating, with access gated for users with at least 42 Baxx points.

**Integration and Documentation**
- Passed the new `$topThemes` data to the statistics view for rendering.
- Documented the new feature in `changelog.json` for release notes.

**Testing**
- Enhanced test data in `StatistikTest.php` to include keywords for novels. [[1]](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R56) [[2]](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R65)
- Added tests to verify that the TOP20 Maddrax themes statistic is visible only to users with enough points and properly locked otherwise.