### PR TITLE
Use placeholders for race and culture selection

### DIFF
--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -20,6 +20,7 @@
                     <div>
                         <label for="race" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Rasse</label>
                         <select name="race" id="race" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                            <option value="" disabled selected>Rasse wählen</option>
                             <option value="Barbar">Barbar</option>
                         </select>
                     </div>
@@ -27,6 +28,7 @@
                     <div>
                         <label for="culture" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Kultur</label>
                         <select name="culture" id="culture" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                            <option value="" disabled selected>Kultur wählen</option>
                             <option value="Landbewohner">Landbewohner</option>
                         </select>
                     </div>


### PR DESCRIPTION
This pull request introduces a minor usability improvement to the character editor form. Specifically, it adds placeholder options to the "race" and "culture" dropdown menus to prompt users to make a selection.

Form usability enhancements:

* Added a disabled and selected placeholder option ("Rasse wählen" and "Kultur wählen") at the top of the `race` and `culture` `<select>` elements in `char-editor.blade.php` to guide users to choose an option.