### PR TITLE
Expand Barbar and Landbewohner descriptions in character editor

### DIFF
--- a/resources/js/char-editor.js
+++ b/resources/js/char-editor.js
@@ -50,8 +50,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const skillsDatalist = document.getElementById('skills-list');
 
     const raceDescriptions = {
-        Barbar: 'Barbaren sind wilde Krieger.'
+        Barbar: 'Im 26. Jahrhundert besteht die Zivilisation zum größten Teil aus Barbaren. Sie leben in unterschiedlichen Kulturen, beispielsweise als Seefahrer (die Disuuslachter), Nomaden (die Wandernden Völker) oder Ruinenbewohner (die Loords von Landán). Die zeichnen sich durch Zähigkeit, Wildheit und Kampflust aus, sind zumeist primitiv und leben in Clans. Ehre und Mut werden hoch geschätzt. Technologisch bewegen sich die meisten Barbaren zwischen der späten Steinzeit und dem frühen Mittelalter.'
     };
+
+    const cultureDescriptions = {
+        Landbewohner: 'Landbewohner bewirtschaften den Boden und versuchen als Bauern und Viehzüchter ihren Lebensunterhalt zu verdienen. Die meisten sind einfache Menschen, die Ruhe und Frieden suchen, nicht viel von der Welt wissen und einfache Landgötter anbeten. Aberglauben ist weit verbreitet.'
+    };
+
+    if (descriptionField) {
+        descriptionField.addEventListener('input', () => {
+            descriptionField.dataset.userEdited = 'true';
+        });
+    }
 
     // initialise counters
     updateAPCounter(state.base.AP);
@@ -473,8 +483,12 @@ document.addEventListener('DOMContentLoaded', () => {
     function handleRaceChange() {
         clearRace();
         if (raceSelect.value === 'Barbar') applyRaceBarbar();
-        if (descriptionField && raceDescriptions[raceSelect.value] && !descriptionField.value.trim()) {
-            descriptionField.value = raceDescriptions[raceSelect.value];
+        if (descriptionField && descriptionField.dataset.userEdited !== 'true') {
+            let text = raceDescriptions[raceSelect.value] || '';
+            if (cultureDescriptions[cultureSelect.value]) {
+                text += (text ? '\n\n' : '') + cultureDescriptions[cultureSelect.value];
+            }
+            descriptionField.value = text;
         }
         updateContinueVisibility();
         recomputeAll();
@@ -522,6 +536,13 @@ document.addEventListener('DOMContentLoaded', () => {
     function handleCultureChange() {
         clearCulture();
         if (cultureSelect.value === 'Landbewohner') applyCultureLandbewohner();
+        if (descriptionField && descriptionField.dataset.userEdited !== 'true') {
+            let text = raceDescriptions[raceSelect.value] || '';
+            if (cultureDescriptions[cultureSelect.value]) {
+                text += (text ? '\n\n' : '') + cultureDescriptions[cultureSelect.value];
+            }
+            descriptionField.value = text;
+        }
         updateContinueVisibility();
         recomputeAll();
     }

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -24,7 +24,7 @@
                         <label for="race" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Rasse</label>
                         <select name="race" id="race" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                             <option value="" disabled selected>Rasse wählen</option>
-                            <option value="Barbar">Barbar</option>
+                            <option value="Barbar" title="Im 26. Jahrhundert besteht die Zivilisation zum größten Teil aus Barbaren. Sie leben in unterschiedlichen Kulturen, beispielsweise als Seefahrer (die Disuuslachter), Nomaden (die Wandernden Völker) oder Ruinenbewohner (die Loords von Landán). Die zeichnen sich durch Zähigkeit, Wildheit und Kampflust aus, sind zumeist primitiv und leben in Clans. Ehre und Mut werden hoch geschätzt. Technologisch bewegen sich die meisten Barbaren zwischen der späten Steinzeit und dem frühen Mittelalter.">Barbar</option>
                         </select>
                     </div>
 
@@ -32,7 +32,7 @@
                         <label for="culture" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Kultur</label>
                         <select name="culture" id="culture" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                             <option value="" disabled selected>Kultur wählen</option>
-                            <option value="Landbewohner">Landbewohner</option>
+                            <option value="Landbewohner" title="Landbewohner bewirtschaften den Boden und versuchen als Bauern und Viehzüchter ihren Lebensunterhalt zu verdienen. Die meisten sind einfache Menschen, die Ruhe und Frieden suchen, nicht viel von der Welt wissen und einfache Landgötter anbeten. Aberglauben ist weit verbreitet.">Landbewohner</option>
                         </select>
                     </div>
 


### PR DESCRIPTION
This pull request enhances the character editor by providing more detailed descriptions for races and cultures, and improves the user experience when editing the character description. The most important changes are grouped below:

**Expanded Descriptions and UI Enhancements:**

* Added detailed descriptions for the `Barbar` race and the `Landbewohner` culture in both the JavaScript logic (`raceDescriptions`, `cultureDescriptions`) and as `title` attributes in the corresponding `<option>` elements in the dropdown menus, allowing users to view more context about their selections. [[1]](diffhunk://#diff-7438a413b83ecd16d538486287b615a7d8d3cab9e7ab59e1547cdbd10eec5498L53-R65) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L27-R35)

**Improved Description Field Logic:**

* Updated the logic for auto-filling the character description field: now, if the user has not manually edited the field, selecting a race or culture will combine and insert both the race and culture descriptions, separated by a blank line if both are present. [[1]](diffhunk://#diff-7438a413b83ecd16d538486287b615a7d8d3cab9e7ab59e1547cdbd10eec5498L476-R491) [[2]](diffhunk://#diff-7438a413b83ecd16d538486287b615a7d8d3cab9e7ab59e1547cdbd10eec5498R539-R545)
* Introduced a mechanism to track if the user has manually edited the description field (`dataset.userEdited`), so that auto-filling does not override user input.