### PR TITLE
chore: run feature tests with sqlite

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -18,24 +18,9 @@ jobs:
       matrix:
         php-version: ['8.2', '8.3', '8.4']
     
-    services:
-      mysql:
-        image: mysql:8
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: false
-          MYSQL_ROOT_PASSWORD: password
-          MYSQL_DATABASE: laravel_testing
-        ports:
-          - "3306:3306"
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
     env:
-      DB_CONNECTION: mysql
-      DB_HOST: 127.0.0.1
-      DB_PORT: 3306
-      DB_DATABASE: laravel_testing
-      DB_USERNAME: root
-      DB_PASSWORD: password
+      DB_CONNECTION: sqlite
+      DB_DATABASE: database/database.sqlite
 
     name: PHP ${{ matrix.php-version }} - Feature Tests
     
@@ -47,7 +32,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
-        extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, pdo_mysql, xdebug
+        extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, xdebug
         coverage: xdebug
         tools: composer:v2
 
@@ -85,6 +70,10 @@ jobs:
 
     - name: Directory Permissions
       run: chmod -R 755 storage bootstrap/cache
+    - name: Create SQLite database
+      run: |
+        mkdir -p database
+        touch database/database.sqlite
     - name: Run migrations
       run: php artisan migrate --force --seed
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,12 +19,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_CONNECTION" value="mysql"/>
-        <env name="DB_HOST" value="127.0.0.1"/>
-        <env name="DB_PORT" value="3306"/>
-        <env name="DB_USERNAME" value="root"/>
-        <env name="DB_PASSWORD" value="password"/>
-        <env name="DB_DATABASE" value="laravel_testing"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value="database/database.sqlite"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
This pull request updates the test environment to use SQLite instead of MySQL for running unit tests. The changes simplify the setup process and remove the dependency on a MySQL service in CI workflows.

**Test environment migration to SQLite:**

* [`.github/workflows/unittests.yml`](diffhunk://#diff-54c039feb42ef7c758e4cbc3aaa48971a1b41a1132399420b4c98d984ad62828L21-R23): Removed MySQL service configuration and related environment variables, and switched the database connection to SQLite for unit tests.
* [`.github/workflows/unittests.yml`](diffhunk://#diff-54c039feb42ef7c758e4cbc3aaa48971a1b41a1132399420b4c98d984ad62828R73-R76): Added a step to create the SQLite database file before running migrations.
* [`phpunit.xml`](diffhunk://#diff-ae310e922c85656813bd29d9f3c9a1b87c8aaa83d924813a5b91c67b7abb3cb9L22-R23): Updated database environment variables to use SQLite instead of MySQL.

**Workflow dependency cleanup:**

* [`.github/workflows/unittests.yml`](diffhunk://#diff-54c039feb42ef7c758e4cbc3aaa48971a1b41a1132399420b4c98d984ad62828L50-R35): Removed the `pdo_mysql` extension from the PHP setup since MySQL is no longer used.