### PR TITLE
Add favorite topics statistic

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Review;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
@@ -135,6 +136,20 @@ class StatistikController extends Controller
             ])
             ->sortByDesc('average')
             ->take(20)
+            ->values();
+
+        // ── Card 31 – TOP10 Lieblingsthemen ────────────────────────────
+        $topFavoriteThemes = User::query()
+            ->whereNotNull('lieblingsthema')
+            ->pluck('lieblingsthema')
+            ->filter()
+            ->countBy()
+            ->sortDesc()
+            ->take(3)
+            ->map(fn ($count, $theme) => [
+                'thema' => $theme,
+                'count' => $count,
+            ])
             ->values();
 
         // ── Card 8 – Bewertungen des Euree-Zyklus ───────────────────────
@@ -431,6 +446,7 @@ class StatistikController extends Controller
             'hardcoverLabels' => $hardcoverLabels,
             'hardcoverValues' => $hardcoverValues,
             'hardcoverAuthorCounts' => $hardcoverAuthorCounts,
+            'topFavoriteThemes' => $topFavoriteThemes,
             'totalReviews' => $totalReviews,
             'averageReviewsPerBook' => $averageReviewsPerBook,
             'topReviewers' => $topReviewers,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -172,6 +172,11 @@ return [
         'points' => 41,
     ],
     [
+        'title' => 'Statistik - TOP10 Lieblingsthemen',
+        'description' => 'Zeigt die beliebtesten Lieblingsthemen der Mitglieder.',
+        'points' => 50,
+    ],
+    [
         'title' => 'Kompendium-Suche',
         'description' => 'Erlaubt die Volltextsuche im Maddrax-Kompendium.',
         'points' => 100,

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -5,6 +5,7 @@
     "notes": [
       "[New] Zwei Statistiken zu Hardcovern ergänzt",
       "[New] Neue Statistik zu TOP20 Maddrax-Themen ab 42 Baxx",
+      "[New] Neue Statistik zu TOP10 Lieblingsthemen ab 50 Baxx",
       "[New] EARDRAX Dashboard mit Übersicht über EARDRAX-Projekt für Vorstand und Rollenverwaltung",
       "[New] Hardcover tauschen in der Romantauschbörse",
       "[New] Hardcover rezensieren",

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -651,6 +651,38 @@
                             </tbody>
                         </table>
                     </div>
+                @if($userPoints < $min)
+                    @include('statistik.lock-message', ['min' => $min, 'userPoints' => $userPoints])
+                @endif
+            </div>
+
+            {{-- Card 31 – TOP10 Lieblingsthemen (≥ 50 Baxx) --}}
+                @php($min = 50)
+                <div data-min-points="{{ $min }}" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        TOP10 Lieblingsthemen
+                    </h2>
+
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-left">
+                            <thead>
+                                <tr>
+                                    <th>Rang</th>
+                                    <th>Thema</th>
+                                    <th>Anzahl</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($topFavoriteThemes as $i => $row)
+                                    <tr>
+                                        <td>{{ $i + 1 }}</td>
+                                        <td>{{ $row['thema'] }}</td>
+                                        <td>{{ $row['count'] }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
                     @if($userPoints < $min)
                         @include('statistik.lock-message', ['min' => $min, 'userPoints' => $userPoints])
                     @endif

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -671,4 +671,36 @@ class StatistikTest extends TestCase
         $response->assertSee('TOP20 Maddrax-Themen');
         $response->assertSee('42 Baxx');
     }
+
+    public function test_favorite_themes_visible_with_enough_points(): void
+    {
+        $this->createDataFile();
+        User::factory()->create(['lieblingsthema' => 'Thema1']);
+        User::factory()->create(['lieblingsthema' => 'Thema1']);
+        User::factory()->create(['lieblingsthema' => 'Thema2']);
+        User::factory()->create(['lieblingsthema' => 'Thema3']);
+        $user = $this->actingMemberWithPoints(50);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('TOP10 Lieblingsthemen');
+        $response->assertSee('Thema1');
+        $response->assertSee('Thema2');
+        $response->assertSee('Thema3');
+    }
+
+    public function test_favorite_themes_locked_below_threshold(): void
+    {
+        $this->createDataFile();
+        $user = $this->actingMemberWithPoints(49);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('TOP10 Lieblingsthemen');
+        $response->assertSee('50 Baxx');
+    }
 }


### PR DESCRIPTION
## Summary
- show top selected themes in user profiles under `TOP10 Lieblingsthemen` card
- document new statistic in changelog and rewards configuration
- cover favorite themes feature with tests

## Testing
- `npm test`
- `php artisan test` *(fails: SQLSTATE[HY000] [1698] Access denied for user 'root'@'localhost')*

------
https://chatgpt.com/codex/tasks/task_e_68b129338d94832eaa1c329a1511e822