### PR TITLE
Update book type enum to include Mission Mars

### DIFF
--- a/database/migrations/2025_10_01_000000_update_book_type_enum.php
+++ b/database/migrations/2025_10_01_000000_update_book_type_enum.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Enums\BookType;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $values = array_map(fn ($case) => "'{$case->value}'", BookType::cases());
+        $valuesString = implode(',', $values);
+        DB::statement("ALTER TABLE books MODIFY COLUMN type ENUM($valuesString) NOT NULL DEFAULT '".BookType::MaddraxDieDunkleZukunftDerErde->value."'");
+    }
+
+    public function down(): void
+    {
+        $values = array_filter(BookType::cases(), fn ($case) => $case !== BookType::MissionMars);
+        $values = array_map(fn ($case) => "'{$case->value}'", $values);
+        $valuesString = implode(',', $values);
+        DB::statement("ALTER TABLE books MODIFY COLUMN type ENUM($valuesString) NOT NULL DEFAULT '".BookType::MaddraxDieDunkleZukunftDerErde->value."'");
+    }
+};

--- a/tests/Feature/ImportMaddraxBooksCommandTest.php
+++ b/tests/Feature/ImportMaddraxBooksCommandTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-use App\Models\Book;
-use Illuminate\Support\Facades\File;
 use App\Enums\BookType;
+use App\Models\Book;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
 
 class ImportMaddraxBooksCommandTest extends TestCase
 {
@@ -20,8 +20,8 @@ class ImportMaddraxBooksCommandTest extends TestCase
 
         $this->testStoragePath = base_path('storage/testing');
         $this->app->useStoragePath($this->testStoragePath);
-        File::ensureDirectoryExists($this->testStoragePath . '/app/private');
-        File::ensureDirectoryExists($this->testStoragePath . '/framework/views');
+        File::ensureDirectoryExists($this->testStoragePath.'/app/private');
+        File::ensureDirectoryExists($this->testStoragePath.'/framework/views');
     }
 
     protected function tearDown(): void
@@ -37,9 +37,9 @@ class ImportMaddraxBooksCommandTest extends TestCase
         File::put(storage_path('app/private/missionmars.json'), '[]');
 
         $this->artisan('books:import', ['--path' => 'private/missing.json'])
-            ->expectsOutput('Import for ' . BookType::MaddraxDieDunkleZukunftDerErde->value . ' failed: JSON file not found at ' . storage_path('app/private/missing.json'))
-            ->expectsOutput(PHP_EOL . 'Import for ' . BookType::MaddraxHardcover->value . ' completed successfully.')
-            ->expectsOutput(PHP_EOL . 'Import for ' . BookType::MissionMars->value . ' completed successfully.')
+            ->expectsOutput('Import for '.BookType::MaddraxDieDunkleZukunftDerErde->value.' failed: JSON file not found at '.storage_path('app/private/missing.json'))
+            ->expectsOutput(PHP_EOL.'Import for '.BookType::MaddraxHardcover->value.' completed successfully.')
+            ->expectsOutput(PHP_EOL.'Import for '.BookType::MissionMars->value.' completed successfully.')
             ->assertExitCode(0);
     }
 
@@ -50,9 +50,9 @@ class ImportMaddraxBooksCommandTest extends TestCase
         File::put(storage_path('app/private/missionmars.json'), '[]');
 
         $this->artisan('books:import', ['--path' => 'private/maddrax.json'])
-            ->expectsOutput('Import for ' . BookType::MaddraxDieDunkleZukunftDerErde->value . ' failed: Invalid JSON - Syntax error')
-            ->expectsOutput(PHP_EOL . 'Import for ' . BookType::MaddraxHardcover->value . ' completed successfully.')
-            ->expectsOutput(PHP_EOL . 'Import for ' . BookType::MissionMars->value . ' completed successfully.')
+            ->expectsOutput('Import for '.BookType::MaddraxDieDunkleZukunftDerErde->value.' failed: Invalid JSON - Syntax error')
+            ->expectsOutput(PHP_EOL.'Import for '.BookType::MaddraxHardcover->value.' completed successfully.')
+            ->expectsOutput(PHP_EOL.'Import for '.BookType::MissionMars->value.' completed successfully.')
             ->assertExitCode(0);
     }
 
@@ -82,9 +82,9 @@ class ImportMaddraxBooksCommandTest extends TestCase
         File::put(storage_path('app/private/missionmars.json'), json_encode($missionMars));
 
         $this->artisan('books:import', ['--path' => 'private/maddrax.json'])
-            ->expectsOutput(PHP_EOL . 'Import for ' . BookType::MaddraxDieDunkleZukunftDerErde->value . ' completed successfully.')
-            ->expectsOutput(PHP_EOL . 'Import for ' . BookType::MaddraxHardcover->value . ' completed successfully.')
-            ->expectsOutput(PHP_EOL . 'Import for ' . BookType::MissionMars->value . ' completed successfully.')
+            ->expectsOutput(PHP_EOL.'Import for '.BookType::MaddraxDieDunkleZukunftDerErde->value.' completed successfully.')
+            ->expectsOutput(PHP_EOL.'Import for '.BookType::MaddraxHardcover->value.' completed successfully.')
+            ->expectsOutput(PHP_EOL.'Import for '.BookType::MissionMars->value.' completed successfully.')
             ->assertExitCode(0);
 
         $this->assertDatabaseHas('books', [
@@ -124,6 +124,7 @@ class ImportMaddraxBooksCommandTest extends TestCase
             '--path' => [
                 'database/migrations/2025_05_18_065853_create_books_table.php',
                 'database/migrations/2025_09_19_000000_add_type_to_books_table.php',
+                'database/migrations/2025_10_01_000000_update_book_type_enum.php',
             ],
         ];
     }


### PR DESCRIPTION
This pull request updates the database schema and related tests to support changes in the `BookType` enum for the `books` table. The main change is a migration that modifies the `type` column to reflect the latest enum values, ensuring the database stays in sync with the application logic.

**Database migration updates:**

* Added a new migration (`database/migrations/2025_10_01_000000_update_book_type_enum.php`) to update the `type` column in the `books` table. The migration dynamically sets the ENUM values based on the current cases in the `BookType` enum, and specifies the default value. The `down` method reverts the change by removing the `MissionMars` type from the ENUM.

**Test suite adjustments:**

* Included the new migration in the test setup by adding its path to the `migrateFreshUsing` method in `ImportMaddraxBooksCommandTest.php`, ensuring tests run against the updated schema.
* Minor reordering of imports in `ImportMaddraxBooksCommandTest.php` for improved clarity and consistency.