### PR TITLE
List TOP20 Maddrax-Themen reward

### DIFF
--- a/config/rewards.php
+++ b/config/rewards.php
@@ -172,6 +172,11 @@ return [
         'points' => 41,
     ],
     [
+        'title' => 'Statistik - TOP20 Maddrax-Themen',
+        'description' => 'Zeigt die 20 am besten bewerteten MADDRAX-Themen im Maddraxikon.',
+        'points' => 42,
+    ],
+    [
         'title' => 'Statistik - TOP10 Lieblingsthemen',
         'description' => 'Zeigt die beliebtesten Lieblingsthemen der Mitglieder.',
         'points' => 50,

--- a/tests/Feature/RewardControllerTest.php
+++ b/tests/Feature/RewardControllerTest.php
@@ -83,4 +83,15 @@ class RewardControllerTest extends TestCase
         $response->assertOk();
         $response->assertSee('Statistik - Maddrax-Hardcover je Autor:in');
     }
+
+    public function test_top20_themes_reward_visible(): void
+    {
+        $user = $this->actingMember(42);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $response->assertSee('Statistik - TOP20 Maddrax-Themen');
+    }
 }


### PR DESCRIPTION
This pull request introduces a new reward for the "TOP20 Maddrax-Themen" statistic and ensures its visibility in the rewards feature test. The main changes add the new reward to the configuration and verify its display in the application.

Reward configuration update:
* Added a new entry for "Statistik - TOP20 Maddrax-Themen" to the rewards list in `config/rewards.php`, including its description and points value.

Feature test addition:
* Added a new test method `test_top20_themes_reward_visible` in `RewardControllerTest.php` to verify that the new reward is visible to users.