### PR TITLE
Run Node tasks only for PHP 8.3 in unit test workflow

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -52,6 +52,7 @@ jobs:
         tools: composer:v2
 
     - name: Setup Node.js
+      if: matrix.php-version == '8.3'
       uses: actions/setup-node@v4
       with:
         node-version: '20'
@@ -72,9 +73,11 @@ jobs:
       run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
 
     - name: Install NPM dependencies
+      if: matrix.php-version == '8.3'
       run: npm ci
 
     - name: Build assets
+      if: matrix.php-version == '8.3'
       run: npm run build
 
     - name: Copy .env
@@ -98,6 +101,7 @@ jobs:
       run: php artisan test tests/Feature --coverage-clover=coverage.xml
 
     - name: Run Jest tests with coverage
+      if: matrix.php-version == '8.3'
       run: npm test -- --coverage --coverageReporters=json-summary --coverageDirectory=coverage
 
     - name: Create JS coverage badge


### PR DESCRIPTION
This pull request updates the unit test workflow configuration to ensure that Node.js and related frontend build and test steps are only executed for PHP version 8.3. This change helps streamline the CI process by skipping unnecessary frontend steps for other PHP versions.

Conditional execution for PHP 8.3:

* Added `if: matrix.php-version == '8.3'` to the Node.js setup step, so Node.js is only installed when testing against PHP 8.3. (`.github/workflows/unittests.yml`)
* Added the same conditional to the NPM dependencies installation and asset build steps, restricting them to PHP 8.3 runs. (`.github/workflows/unittests.yml`)
* Restricted the Jest test and coverage step to only run for PHP 8.3, preventing unnecessary frontend test runs for other PHP versions. (`.github/workflows/unittests.yml`)