### PR TITLE
Filter TOP20 themes by novels with at least eight votes

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -124,6 +124,7 @@ class StatistikController extends Controller
 
         // ── Card 30 – TOP20 Maddrax-Themen ─────────────────────────────
         $topThemes = $romane
+            ->filter(fn ($r) => ($r['stimmen'] ?? 0) >= 8)
             ->flatMap(fn ($r) => collect($r['schlagworte'] ?? [])->map(fn ($s) => [
                 'keyword' => trim($s),
                 'rating' => $r['bewertung'],

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -173,7 +173,7 @@ return [
     ],
     [
         'title' => 'Statistik - TOP20 Maddrax-Themen',
-        'description' => 'Zeigt die 20 am besten bewerteten MADDRAX-Themen im Maddraxikon.',
+        'description' => 'Zeigt die 20 am besten bewerteten MADDRAX-Themen im Maddraxikon. Berücksichtigt nur Romane mit mindestens 8 Bewertungen.',
         'points' => 42,
     ],
     [

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -624,7 +624,7 @@
                     window.hardcoverAuthorChartLabels = @json($hardcoverAuthorCounts->keys());
                     window.hardcoverAuthorChartValues = @json($hardcoverAuthorCounts->values());
                 </script>
-            {{-- Card 30 – TOP20 Maddrax-Themen (≥ 42 Baxx) --}}
+            {{-- Card 30 – TOP20 Maddrax-Themen (≥ 42 Baxx, nur Romane mit ≥ 8 Bewertungen) --}}
                 @php($min = 42)
                 <div data-min-points="{{ $min }}" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -672,6 +672,32 @@ class StatistikTest extends TestCase
         $response->assertSee('42 Baxx');
     }
 
+    public function test_top_themes_ignore_books_with_few_votes(): void
+    {
+        $this->createDataFile();
+        $path = storage_path('app/private/maddrax.json');
+        $data = json_decode(file_get_contents($path), true);
+        $data[] = [
+            'nummer' => 3,
+            'titel' => 'Roman3',
+            'text' => ['Author3'],
+            'bewertung' => 4.5,
+            'stimmen' => 7,
+            'personen' => [],
+            'schlagworte' => ['LowVotesTheme'],
+        ];
+        file_put_contents($path, json_encode($data));
+
+        $user = $this->actingMemberWithPoints(42);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('TOP20 Maddrax-Themen');
+        $response->assertDontSee('LowVotesTheme');
+    }
+
     public function test_favorite_themes_visible_with_enough_points(): void
     {
         $this->createDataFile();


### PR DESCRIPTION
This pull request updates the logic and documentation for the "TOP20 Maddrax-Themen" statistics card to ensure only novels with at least 8 ratings are considered. It also adds a test to verify that themes from books with fewer than 8 votes are excluded. The most important changes are grouped below:

**Feature Logic Update**

* The filtering for the TOP20 Maddrax-Themen now excludes novels with fewer than 8 ratings in the `StatistikController` (`app/Http/Controllers/StatistikController.php`).

**Documentation and UI**

* The description for the reward in `config/rewards.php` is updated to clarify that only novels with at least 8 ratings are considered.
* The UI card label in `resources/views/statistik/index.blade.php` is updated to mention the new minimum ratings requirement.

**Testing**

* A new test is added to `StatistikTest.php` to ensure that themes from books with fewer than 8 votes are not shown in the TOP20 Maddrax-Themen statistics.