### PR TITLE
Seed default team for tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Directory Permissions
       run: chmod -R 755 storage bootstrap/cache
     - name: Run migrations
-      run: php artisan migrate --force
+      run: php artisan migrate --force --seed
 
     - name: Execute tests (Feature tests only)
       run: php artisan test tests/Feature

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,6 +21,7 @@ class DatabaseSeeder extends Seeder
         ]);
         $this->call([
             // Andere Seeder
+            TeamSeeder::class,
             TodoCategorySeeder::class,
         ]);
     }

--- a/database/seeders/TeamSeeder.php
+++ b/database/seeders/TeamSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Team;
+use App\Models\User;
+
+class TeamSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Ensure there is at least one user to own the team
+        $owner = User::first() ?? User::factory()->create();
+
+        Team::firstOrCreate(
+            ['name' => 'Mitglieder'],
+            [
+                'user_id' => $owner->id,
+                'personal_team' => false,
+            ]
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,8 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    /**
+     * Indicates whether the default seeder should run before each test.
+     */
+    protected bool $seed = true;
 }


### PR DESCRIPTION
This pull request introduces a new database seeder for teams and ensures that seeders are consistently run during migrations and tests. The main focus is on improving test reliability and data initialization by seeding the database with required data, specifically teams.

**Database seeding improvements:**

* Added a new `TeamSeeder` class to create a default team if it does not exist, ensuring there's always a team in the database. (`database/seeders/TeamSeeder.php`)
* Registered the new `TeamSeeder` in the main `DatabaseSeeder` so it runs with other seeders. (`database/seeders/DatabaseSeeder.php`)

**Testing and workflow enhancements:**

* Updated the GitHub Actions unit test workflow to run the database seeder during migrations, ensuring the test database is properly seeded. (`.github/workflows/unittests.yml`)
* Modified the base `TestCase` so that the default seeder runs before each test, providing consistent test data. (`tests/TestCase.php`)