### PR TITLE
Filter Maddrax themes by minimum novel count

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -131,6 +131,7 @@ class StatistikController extends Controller
             ]))
             ->filter(fn ($row) => $row['keyword'] !== '')
             ->groupBy('keyword')
+            ->filter(fn ($rows) => $rows->count() >= 5)
             ->map(fn ($rows, $keyword) => [
                 'keyword' => $keyword,
                 'average' => round(collect($rows)->avg('rating'), 2),

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -624,7 +624,7 @@
                     window.hardcoverAuthorChartLabels = @json($hardcoverAuthorCounts->keys());
                     window.hardcoverAuthorChartValues = @json($hardcoverAuthorCounts->values());
                 </script>
-            {{-- Card 30 – TOP20 Maddrax-Themen (≥ 42 Baxx, nur Romane mit ≥ 8 Bewertungen) --}}
+            {{-- Card 30 – TOP20 Maddrax-Themen (≥ 42 Baxx, nur Romane mit ≥ 8 Bewertungen, Themen in ≥ 5 Romanen) --}}
                 @php($min = 42)
                 <div data-min-points="{{ $min }}" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -698,6 +698,35 @@ class StatistikTest extends TestCase
         $response->assertDontSee('LowVotesTheme');
     }
 
+    public function test_top_themes_require_minimum_book_count(): void
+    {
+        $this->createDataFile();
+        $path = storage_path('app/private/maddrax.json');
+        $data = json_decode(file_get_contents($path), true);
+        for ($i = 3; $i <= 7; $i++) {
+            $data[] = [
+                'nummer' => $i,
+                'titel' => 'Roman'.$i,
+                'text' => ['Author'.$i],
+                'bewertung' => 4.5,
+                'stimmen' => 10,
+                'personen' => [],
+                'schlagworte' => ['PopularTheme'],
+            ];
+        }
+        file_put_contents($path, json_encode($data));
+
+        $user = $this->actingMemberWithPoints(42);
+        $this->actingAs($user);
+
+        $response = $this->get('/statistik');
+
+        $response->assertOk();
+        $response->assertSee('TOP20 Maddrax-Themen');
+        $response->assertSee('PopularTheme');
+        $response->assertDontSee('Thema1');
+    }
+
     public function test_favorite_themes_visible_with_enough_points(): void
     {
         $this->createDataFile();


### PR DESCRIPTION
This pull request introduces a new requirement for the "TOP20 Maddrax-Themen" statistics: a theme must appear in at least five different novels to be included. The changes update both the backend filtering logic and the frontend description, and add a corresponding feature test to ensure the new rule is enforced.

**Backend logic update:**
* The `StatistikController.php` now filters grouped themes so only those appearing in five or more novels are considered for the TOP20 list.

**Frontend display update:**
* The description for Card 30 in `index.blade.php` is updated to mention the new requirement: "Themen in ≥ 5 Romanen".

**Testing:**
* A new feature test `test_top_themes_require_minimum_book_count` is added to `StatistikTest.php` to verify that only themes present in at least five novels are shown in the TOP20 list.