### PR TITLE
Restrict AG leader editing of AG name and leader

### DIFF
--- a/app/Http/Controllers/ArbeitsgruppenController.php
+++ b/app/Http/Controllers/ArbeitsgruppenController.php
@@ -176,6 +176,7 @@ class ArbeitsgruppenController extends Controller
 
         if (!$user->hasRole('Admin')) {
             $validated['leader_id'] = $team->user_id;
+            $validated['name'] = $team->name;
         }
 
         $logoPath = $request->file('logo')?->store('ag-logos', 'public') ?? $team->logo_path;

--- a/resources/views/arbeitsgruppen/edit.blade.php
+++ b/resources/views/arbeitsgruppen/edit.blade.php
@@ -6,10 +6,14 @@
             <form action="{{ route('arbeitsgruppen.update', $team) }}" method="POST" enctype="multipart/form-data">
                 @csrf
                 @method('PUT')
+                @php($isAdmin = Auth::user()->hasRole('Admin'))
 
                 <div class="mb-4">
                     <label for="name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name der AG</label>
-                    <input type="text" name="name" id="name" value="{{ old('name', $team->name) }}" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    <input type="text" name="name" id="name" value="{{ old('name', $team->name) }}" @if(!$isAdmin) disabled @endif required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    @unless($isAdmin)
+                        <input type="hidden" name="name" value="{{ old('name', $team->name) }}">
+                    @endunless
                     @error('name')
                         <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                     @enderror
@@ -17,11 +21,14 @@
 
                 <div class="mb-4">
                     <label for="leader_id" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">AG-Leiter</label>
-                    <select name="leader_id" id="leader_id" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                    <select name="leader_id" id="leader_id" @if(!$isAdmin) disabled @endif required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                         @foreach($users as $member)
                             <option value="{{ $member->id }}" {{ old('leader_id', $team->user_id) == $member->id ? 'selected' : '' }}>{{ $member->name }}</option>
                         @endforeach
                     </select>
+                    @unless($isAdmin)
+                        <input type="hidden" name="leader_id" value="{{ old('leader_id', $team->user_id) }}">
+                    @endunless
                     @error('leader_id')
                         <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                     @enderror

--- a/tests/Feature/ArbeitsgruppenControllerTest.php
+++ b/tests/Feature/ArbeitsgruppenControllerTest.php
@@ -19,9 +19,10 @@ class ArbeitsgruppenControllerTest extends TestCase
         return $user;
     }
 
-    public function test_ag_leader_can_update_own_team(): void
+    public function test_ag_leader_cannot_change_name_or_leader(): void
     {
         $leader = $this->createMemberWithRole();
+        $otherLeader = $this->createMemberWithRole();
         $ag = Team::factory()->create([
             'user_id' => $leader->id,
             'personal_team' => false,
@@ -33,7 +34,7 @@ class ArbeitsgruppenControllerTest extends TestCase
 
         $response = $this->put(route('arbeitsgruppen.update', $ag), [
             'name' => 'AG Neu',
-            'leader_id' => $leader->id,
+            'leader_id' => $otherLeader->id,
             'description' => 'Desc',
             'email' => 'ag@example.com',
             'meeting_schedule' => 'montags',
@@ -42,7 +43,8 @@ class ArbeitsgruppenControllerTest extends TestCase
         $response->assertRedirect(route('arbeitsgruppen.index'));
         $this->assertDatabaseHas('teams', [
             'id' => $ag->id,
-            'name' => 'AG Neu',
+            'name' => 'AG Test',
+            'user_id' => $leader->id,
             'description' => 'Desc',
             'email' => 'ag@example.com',
             'meeting_schedule' => 'montags',


### PR DESCRIPTION
## Summary
- Grey-out AG name and leader fields for non-admin users when editing a working group
- Ensure only admins can modify an AG's name or leader in the controller logic
- Update feature test to assert AG leaders cannot change these attributes

## Testing
- `php artisan test` *(fails: SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: YES))*

------
https://chatgpt.com/codex/tasks/task_e_68bd138135b0832ebf96f8df50e0bc14