### PR TITLE
Add primary button Blade component

### DIFF
--- a/resources/views/components/primary-button.blade.php
+++ b/resources/views/components/primary-button.blade.php
@@ -1,0 +1,3 @@
+<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-indigo-600 dark:bg-indigo-500 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-500 dark:hover:bg-indigo-400 focus:bg-indigo-500 dark:focus:bg-indigo-400 active:bg-indigo-700 dark:active:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 transition ease-in-out duration-150']) }}>
+    {{ $slot }}
+</button>


### PR DESCRIPTION
This pull request introduces a new Blade component for a primary button. The change adds a reusable button template that applies consistent styling and behavior for primary actions across the application.

UI component addition:

* Added a new `primary-button` Blade component in `resources/views/components/primary-button.blade.php` with standardized classes for styling, accessibility, and interaction states.