### PR TITLE
Run Node steps only for PHP 8.3 in tests workflow

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -52,7 +52,7 @@ jobs:
         tools: composer:v2
 
     - name: Setup Node.js
-      if: matrix.php-version == '8.3'
+      if: ${{ matrix.php-version == '8.3' }}
       uses: actions/setup-node@v4
       with:
         node-version: '20'
@@ -73,11 +73,11 @@ jobs:
       run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
 
     - name: Install NPM dependencies
-      if: matrix.php-version == '8.3'
+      if: ${{ matrix.php-version == '8.3' }}
       run: npm ci
 
     - name: Build assets
-      if: matrix.php-version == '8.3'
+      if: ${{ matrix.php-version == '8.3' }}
       run: npm run build
 
     - name: Copy .env
@@ -92,20 +92,21 @@ jobs:
       run: php artisan migrate --force
 
     - name: Execute tests (Feature tests only)
+      if: ${{ matrix.php-version != '8.3' }}
       run: php artisan test tests/Feature
 
     - name: Execute tests with coverage (PHP 8.3 only)
-      if: matrix.php-version == '8.3'
+      if: ${{ matrix.php-version == '8.3' }}
       env:
         XDEBUG_MODE: coverage
       run: php artisan test tests/Feature --coverage-clover=coverage.xml
 
     - name: Run Jest tests with coverage
-      if: matrix.php-version == '8.3'
+      if: ${{ matrix.php-version == '8.3' }}
       run: npm test -- --coverage --coverageReporters=json-summary --coverageDirectory=coverage
 
     - name: Create JS coverage badge
-      if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
+      if: ${{ matrix.php-version == '8.3' && github.ref == 'refs/heads/main' }}
       run: |
         mkdir -p output
         if [ ! -f "coverage/coverage-summary.json" ]; then
@@ -120,7 +121,7 @@ jobs:
         sed -i 's/Coverage/JS Coverage/' output/js-coverage.svg
 
     - name: Create PHP coverage badge
-      if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
+      if: ${{ matrix.php-version == '8.3' && github.ref == 'refs/heads/main' }}
       uses: timkrase/phpunit-coverage-badge@v1.2.1
       with:
         report: coverage.xml
@@ -128,7 +129,7 @@ jobs:
         push_badge: false
 
     - name: Customize PHP coverage badge label
-      if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
+      if: ${{ matrix.php-version == '8.3' && github.ref == 'refs/heads/main' }}
       run: |
         if [ -f output/php-coverage.svg ]; then
           sed -i 's/Coverage/PHP Coverage/' output/php-coverage.svg
@@ -138,7 +139,7 @@ jobs:
         fi
 
     - name: Deploy coverage badges to image-data branch
-      if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
+      if: ${{ matrix.php-version == '8.3' && github.ref == 'refs/heads/main' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         publish_dir: ./output

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -52,6 +52,7 @@ jobs:
         tools: composer:v2
 
     - name: Setup Node.js
+      if: matrix.php-version == '8.3'
       uses: actions/setup-node@v4
       with:
         node-version: '20'
@@ -72,9 +73,11 @@ jobs:
       run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
 
     - name: Install NPM dependencies
+      if: matrix.php-version == '8.3'
       run: npm ci
 
     - name: Build assets
+      if: matrix.php-version == '8.3'
       run: npm run build
 
     - name: Copy .env
@@ -98,6 +101,7 @@ jobs:
       run: php artisan test tests/Feature --coverage-clover=coverage.xml
 
     - name: Run Jest tests with coverage
+      if: matrix.php-version == '8.3'
       run: npm test -- --coverage --coverageReporters=json-summary --coverageDirectory=coverage
 
     - name: Create JS coverage badge


### PR DESCRIPTION
This pull request updates the unit test GitHub Actions workflow to only run Node.js and frontend-related steps when testing against PHP 8.3. This streamlines the workflow by avoiding unnecessary Node.js setup and frontend build steps for other PHP versions.

Workflow optimization for PHP 8.3:

* Added a condition to the Node.js setup step so it only runs when `matrix.php-version` is `8.3` (`.github/workflows/unittests.yml`)
* Limited NPM dependency installation and asset build steps to PHP 8.3 runs (`.github/workflows/unittests.yml`)
* Restricted running Jest tests with coverage to PHP 8.3 (`.github/workflows/unittests.yml`)