### PR TITLE
Import Mission Mars novels

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Die im Footer angezeigte Versionsnummer wird automatisch aus dem neuesten Git-Ta
 | Application Cache leeren | `php artisan cache:clear` |
 | Romane indexieren | `php artisan romane:index` |
 | Romane komplett neu indexieren | `php artisan romane:index --fresh` |
-| Romane & Hardcover importieren | `php artisan books:import` |
+| Romane, Hardcover & Mission Mars-Heftromane importieren | `php artisan books:import` |
 | Rezensionen importieren | `php artisan reviews:import-old --fresh` |
 | Neue Romane & Hardcover crawlen | `php artisan crawlnovels` |
 | Sitemap generieren | `php artisan sitemap:generate` |

--- a/app/Console/Commands/ImportMaddraxBooks.php
+++ b/app/Console/Commands/ImportMaddraxBooks.php
@@ -13,14 +13,14 @@ class ImportMaddraxBooks extends Command
      *
      * @var string
      */
-    protected $signature = 'books:import {--path=private/maddrax.json : Path to novels JSON file relative to storage/app} {--hardcovers-path=private/hardcovers.json : Path to hardcovers JSON file relative to storage/app}';
+    protected $signature = 'books:import {--path=private/maddrax.json : Path to novels JSON file relative to storage/app} {--hardcovers-path=private/hardcovers.json : Path to hardcovers JSON file relative to storage/app} {--missionmars-path=private/missionmars.json : Path to Mission Mars novels JSON file relative to storage/app}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Import books from maddrax.json and hardcovers.json into the books table';
+    protected $description = 'Import books from maddrax.json, hardcovers.json and missionmars.json into the books table';
 
     /**
      * Execute the console command.
@@ -29,11 +29,13 @@ class ImportMaddraxBooks extends Command
     {
         $novelsPath = $this->option('path');
         $hardcoversPath = $this->option('hardcovers-path');
+        $missionMarsPath = $this->option('missionmars-path');
 
         $novelsResult = $this->importFile($novelsPath, BookType::MaddraxDieDunkleZukunftDerErde);
         $hardcoversResult = $this->importFile($hardcoversPath, BookType::MaddraxHardcover);
+        $missionMarsResult = $this->importFile($missionMarsPath, BookType::MissionMars);
 
-        return ($novelsResult || $hardcoversResult) ? 0 : 1;
+        return ($novelsResult || $hardcoversResult || $missionMarsResult) ? 0 : 1;
     }
 
     private function importFile(string $path, BookType $type): bool

--- a/app/Enums/BookType.php
+++ b/app/Enums/BookType.php
@@ -6,7 +6,7 @@ enum BookType: string
 {
     case MaddraxDieDunkleZukunftDerErde = 'Maddrax - Die dunkle Zukunft der Erde';
     case MaddraxHardcover = 'Maddrax-Hardcover';
-    case MissionMars = 'Mission Mars';
+    case MissionMars = 'Mission Mars-Heftromane';
     case DasVolkDerTiefe = 'Das Volk der Tiefe';
     case ZweiTausendZwölfDasJahrDerApokalypse = '2012 - Das Jahr der Apokalypse';
     case DieAbenteurer = 'Die Abenteurer';


### PR DESCRIPTION
This pull request extends the book import functionality to support a new category: Mission Mars-Heftromane. The command now imports Mission Mars novels alongside Maddrax novels and hardcovers, with corresponding updates to documentation, command signature, enum values, and test coverage.

**Feature extension: Mission Mars-Heftromane import**
* Updated the `books:import` command to accept a new `--missionmars-path` option for importing Mission Mars novels from a JSON file, and adjusted the command description accordingly. (`app/Console/Commands/ImportMaddraxBooks.php`)
* Modified the import logic to process Mission Mars data and return a successful exit code if any category imports successfully. (`app/Console/Commands/ImportMaddraxBooks.php`)

**Documentation update**
* Updated the `README.md` to reflect the new capability of importing Mission Mars-Heftromane with the `books:import` command. (`README.md`)

**Enum update**
* Changed the `BookType::MissionMars` value to `'Mission Mars-Heftromane'` for consistency with the new import category. (`app/Enums/BookType.php`)

**Test coverage**
* Extended feature tests to cover Mission Mars import scenarios, including success, missing files, invalid JSON, and invalid entries, ensuring the database contains only valid records and the count reflects the new category. (`tests/Feature/ImportMaddraxBooksCommandTest.php`) [[1]](diffhunk://#diff-28069f8eea0acca3b85e2c47ec65766abec2608f91b53a3b27f6d8b11cd6a008R37-R55) [[2]](diffhunk://#diff-28069f8eea0acca3b85e2c47ec65766abec2608f91b53a3b27f6d8b11cd6a008R78-R87) [[3]](diffhunk://#diff-28069f8eea0acca3b85e2c47ec65766abec2608f91b53a3b27f6d8b11cd6a008R108-R118)