### PR TITLE
Add Mission Mars series option for book swaps

### DIFF
--- a/app/Http/Controllers/RomantauschController.php
+++ b/app/Http/Controllers/RomantauschController.php
@@ -21,6 +21,7 @@ class RomantauschController extends Controller
     private const ALLOWED_TYPES = [
         BookType::MaddraxDieDunkleZukunftDerErde,
         BookType::MaddraxHardcover,
+        BookType::MissionMars,
     ];
     // Übersicht
     public function index()

--- a/tests/Feature/RomantauschControllerTest.php
+++ b/tests/Feature/RomantauschControllerTest.php
@@ -31,6 +31,12 @@ class RomantauschControllerTest extends TestCase
             'author' => 'Author',
             'type' => BookType::MaddraxDieDunkleZukunftDerErde,
         ]);
+        Book::create([
+            'roman_number' => 2,
+            'title' => 'MM Roman',
+            'author' => 'Author',
+            'type' => BookType::MissionMars,
+        ]);
     }
 
     public function test_complete_swap_marks_entries_completed(): void
@@ -96,6 +102,29 @@ class RomantauschControllerTest extends TestCase
             'series' => BookType::MaddraxDieDunkleZukunftDerErde->value,
             'book_number' => 1,
             'book_title' => 'Roman1',
+            'condition' => 'neu',
+        ]);
+    }
+
+    public function test_store_offer_creates_entry_for_mission_mars(): void
+    {
+        $this->putBookData();
+
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $response = $this->post('/romantauschboerse/angebot-speichern', [
+            'series' => BookType::MissionMars->value,
+            'book_number' => 2,
+            'condition' => 'neu',
+        ]);
+
+        $response->assertRedirect(route('romantausch.index', [], false));
+        $this->assertDatabaseHas('book_offers', [
+            'user_id' => $user->id,
+            'series' => BookType::MissionMars->value,
+            'book_number' => 2,
+            'book_title' => 'MM Roman',
             'condition' => 'neu',
         ]);
     }
@@ -218,6 +247,29 @@ class RomantauschControllerTest extends TestCase
             'series' => BookType::MaddraxDieDunkleZukunftDerErde->value,
             'book_number' => 1,
             'book_title' => 'Roman1',
+            'condition' => 'neu',
+        ]);
+    }
+
+    public function test_store_request_creates_entry_for_mission_mars(): void
+    {
+        $this->putBookData();
+
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $response = $this->post('/romantauschboerse/anfrage-speichern', [
+            'series' => BookType::MissionMars->value,
+            'book_number' => 2,
+            'condition' => 'neu',
+        ]);
+
+        $response->assertRedirect(route('romantausch.index', [], false));
+        $this->assertDatabaseHas('book_requests', [
+            'user_id' => $user->id,
+            'series' => BookType::MissionMars->value,
+            'book_number' => 2,
+            'book_title' => 'MM Roman',
             'condition' => 'neu',
         ]);
     }


### PR DESCRIPTION
## Summary
- allow trading of "Mission Mars-Heftromane" in book swap
- cover Mission Mars series in controller tests

## Testing
- `npm test` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: see log for unresolved errors)*
- `./vendor/bin/pint --test` *(fails: code style violations)*

------
https://chatgpt.com/codex/tasks/task_e_68ba58a65b1c832e8cfbe9ec620da760