### PR TITLE
Add leader-only AG management page

### DIFF
--- a/app/Http/Controllers/ArbeitsgruppenController.php
+++ b/app/Http/Controllers/ArbeitsgruppenController.php
@@ -34,6 +34,28 @@ class ArbeitsgruppenController extends Controller
     }
 
     /**
+     * Display a listing of the AGs for leaders only.
+     */
+    public function leaderIndex(Request $request)
+    {
+        $user = $request->user();
+
+        $ags = Team::where('personal_team', false)
+            ->where('name', '!=', 'Mitglieder')
+            ->where('user_id', $user->id)
+            ->orderBy('name')
+            ->get();
+
+        if ($ags->isEmpty()) {
+            abort(403);
+        }
+
+        return view('arbeitsgruppen.index', [
+            'ags' => $ags,
+        ]);
+    }
+
+    /**
      * Display a listing of the AGs for the public page.
      */
     public function publicIndex()

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -68,8 +68,15 @@
                             </div>
                         </div>
                         @endvorstand
-                        @if(!Auth::user()->hasRole('Admin') && Auth::user()->ownedTeams()->where('personal_team', false)->exists())
-                            <x-nav-link href="{{ route('arbeitsgruppen.index') }}">Arbeitsgruppen</x-nav-link>
+                        @if(Auth::user()->ownedTeams()->where('personal_team', false)->exists())
+                        <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
+                            <button id="ag-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="ag-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                                AG
+                            </button>
+                            <div id="ag-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
+                                <x-dropdown-link href="{{ route('ag.index') }}">AG verwalten</x-dropdown-link>
+                            </div>
+                        </div>
                         @endif
                         @if(Auth::user()->hasRole('Admin'))
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
@@ -181,8 +188,12 @@
                 <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
             </div>
             @endvorstand
-            @if(!Auth::user()->hasRole('Admin') && Auth::user()->ownedTeams()->where('personal_team', false)->exists())
-                <x-responsive-nav-link href="{{ route('arbeitsgruppen.index') }}">Arbeitsgruppen</x-responsive-nav-link>
+            @if(Auth::user()->ownedTeams()->where('personal_team', false)->exists())
+            <button id="ag-mobile-button" type="button" @click="openMenu = (openMenu === 'ag' ? null : 'ag')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'ag' }" :aria-expanded="openMenu === 'ag'" aria-controls="ag-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'ag' ? null : 'ag')" @keydown.space.prevent="openMenu = (openMenu === 'ag' ? null : 'ag')">
+            AG</button>
+            <div id="ag-mobile-menu" x-show="openMenu === 'ag'" x-cloak class="italic">
+                <x-responsive-nav-link href="{{ route('ag.index') }}">AG verwalten</x-responsive-nav-link>
+            </div>
             @endif
             @if(Auth::user()->hasRole('Admin'))
             <button id="admin-mobile-button" type="button" @click="openMenu = (openMenu === 'admin' ? null : 'admin')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'admin' }" :aria-expanded="openMenu === 'admin'" aria-controls="admin-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')" @keydown.space.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')">

--- a/routes/web.php
+++ b/routes/web.php
@@ -134,6 +134,8 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::put('{team}', 'update')->name('update');
     });
 
+    Route::get('/ag', [ArbeitsgruppenController::class, 'leaderIndex'])->name('ag.index');
+
     Route::get('/belohnungen', [RewardController::class, 'index'])->name('rewards.index');
 
     Route::prefix('treffen')->controller(MeetingController::class)->group(function () {

--- a/tests/Feature/ArbeitsgruppenControllerTest.php
+++ b/tests/Feature/ArbeitsgruppenControllerTest.php
@@ -91,4 +91,39 @@ class ArbeitsgruppenControllerTest extends TestCase
             'user_id' => $admin->id,
         ]);
     }
+
+    public function test_ag_leader_can_access_ag_page(): void
+    {
+        $leader = $this->createMemberWithRole();
+        $ag = Team::factory()->create([
+            'user_id' => $leader->id,
+            'personal_team' => false,
+            'name' => 'Meine AG',
+        ]);
+        $ag->users()->attach($leader, ['role' => 'Mitglied']);
+
+        $this->actingAs($leader);
+
+        $this->get(route('ag.index'))
+            ->assertOk()
+            ->assertSee('Meine AG');
+    }
+
+    public function test_non_leader_cannot_access_ag_page(): void
+    {
+        $member = $this->createMemberWithRole();
+
+        $this->actingAs($member);
+
+        $this->get(route('ag.index'))->assertForbidden();
+    }
+
+    public function test_admin_not_leader_cannot_access_ag_page(): void
+    {
+        $admin = $this->createMemberWithRole('Admin');
+
+        $this->actingAs($admin);
+
+        $this->get(route('ag.index'))->assertForbidden();
+    }
 }


### PR DESCRIPTION
This pull request introduces a new "AG verwalten" (manage working groups) page specifically for AG leaders, updates the navigation to provide access to this page, and adds tests to ensure the correct authorization logic. The main changes are the addition of a new controller action, route, navigation updates for both desktop and mobile, and feature tests for access control.

**New AG Leader Management Page:**

* Added a new `leaderIndex` method to `ArbeitsgruppenController`, which lists AGs managed by the current user and restricts access to AG leaders only.
* Registered a new route `/ag` pointing to the `leaderIndex` method, named `ag.index`.

**Navigation Updates:**

* Updated `navigation-menu.blade.php` to add an "AG verwalten" dropdown/menu for users who own at least one non-personal AG, accessible from both desktop and mobile navigation. The old "Arbeitsgruppen" link is replaced for non-admins. [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL71-R79) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL184-R196)

**Testing and Authorization:**

* Added feature tests to ensure only AG leaders can access the new AG management page, and that non-leaders and admins without AG ownership are forbidden.