### PR TITLE
Link RPG Char Editor from Admin menu

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -65,7 +65,6 @@
                             </button>
                             <div id="vorstand-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="vorstand-button">
                                 <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
-                                <x-dropdown-link href="{{ route('rpg.char-editor') }}">Charakter-Editor</x-dropdown-link>
                             </div>
                         </div>
                         @endvorstand
@@ -80,6 +79,7 @@
                             <div id="admin-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="admin-button">
                                 <x-dropdown-link href="{{ route('admin.index') }}">Admin</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-dropdown-link>
+                                <x-dropdown-link href="{{ route('rpg.char-editor') }}">Charakter-Editor</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('arbeitsgruppen.index') }}">Arbeitsgruppen</x-dropdown-link>
                             </div>
                         </div>
@@ -178,7 +178,6 @@
             Vorstand</button>
             <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic" aria-labelledby="vorstand-mobile-button">
                 <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
-                <x-responsive-nav-link href="{{ route('rpg.char-editor') }}">Charakter-Editor</x-responsive-nav-link>
             </div>
             @endvorstand
             @if(!Auth::user()->hasRole('Admin') && Auth::user()->ownedTeams()->where('personal_team', false)->exists())
@@ -190,6 +189,7 @@
             <div id="admin-mobile-menu" x-show="openMenu === 'admin'" x-cloak class="italic" aria-labelledby="admin-mobile-button">
                 <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-responsive-nav-link>
+                <x-responsive-nav-link href="{{ route('rpg.char-editor') }}">Charakter-Editor</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('arbeitsgruppen.index') }}">Arbeitsgruppen</x-responsive-nav-link>
             </div>
             @endif

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -65,6 +65,7 @@
                             </button>
                             <div id="vorstand-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="vorstand-button">
                                 <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
+                                <x-dropdown-link href="{{ route('rpg.char-editor') }}">Charakter-Editor</x-dropdown-link>
                             </div>
                         </div>
                         @endvorstand
@@ -177,6 +178,7 @@
             Vorstand</button>
             <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic" aria-labelledby="vorstand-mobile-button">
                 <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
+                <x-responsive-nav-link href="{{ route('rpg.char-editor') }}">Charakter-Editor</x-responsive-nav-link>
             </div>
             @endvorstand
             @if(!Auth::user()->hasRole('Admin') && Auth::user()->ownedTeams()->where('personal_team', false)->exists())


### PR DESCRIPTION
This pull request adds a new "Charakter-Editor" (Character Editor) link to both the desktop and mobile versions of the admin navigation menu. This change ensures that users can easily access the character editor feature from the admin menu in both viewports.

Navigation menu updates:

* Added a `Charakter-Editor` link to the admin dropdown menu in `navigation-menu.blade.php`, making the character editor accessible from the desktop navigation.
* Added a `Charakter-Editor` link to the admin mobile menu in `navigation-menu.blade.php`, ensuring mobile users can also access the character editor.