### PR TITLE
Use string columns for statuses and types

### DIFF
--- a/app/Enums/AudiobookEpisodeStatus.php
+++ b/app/Enums/AudiobookEpisodeStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum AudiobookEpisodeStatus: string
+{
+    case Skripterstellung = 'Skripterstellung';
+    case Korrekturlesung = 'Korrekturlesung';
+    case Rollenbesetzung = 'Rollenbesetzung';
+    case Aufnahmensammlung = 'Aufnahmensammlung';
+    case Musikerstellung = 'Musikerstellung';
+    case Audiobearbeitung = 'Audiobearbeitung';
+    case Videobearbeitung = 'Videobearbeitung';
+    case Grafiken = 'Grafiken';
+    case Veroeffentlichungsplanung = 'Veröffentlichungsplanung';
+    case Veroeffentlichung = 'Veröffentlichung';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Enums/KassenbuchEntryType.php
+++ b/app/Enums/KassenbuchEntryType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum KassenbuchEntryType: string
+{
+    case Einnahme = 'einnahme';
+    case Ausgabe = 'ausgabe';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Enums/TodoStatus.php
+++ b/app/Enums/TodoStatus.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+enum TodoStatus: string
+{
+    case Open = 'open';
+    case Assigned = 'assigned';
+    case Completed = 'completed';
+    case Verified = 'verified';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -2,16 +2,15 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\AudiobookEpisodeStatus;
 use App\Models\AudiobookEpisode;
 use App\Models\AudiobookRole;
-use App\Models\Team;
 use App\Models\User;
-use Illuminate\Http\Request;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Validation\Rule;
 use App\Rules\ValidReleaseTime;
 use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class HoerbuchController extends Controller
 {
@@ -48,7 +47,7 @@ class HoerbuchController extends Controller
 
         return view('hoerbuecher.index', [
             'episodes' => $episodes,
-            'statuses' => AudiobookEpisode::STATUSES,
+            'statuses' => AudiobookEpisodeStatus::values(),
             'years' => $years,
             'totalUnfilledRoles' => $totalUnfilledRoles,
             'openRolesEpisodes' => $openRolesEpisodes,
@@ -108,8 +107,10 @@ class HoerbuchController extends Controller
     private function previousSpeakersForEpisode(AudiobookEpisode $episode): array
     {
         $episode->loadMissing('roles');
+
         return $this->latestSpeakersForNames($episode->roles->pluck('name'));
     }
+
     /**
      * Formular zum Erstellen einer neuen Hörbuchfolge.
      */
@@ -119,7 +120,7 @@ class HoerbuchController extends Controller
 
         return view('hoerbuecher.create', [
             'users' => $users,
-            'statuses' => AudiobookEpisode::STATUSES,
+            'statuses' => AudiobookEpisodeStatus::values(),
         ]);
     }
 
@@ -132,8 +133,8 @@ class HoerbuchController extends Controller
             'episode_number' => 'required|string|max:10|unique:audiobook_episodes,episode_number',
             'title' => 'required|string|max:255',
             'author' => 'required|string|max:255',
-            'planned_release_date' => ['required', 'string', new ValidReleaseTime()],
-            'status' => 'required|in:' . implode(',', AudiobookEpisode::STATUSES),
+            'planned_release_date' => ['required', 'string', new ValidReleaseTime],
+            'status' => 'required|in:'.implode(',', AudiobookEpisodeStatus::values()),
             'responsible_user_id' => 'nullable|exists:users,id',
             'progress' => 'required|integer|min:0|max:100',
             'notes' => 'nullable|string',
@@ -170,7 +171,6 @@ class HoerbuchController extends Controller
     /**
      * Detailansicht einer Hörbuchfolge.
      */
-    
     public function show(AudiobookEpisode $episode)
     {
         $episode->load('roles.user');
@@ -196,7 +196,7 @@ class HoerbuchController extends Controller
         return view('hoerbuecher.edit', [
             'episode' => $episode,
             'users' => $users,
-            'statuses' => AudiobookEpisode::STATUSES,
+            'statuses' => AudiobookEpisodeStatus::values(),
             'previousSpeakers' => $previous,
         ]);
     }
@@ -215,8 +215,8 @@ class HoerbuchController extends Controller
             ],
             'title' => 'required|string|max:255',
             'author' => 'required|string|max:255',
-            'planned_release_date' => ['required', 'string', new ValidReleaseTime()],
-            'status' => 'required|in:' . implode(',', AudiobookEpisode::STATUSES),
+            'planned_release_date' => ['required', 'string', new ValidReleaseTime],
+            'status' => 'required|in:'.implode(',', AudiobookEpisodeStatus::values()),
             'responsible_user_id' => 'nullable|exists:users,id',
             'progress' => 'required|integer|min:0|max:100',
             'notes' => 'nullable|string',

--- a/app/Http/Controllers/KassenbuchController.php
+++ b/app/Http/Controllers/KassenbuchController.php
@@ -2,13 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\KassenbuchEntryType;
+use App\Models\KassenbuchEntry;
+use App\Models\Kassenstand;
+use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use App\Models\User;
-use App\Models\KassenbuchEntry;
-use App\Models\Kassenstand;
-use Carbon\Carbon;
 
 class KassenbuchController extends Controller
 {
@@ -16,44 +17,44 @@ class KassenbuchController extends Controller
     {
         $user = Auth::user();
         $team = $user->currentTeam;
-        
+
         // Benutzerrolle ermitteln
         $userRole = $team->users()
             ->where('user_id', $user->id)
             ->first()
             ->membership
             ->role;
-            
+
         // Aktuellen Kassenstand abrufen
         $kassenstand = Kassenstand::where('team_id', $team->id)->first();
-        
+
         // Falls noch kein Kassenstand existiert, einen initialen Eintrag erstellen
-        if (!$kassenstand) {
+        if (! $kassenstand) {
             $kassenstand = Kassenstand::create([
                 'team_id' => $team->id,
                 'betrag' => 0.00,
                 'letzte_aktualisierung' => now(),
             ]);
         }
-        
+
         // Für Vorstand und Kassenwart: Alle Mitglieder mit ihren Zahlungsdaten abrufen
         $members = null;
         $kassenbuchEntries = null;
-        
+
         if (in_array($userRole, ['Vorstand', 'Admin', 'Kassenwart'])) {
             $members = $team->users()
                 ->wherePivotNotIn('role', ['Anwärter'])
                 ->orderBy('bezahlt_bis')
                 ->get();
-                
+
             $kassenbuchEntries = KassenbuchEntry::where('team_id', $team->id)
                 ->orderBy('buchungsdatum', 'desc')
                 ->get();
         }
-        
+
         // Für das angemeldete Mitglied: Eigene Zahlungsdaten abrufen
         $memberData = $user;
-        
+
         // Prüfen, ob Mitgliedschaft bald abläuft (innerhalb eines Monats)
         $renewalWarning = false;
         if ($user->bezahlt_bis) {
@@ -62,12 +63,12 @@ class KassenbuchController extends Controller
                 ? $user->bezahlt_bis
                 : Carbon::parse((string) $user->bezahlt_bis);
             $daysUntilExpiry = $today->diffInDays($expiryDate, false);
-            
+
             if ($daysUntilExpiry > 0 && $daysUntilExpiry <= 30) {
                 $renewalWarning = true;
             }
         }
-        
+
         return view('kassenbuch.index', [
             'userRole' => $userRole,
             'kassenstand' => $kassenstand,
@@ -77,7 +78,7 @@ class KassenbuchController extends Controller
             'renewalWarning' => $renewalWarning,
         ]);
     }
-    
+
     public function updatePaymentStatus(Request $request, User $user)
     {
         $data = $request->validate([
@@ -85,60 +86,60 @@ class KassenbuchController extends Controller
             'mitgliedsbeitrag' => 'required|numeric|min:0',
             'mitglied_seit' => 'nullable|date',
         ]);
-        
+
         $currentUser = Auth::user();
         $team = $currentUser->currentTeam;
-        
+
         // Prüfen, ob der aktuelle Benutzer die Rolle "Kassenwart" hat
         $userRole = $team->users()
             ->where('user_id', $currentUser->id)
             ->first()
             ->membership
             ->role;
-            
-        if (!in_array($userRole, ['Kassenwart', 'Admin'])) {
+
+        if (! in_array($userRole, ['Kassenwart', 'Admin'])) {
             return back()->with('error', 'Du hast keine Berechtigung, Zahlungsdaten zu aktualisieren.');
         }
-        
+
         // Zahlungsdaten aktualisieren
         $user->update([
             'bezahlt_bis' => $data['bezahlt_bis'],
             'mitgliedsbeitrag' => $data['mitgliedsbeitrag'],
             'mitglied_seit' => $data['mitglied_seit'] ?? null,
         ]);
-        
-        return back()->with('status', 'Zahlungsdaten für ' . $user->name . ' wurden aktualisiert.');
+
+        return back()->with('status', 'Zahlungsdaten für '.$user->name.' wurden aktualisiert.');
     }
-    
+
     public function addKassenbuchEntry(Request $request)
     {
         $data = $request->validate([
             'buchungsdatum' => 'required|date',
             'betrag' => 'required|numeric|not_in:0',
             'beschreibung' => 'required|string|max:255',
-            'typ' => 'required|in:einnahme,ausgabe',
+            'typ' => 'required|in:'.implode(',', KassenbuchEntryType::values()),
         ]);
-        
+
         $user = Auth::user();
         $team = $user->currentTeam;
-        
+
         // Prüfen, ob der aktuelle Benutzer die Rolle "Kassenwart" hat
         $userRole = $team->users()
             ->where('user_id', $user->id)
             ->first()
             ->membership
             ->role;
-            
-        if (!in_array($userRole, ['Kassenwart', 'Admin'])) {
+
+        if (! in_array($userRole, ['Kassenwart', 'Admin'])) {
             return back()->with('error', 'Du hast keine Berechtigung, Kassenbucheinträge hinzuzufügen.');
         }
-        
+
         // Betrag anpassen (positiv für Einnahmen, negativ für Ausgaben)
         $amount = abs($data['betrag']);
-        if ($data['typ'] === 'ausgabe') {
+        if ($data['typ'] === KassenbuchEntryType::Ausgabe->value) {
             $amount = -$amount;
         }
-        
+
         // Neuen Eintrag erstellen
         DB::transaction(function () use ($team, $user, $data, $amount) {
             // Kassenbucheintrag erstellen
@@ -150,14 +151,14 @@ class KassenbuchController extends Controller
                 'beschreibung' => $data['beschreibung'],
                 'typ' => $data['typ'],
             ]);
-            
+
             // Kassenstand aktualisieren
             $kassenstand = Kassenstand::where('team_id', $team->id)->first();
             $kassenstand->betrag += $amount;
             $kassenstand->letzte_aktualisierung = now();
             $kassenstand->save();
         });
-        
+
         return back()->with('status', 'Kassenbucheintrag wurde hinzugefügt.');
     }
 }

--- a/app/Models/AudiobookEpisode.php
+++ b/app/Models/AudiobookEpisode.php
@@ -2,30 +2,18 @@
 
 namespace App\Models;
 
+use App\Enums\AudiobookEpisodeStatus;
 use Carbon\Carbon;
 use Carbon\Exceptions\InvalidFormatException;
-use InvalidArgumentException;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use InvalidArgumentException;
 
 class AudiobookEpisode extends Model
 {
     use HasFactory;
-
-    public const STATUSES = [
-        'Skripterstellung',
-        'Korrekturlesung',
-        'Rollenbesetzung',
-        'Aufnahmensammlung',
-        'Musikerstellung',
-        'Audiobearbeitung',
-        'Videobearbeitung',
-        'Grafiken',
-        'Veröffentlichungsplanung',
-        'Veröffentlichung',
-    ];
 
     /**
      * Scale factor mapping 0–100% progress to a 0–120° hue range,
@@ -44,6 +32,10 @@ class AudiobookEpisode extends Model
         'notes',
         'roles_total',
         'roles_filled',
+    ];
+
+    protected $casts = [
+        'status' => AudiobookEpisodeStatus::class,
     ];
 
     public function responsible(): BelongsTo
@@ -107,7 +99,7 @@ class AudiobookEpisode extends Model
      */
     public function getPlannedReleaseDateParsedAttribute(): ?Carbon
     {
-        if (!$this->planned_release_date) {
+        if (! $this->planned_release_date) {
             return null;
         }
 
@@ -120,7 +112,7 @@ class AudiobookEpisode extends Model
                 } else {
                     $date = Carbon::createFromFormat($format, $this->planned_release_date);
                 }
-            } catch (InvalidArgumentException | InvalidFormatException $e) {
+            } catch (InvalidArgumentException|InvalidFormatException $e) {
                 continue;
             }
 

--- a/app/Models/KassenbuchEntry.php
+++ b/app/Models/KassenbuchEntry.php
@@ -2,10 +2,11 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Enums\KassenbuchEntryType;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property int $id
@@ -14,7 +15,7 @@ use Carbon\Carbon;
  * @property Carbon $buchungsdatum
  * @property float $betrag
  * @property string $beschreibung
- * @property string $typ
+ * @property KassenbuchEntryType $typ
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Team $team
@@ -30,12 +31,13 @@ class KassenbuchEntry extends Model
         'buchungsdatum',
         'betrag',
         'beschreibung',
-        'typ'
+        'typ',
     ];
 
     protected $casts = [
         'buchungsdatum' => 'date',
         'betrag' => 'decimal:2',
+        'typ' => KassenbuchEntryType::class,
     ];
 
     /**

--- a/app/Models/Todo.php
+++ b/app/Models/Todo.php
@@ -2,10 +2,11 @@
 
 namespace App\Models;
 
+use App\Enums\TodoStatus;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Carbon\Carbon;
 
 /**
  * @property int $id
@@ -16,7 +17,7 @@ use Carbon\Carbon;
  * @property string $title
  * @property string|null $description
  * @property int $points
- * @property string $status
+ * @property TodoStatus $status
  * @property Carbon|null $completed_at
  * @property Carbon|null $verified_at
  * @property int|null $category_id
@@ -31,6 +32,7 @@ use Carbon\Carbon;
 class Todo extends Model
 {
     use HasFactory;
+
     protected $fillable = [
         'team_id',
         'created_by',
@@ -50,6 +52,7 @@ class Todo extends Model
         return [
             'completed_at' => 'datetime',
             'verified_at' => 'datetime',
+            'status' => TodoStatus::class,
         ];
     }
 
@@ -101,7 +104,7 @@ class Todo extends Model
         $eligibleRoles = ['Mitglied', 'Ehrenmitglied', 'Kassenwart', 'Vorstand', 'Admin'];
         $team = $this->team;
 
-        if (!$team) {
+        if (! $team) {
             return false;
         }
 
@@ -121,7 +124,7 @@ class Todo extends Model
         $eligibleRoles = ['Kassenwart', 'Vorstand', 'Admin'];
         $team = $this->team;
 
-        if (!$team) {
+        if (! $team) {
             return false;
         }
 
@@ -141,7 +144,7 @@ class Todo extends Model
         $eligibleRoles = ['Kassenwart', 'Vorstand', 'Admin'];
         $team = $this->team;
 
-        if (!$team) {
+        if (! $team) {
             return false;
         }
 

--- a/database/migrations/2025_04_01_183444_create_todos_table.php
+++ b/database/migrations/2025_04_01_183444_create_todos_table.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */
@@ -19,7 +20,7 @@ return new class extends Migration {
             $table->string('title');
             $table->text('description')->nullable();
             $table->integer('points')->default(0);
-            $table->enum('status', ['open', 'assigned', 'completed', 'verified'])->default('open');
+            $table->string('status')->default('open');
             $table->timestamp('completed_at')->nullable();
             $table->timestamp('verified_at')->nullable();
             $table->timestamps();

--- a/database/migrations/2025_04_07_131350_create_kassenbuch.php
+++ b/database/migrations/2025_04_07_131350_create_kassenbuch.php
@@ -4,7 +4,8 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class extends Migration
+{
     /**
      * Run the migrations.
      */
@@ -17,7 +18,7 @@ return new class extends Migration {
             $table->date('buchungsdatum');
             $table->decimal('betrag', 10, 2); // Positiv für Einnahmen, negativ für Ausgaben
             $table->string('beschreibung');
-            $table->enum('typ', ['einnahme', 'ausgabe']);
+            $table->string('typ');
             $table->timestamps();
         });
 

--- a/database/migrations/2025_09_15_000000_create_audiobook_episodes_table.php
+++ b/database/migrations/2025_09_15_000000_create_audiobook_episodes_table.php
@@ -17,18 +17,7 @@ return new class extends Migration
             $table->string('title');
             $table->string('author');
             $table->date('planned_release_date')->nullable();
-            $table->enum('status', [
-                'Skripterstellung',
-                'Korrekturlesung',
-                'Rollenbesetzung',
-                'Aufnahmensammlung',
-                'Musikerstellung',
-                'Audiobearbeitung',
-                'Videobearbeitung',
-                'Grafiken',
-                'Veröffentlichungsplanung',
-                'Veröffentlichung',
-            ]);
+            $table->string('status');
             $table->foreignId('responsible_user_id')->nullable()->constrained('users')->nullOnDelete();
             $table->unsignedTinyInteger('progress')->default(0);
             $table->text('notes')->nullable();

--- a/database/migrations/2025_09_18_000000_update_status_enum_in_audiobook_episodes_table.php
+++ b/database/migrations/2025_09_18_000000_update_status_enum_in_audiobook_episodes_table.php
@@ -10,35 +10,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $oldValues = [
-            'Skript wird erstellt',
-            'In Korrekturlesung',
-            'Rollenbesetzung',
-            'Aufnahmen in Arbeit',
-            'Musikerstellung',
-            'Audiobearbeitung gestartet',
-            'Videobearbeitung gestartet',
-            'Cover und Thumbnail in Arbeit',
-            'Veröffentlichung geplant',
-            'Veröffentlicht',
-        ];
-
-        $newValues = [
-            'Skripterstellung',
-            'Korrekturlesung',
-            'Rollenbesetzung',
-            'Aufnahmensammlung',
-            'Musikerstellung',
-            'Audiobearbeitung',
-            'Videobearbeitung',
-            'Grafiken',
-            'Veröffentlichungsplanung',
-            'Veröffentlichung',
-        ];
-
-        $transition = array_unique(array_merge($oldValues, $newValues));
-        DB::statement("ALTER TABLE audiobook_episodes MODIFY `status` ENUM('".implode("','", $transition)."') NOT NULL");
-
         $mapping = [
             'Skript wird erstellt' => 'Skripterstellung',
             'In Korrekturlesung' => 'Korrekturlesung',
@@ -49,12 +20,9 @@ return new class extends Migration
             'Veröffentlichung geplant' => 'Veröffentlichungsplanung',
             'Veröffentlicht' => 'Veröffentlichung',
         ];
-
         foreach ($mapping as $old => $new) {
             DB::table('audiobook_episodes')->where('status', $old)->update(['status' => $new]);
         }
-
-        DB::statement("ALTER TABLE audiobook_episodes MODIFY `status` ENUM('".implode("','", $newValues)."') NOT NULL");
     }
 
     /**
@@ -62,35 +30,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        $oldValues = [
-            'Skript wird erstellt',
-            'In Korrekturlesung',
-            'Rollenbesetzung',
-            'Aufnahmen in Arbeit',
-            'Musikerstellung',
-            'Audiobearbeitung gestartet',
-            'Videobearbeitung gestartet',
-            'Cover und Thumbnail in Arbeit',
-            'Veröffentlichung geplant',
-            'Veröffentlicht',
-        ];
-
-        $newValues = [
-            'Skripterstellung',
-            'Korrekturlesung',
-            'Rollenbesetzung',
-            'Aufnahmensammlung',
-            'Musikerstellung',
-            'Audiobearbeitung',
-            'Videobearbeitung',
-            'Grafiken',
-            'Veröffentlichungsplanung',
-            'Veröffentlichung',
-        ];
-
-        $transition = array_unique(array_merge($oldValues, $newValues));
-        DB::statement("ALTER TABLE audiobook_episodes MODIFY `status` ENUM('".implode("','", $transition)."') NOT NULL");
-
         $mapping = [
             'Skripterstellung' => 'Skript wird erstellt',
             'Korrekturlesung' => 'In Korrekturlesung',
@@ -101,11 +40,8 @@ return new class extends Migration
             'Veröffentlichungsplanung' => 'Veröffentlichung geplant',
             'Veröffentlichung' => 'Veröffentlicht',
         ];
-
         foreach ($mapping as $new => $old) {
             DB::table('audiobook_episodes')->where('status', $new)->update(['status' => $old]);
         }
-
-        DB::statement("ALTER TABLE audiobook_episodes MODIFY `status` ENUM('".implode("','", $oldValues)."') NOT NULL");
     }
 };

--- a/database/migrations/2025_09_19_000000_add_type_to_books_table.php
+++ b/database/migrations/2025_09_19_000000_add_type_to_books_table.php
@@ -1,16 +1,16 @@
 <?php
 
+use App\Enums\BookType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
-use App\Enums\BookType;
 
-return new class extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::table('books', function (Blueprint $table) {
-            $table->enum('type', array_map(fn($case) => $case->value, BookType::cases()))
-                ->default(BookType::MaddraxDieDunkleZukunftDerErde->value);
+            $table->string('type')->default(BookType::MaddraxDieDunkleZukunftDerErde->value);
             $table->dropUnique('books_roman_number_unique');
             $table->unique(['roman_number', 'type'], 'books_roman_number_type_unique');
         });

--- a/database/migrations/2025_10_01_000000_update_book_type_enum.php
+++ b/database/migrations/2025_10_01_000000_update_book_type_enum.php
@@ -1,23 +1,16 @@
 <?php
 
-use App\Enums\BookType;
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Facades\DB;
 
 return new class extends Migration
 {
     public function up(): void
     {
-        $values = array_map(fn ($case) => "'{$case->value}'", BookType::cases());
-        $valuesString = implode(',', $values);
-        DB::statement("ALTER TABLE books MODIFY COLUMN type ENUM($valuesString) NOT NULL DEFAULT '".BookType::MaddraxDieDunkleZukunftDerErde->value."'");
+        // No schema changes necessary; type is stored as a string.
     }
 
     public function down(): void
     {
-        $values = array_filter(BookType::cases(), fn ($case) => $case !== BookType::MissionMars);
-        $values = array_map(fn ($case) => "'{$case->value}'", $values);
-        $valuesString = implode(',', $values);
-        DB::statement("ALTER TABLE books MODIFY COLUMN type ENUM($valuesString) NOT NULL DEFAULT '".BookType::MaddraxDieDunkleZukunftDerErde->value."'");
+        // No schema changes necessary for rollback.
     }
 };

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -29,7 +29,7 @@
                         <select name="status" id="status" required class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
                             <option value="">-- Status wählen --</option>
                             @foreach($statuses as $status)
-                                <option value="{{ $status }}" {{ old('status', $episode->status) === $status ? 'selected' : '' }}>{{ $status }}</option>
+                                <option value="{{ $status }}" {{ old('status', $episode->status->value) === $status ? 'selected' : '' }}>{{ $status }}</option>
                             @endforeach
                         </select>
                         @error('status')

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -82,7 +82,7 @@
                                 role="button"
                                 tabindex="0"
                                 data-href="{{ route('hoerbuecher.show', $episode) }}"
-                                data-status="{{ $episode->status }}"
+                                data-status="{{ $episode->status->value }}"
                                 data-type="{{ $episode->episode_type }}"
                                 data-roles-filled="{{ $episode->all_roles_filled ? '1' : '0' }}"
                                 data-year="{{ $episode->release_year ?? '' }}"
@@ -92,14 +92,14 @@
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->planned_release_date }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
-                                    <span>{{ $episode->status }}</span>
+                                    <span>{{ $episode->status->value }}</span>
                                     <div
                                         class="mt-1 w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4"
                                         role="progressbar"
                                         aria-valuenow="{{ $episode->progress }}"
                                         aria-valuemin="0"
                                         aria-valuemax="100"
-                                        aria-label="Episode progress: {{ $episode->status }}, {{ $episode->progress }}% complete">
+                                        aria-label="Episode progress: {{ $episode->status->value }}, {{ $episode->progress }}% complete">
                                         {{-- Map 0–100% progress to a hue range of 0–120 (red → green). --}}
                                         <div class="h-4 rounded-full text-xs font-medium text-center leading-none text-white" style="width: {{ $episode->progress }}%; background-color: hsl({{ $episode->progressHue() }}, 100%, 40%);">
                                             {{ $episode->progress }}%

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -7,7 +7,7 @@
                 <div><span class="font-medium">Folge:</span> {{ $episode->episode_number }}</div>
                 <div><span class="font-medium">Autor:</span> {{ $episode->author }}</div>
                 <div><span class="font-medium">Ziel-EVT:</span> {{ $episode->planned_release_date }}</div>
-                <div><span class="font-medium">Status:</span> {{ $episode->status }}</div>
+                <div><span class="font-medium">Status:</span> {{ $episode->status->value }}</div>
                 <div class="md:col-span-2">
                     <span class="font-medium">Fortschritt:</span>
                     <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-4 mt-1">

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -57,15 +57,15 @@
                                     <tr>
                                         <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $todo->title }}</td>
                                         <td class="px-4 py-2">
-                                            @if($todo->status === 'assigned')
+                                            @if($todo->status->value === 'assigned')
                                                 <span
                                                     class="px-2 py-1 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded-full text-xs">In
                                                     Bearbeitung</span>
-                                            @elseif($todo->status === 'completed')
+                                            @elseif($todo->status->value === 'completed')
                                                 <span
                                                     class="px-2 py-1 bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 rounded-full text-xs">Wartet
                                                     auf Verifizierung</span>
-                                            @elseif($todo->status === 'verified')
+                                            @elseif($todo->status->value === 'verified')
                                                 <span
                                                     class="px-2 py-1 bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded-full text-xs">Verifiziert</span>
                                             @endif
@@ -79,7 +79,7 @@
                                             @if($todo->created_by === Auth::id())
                                                 <a href="{{ route('todos.edit', $todo) }}" class="ml-2 text-blue-600 dark:text-blue-400 hover:underline">Bearbeiten</a>
                                             @endif
-                                            @if($todo->status === 'assigned')
+                                            @if($todo->status->value === 'assigned')
                                                 <form action="{{ route('todos.complete', $todo) }}" method="POST" class="inline-block ml-2">
                                                     @csrf
                                                     <button type="submit" class="text-green-600 dark:text-green-400 hover:underline">Als erledigt markieren</button>
@@ -105,15 +105,15 @@
                                 <div class="mb-2">
                                     <span class="text-sm text-gray-600 dark:text-gray-400">Status:</span>
                                     <div class="mt-1">
-                                        @if($todo->status === 'assigned')
+                                        @if($todo->status->value === 'assigned')
                                             <span
                                                 class="px-2 py-1 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded-full text-xs">In
                                                 Bearbeitung</span>
-                                        @elseif($todo->status === 'completed')
+                                        @elseif($todo->status->value === 'completed')
                                             <span
                                                 class="px-2 py-1 bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 rounded-full text-xs">Wartet
                                                 auf Verifizierung</span>
-                                        @elseif($todo->status === 'verified')
+                                        @elseif($todo->status->value === 'verified')
                                             <span
                                                 class="px-2 py-1 bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded-full text-xs">Verifiziert</span>
                                         @endif
@@ -131,7 +131,7 @@
                                     @if($todo->created_by === Auth::id())
                                         <a href="{{ route('todos.edit', $todo) }}" class="inline-block bg-blue-500 hover:bg-blue-600 text-white py-1 px-3 rounded text-sm">Bearbeiten</a>
                                     @endif
-                                    @if($todo->status === 'assigned')
+                                    @if($todo->status->value === 'assigned')
                                         <div class="flex gap-2 mt-2">
                                             <form action="{{ route('todos.complete', $todo) }}" method="POST">
                                                 @csrf

--- a/resources/views/todos/show.blade.php
+++ b/resources/views/todos/show.blade.php
@@ -20,18 +20,18 @@
                 <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">{{ $todo->title }}</h2>
                     <div class="mt-2 md:mt-0">
-                        @if($todo->status === 'open')
+                        @if($todo->status->value === 'open')
                             <span
                                 class="px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-full text-sm">Offen</span>
-                        @elseif($todo->status === 'assigned')
+                        @elseif($todo->status->value === 'assigned')
                             <span
                                 class="px-2 py-1 bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded-full text-sm">In
                                 Bearbeitung</span>
-                        @elseif($todo->status === 'completed')
+                        @elseif($todo->status->value === 'completed')
                             <span
                                 class="px-2 py-1 bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 rounded-full text-sm">Wartet
                                 auf Verifizierung</span>
-                        @elseif($todo->status === 'verified')
+                        @elseif($todo->status->value === 'verified')
                             <span
                                 class="px-2 py-1 bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200 rounded-full text-sm">Verifiziert</span>
                         @endif
@@ -156,7 +156,7 @@
                                 </button>
                             </form>
                         @endif
-                        @if($todo->assigned_to === Auth::id() && $todo->status === 'assigned')
+                        @if($todo->assigned_to === Auth::id() && $todo->status->value === 'assigned')
                             <form action="{{ route('todos.release', $todo) }}" method="POST" class="inline">
                                 @csrf
                                 <button type="submit"

--- a/tests/Feature/KassenbuchControllerTest.php
+++ b/tests/Feature/KassenbuchControllerTest.php
@@ -2,10 +2,11 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
+use App\Enums\KassenbuchEntryType;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class KassenbuchControllerTest extends TestCase
 {
@@ -16,6 +17,7 @@ class KassenbuchControllerTest extends TestCase
         $team = Team::where('name', 'Mitglieder')->first();
         $user = User::factory()->create(['current_team_id' => $team->id]);
         $team->users()->attach($user, ['role' => $role]);
+
         return $user;
     }
 
@@ -31,7 +33,7 @@ class KassenbuchControllerTest extends TestCase
             'buchungsdatum' => '2025-01-01',
             'betrag' => 5,
             'beschreibung' => 'Beitrag',
-            'typ' => 'einnahme',
+            'typ' => KassenbuchEntryType::Einnahme->value,
         ]);
 
         $response->assertRedirect();
@@ -111,7 +113,7 @@ class KassenbuchControllerTest extends TestCase
             'buchungsdatum' => now(),
             'betrag' => 5,
             'beschreibung' => 'Beitrag',
-            'typ' => 'einnahme',
+            'typ' => KassenbuchEntryType::Einnahme->value,
         ]);
 
         $response = $this->get('/kassenbuch');
@@ -164,7 +166,7 @@ class KassenbuchControllerTest extends TestCase
             'buchungsdatum' => '2025-01-01',
             'betrag' => 5,
             'beschreibung' => 'Beitrag',
-            'typ' => 'einnahme',
+            'typ' => KassenbuchEntryType::Einnahme->value,
         ]);
 
         $response->assertRedirect('/kassenbuch');

--- a/tests/Feature/KassenbuchEntryModelTest.php
+++ b/tests/Feature/KassenbuchEntryModelTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Enums\KassenbuchEntryType;
+use App\Models\KassenbuchEntry;
+use App\Models\Team;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use App\Models\KassenbuchEntry;
-use App\Models\User;
-use App\Models\Team;
 
 class KassenbuchEntryModelTest extends TestCase
 {
@@ -32,7 +33,7 @@ class KassenbuchEntryModelTest extends TestCase
             'buchungsdatum' => '2025-05-01',
             'betrag' => 10.50,
             'beschreibung' => 'Mitgliedsbeitrag',
-            'typ' => 'einnahme',
+            'typ' => KassenbuchEntryType::Einnahme->value,
         ]);
 
         $this->assertDatabaseHas('kassenbuch_entries', [
@@ -42,7 +43,7 @@ class KassenbuchEntryModelTest extends TestCase
             'buchungsdatum' => '2025-05-01 00:00:00',
             'betrag' => 10.50,
             'beschreibung' => 'Mitgliedsbeitrag',
-            'typ' => 'einnahme',
+            'typ' => KassenbuchEntryType::Einnahme->value,
         ]);
     }
 
@@ -57,14 +58,14 @@ class KassenbuchEntryModelTest extends TestCase
             'buchungsdatum' => '2025-05-02',
             'betrag' => 5,
             'beschreibung' => 'Einkauf',
-            'typ' => 'ausgabe',
+            'typ' => KassenbuchEntryType::Ausgabe->value,
             'id' => 999,
         ]);
 
         $entry->refresh();
 
         $this->assertNotEquals(999, $entry->id);
-        $this->assertEquals('ausgabe', $entry->typ);
+        $this->assertSame(KassenbuchEntryType::Ausgabe, $entry->typ);
         $this->assertEquals('Einkauf', $entry->beschreibung);
     }
 
@@ -79,7 +80,7 @@ class KassenbuchEntryModelTest extends TestCase
             'buchungsdatum' => now(),
             'betrag' => 12,
             'beschreibung' => 'Test',
-            'typ' => 'einnahme',
+            'typ' => KassenbuchEntryType::Einnahme->value,
         ]);
 
         $this->assertTrue($entry->team->is($team));
@@ -96,7 +97,7 @@ class KassenbuchEntryModelTest extends TestCase
             'buchungsdatum' => now(),
             'betrag' => 8,
             'beschreibung' => 'Test',
-            'typ' => 'einnahme',
+            'typ' => KassenbuchEntryType::Einnahme->value,
         ]);
 
         $this->assertTrue($entry->creator->is($user));
@@ -113,7 +114,7 @@ class KassenbuchEntryModelTest extends TestCase
             'buchungsdatum' => '2025-06-01',
             'betrag' => '123.45',
             'beschreibung' => 'Cast Test',
-            'typ' => 'einnahme',
+            'typ' => KassenbuchEntryType::Einnahme->value,
         ]);
 
         $this->assertInstanceOf(\Carbon\Carbon::class, $entry->buchungsdatum);

--- a/tests/Feature/MitgliederKarteControllerTest.php
+++ b/tests/Feature/MitgliederKarteControllerTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
+use App\Enums\TodoStatus;
 use App\Models\Team;
-use App\Models\User;
 use App\Models\Todo;
 use App\Models\TodoCategory;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class MitgliederKarteControllerTest extends TestCase
 {
@@ -18,6 +19,7 @@ class MitgliederKarteControllerTest extends TestCase
         $team = Team::where('name', 'Mitglieder')->first();
         $user = User::factory()->create(['current_team_id' => $team->id]);
         $team->users()->attach($user, ['role' => $role]);
+
         return $user;
     }
 
@@ -25,6 +27,7 @@ class MitgliederKarteControllerTest extends TestCase
     {
         $team = Team::where('name', 'Mitglieder')->first();
         $category = TodoCategory::first() ?? TodoCategory::create(['name' => 'Test', 'slug' => 'test']);
+
         return Todo::create(array_merge([
             'team_id' => $team->id,
             'created_by' => $creator->id,
@@ -32,7 +35,7 @@ class MitgliederKarteControllerTest extends TestCase
             'description' => 'desc',
             'points' => 5,
             'category_id' => $category->id,
-            'status' => 'open',
+            'status' => TodoStatus::Open->value,
         ], $attrs));
     }
 
@@ -46,21 +49,21 @@ class MitgliederKarteControllerTest extends TestCase
 
         $response->assertRedirect(route('todos.show', $todo, false));
         $todo->refresh();
-        $this->assertSame('assigned', $todo->status);
+        $this->assertSame(TodoStatus::Assigned, $todo->status);
         $this->assertSame($user->id, $todo->assigned_to);
     }
 
     public function test_assigned_user_can_complete_todo(): void
     {
         $user = $this->actingMember();
-        $todo = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => 'assigned']);
+        $todo = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => TodoStatus::Assigned->value]);
         $this->actingAs($user);
 
         $response = $this->post(route('todos.complete', $todo));
 
         $response->assertRedirect(route('todos.show', $todo, false));
         $todo->refresh();
-        $this->assertSame('completed', $todo->status);
+        $this->assertSame(TodoStatus::Completed, $todo->status);
         $this->assertNotNull($todo->completed_at);
     }
 
@@ -70,7 +73,7 @@ class MitgliederKarteControllerTest extends TestCase
         $admin = $this->actingMember('Admin');
         $todo = $this->createTodo($admin, [
             'assigned_to' => $assignee->id,
-            'status' => 'completed',
+            'status' => TodoStatus::Completed->value,
             'completed_at' => now(),
         ]);
         $this->actingAs($admin);
@@ -79,7 +82,7 @@ class MitgliederKarteControllerTest extends TestCase
 
         $response->assertRedirect(route('todos.show', $todo, false));
         $todo->refresh();
-        $this->assertSame('verified', $todo->status);
+        $this->assertSame(TodoStatus::Verified, $todo->status);
         $this->assertSame($admin->id, $todo->verified_by);
         $this->assertDatabaseHas('user_points', [
             'user_id' => $assignee->id,
@@ -91,7 +94,7 @@ class MitgliederKarteControllerTest extends TestCase
     public function test_assigned_user_can_release_todo(): void
     {
         $user = $this->actingMember();
-        $todo = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => 'assigned']);
+        $todo = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => TodoStatus::Assigned->value]);
         $this->actingAs($user);
 
         $response = $this->post(route('todos.release', $todo));
@@ -99,6 +102,6 @@ class MitgliederKarteControllerTest extends TestCase
         $response->assertRedirect(route('todos.index', [], false));
         $todo->refresh();
         $this->assertNull($todo->assigned_to);
-        $this->assertSame('open', $todo->status);
+        $this->assertSame(TodoStatus::Open, $todo->status);
     }
 }

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
+use App\Enums\TodoStatus;
 use App\Models\Team;
-use App\Models\User;
 use App\Models\Todo;
 use App\Models\TodoCategory;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class TodoControllerTest extends TestCase
 {
@@ -18,6 +19,7 @@ class TodoControllerTest extends TestCase
         $team = Team::where('name', 'Mitglieder')->first();
         $user = User::factory()->create(['current_team_id' => $team->id]);
         $team->users()->attach($user, ['role' => $role]);
+
         return $user;
     }
 
@@ -25,6 +27,7 @@ class TodoControllerTest extends TestCase
     {
         $team = Team::where('name', 'Mitglieder')->first();
         $category = TodoCategory::first() ?? TodoCategory::create(['name' => 'Test', 'slug' => 'test']);
+
         return Todo::create(array_merge([
             'team_id' => $team->id,
             'created_by' => $creator->id,
@@ -32,7 +35,7 @@ class TodoControllerTest extends TestCase
             'description' => 'desc',
             'points' => 5,
             'category_id' => $category->id,
-            'status' => 'open',
+            'status' => TodoStatus::Open->value,
         ], $attrs));
     }
 
@@ -46,21 +49,21 @@ class TodoControllerTest extends TestCase
 
         $response->assertRedirect(route('todos.show', $todo, false));
         $todo->refresh();
-        $this->assertSame('assigned', $todo->status);
+        $this->assertSame(TodoStatus::Assigned, $todo->status);
         $this->assertSame($user->id, $todo->assigned_to);
     }
 
     public function test_assigned_user_can_complete_todo(): void
     {
         $user = $this->actingMember();
-        $todo = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => 'assigned']);
+        $todo = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => TodoStatus::Assigned->value]);
         $this->actingAs($user);
 
         $response = $this->post(route('todos.complete', $todo));
 
         $response->assertRedirect(route('todos.show', $todo, false));
         $todo->refresh();
-        $this->assertSame('completed', $todo->status);
+        $this->assertSame(TodoStatus::Completed, $todo->status);
         $this->assertNotNull($todo->completed_at);
     }
 
@@ -70,7 +73,7 @@ class TodoControllerTest extends TestCase
         $admin = $this->actingMember('Admin');
         $todo = $this->createTodo($admin, [
             'assigned_to' => $assignee->id,
-            'status' => 'completed',
+            'status' => TodoStatus::Completed->value,
             'completed_at' => now(),
         ]);
         $this->actingAs($admin);
@@ -79,7 +82,7 @@ class TodoControllerTest extends TestCase
 
         $response->assertRedirect(route('todos.show', $todo, false));
         $todo->refresh();
-        $this->assertSame('verified', $todo->status);
+        $this->assertSame(TodoStatus::Verified, $todo->status);
         $this->assertSame($admin->id, $todo->verified_by);
         $this->assertDatabaseHas('user_points', [
             'user_id' => $assignee->id,
@@ -94,7 +97,7 @@ class TodoControllerTest extends TestCase
         $admin = $this->actingMember('Admin');
         $todo = $this->createTodo($admin, [
             'assigned_to' => $assignee->id,
-            'status' => 'completed',
+            'status' => TodoStatus::Completed->value,
             'completed_at' => now(),
         ]);
         $member = $this->actingMember();
@@ -103,14 +106,14 @@ class TodoControllerTest extends TestCase
         $this->post(route('todos.verify', $todo))->assertForbidden();
 
         $todo->refresh();
-        $this->assertSame('completed', $todo->status);
+        $this->assertSame(TodoStatus::Completed, $todo->status);
         $this->assertNull($todo->verified_by);
     }
 
     public function test_assigned_user_can_release_todo(): void
     {
         $user = $this->actingMember();
-        $todo = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => 'assigned']);
+        $todo = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => TodoStatus::Assigned->value]);
         $this->actingAs($user);
 
         $response = $this->post(route('todos.release', $todo));
@@ -118,7 +121,7 @@ class TodoControllerTest extends TestCase
         $response->assertRedirect(route('todos.index', [], false));
         $todo->refresh();
         $this->assertNull($todo->assigned_to);
-        $this->assertSame('open', $todo->status);
+        $this->assertSame(TodoStatus::Open, $todo->status);
     }
 
     public function test_creator_can_update_todo(): void


### PR DESCRIPTION
## Summary
- replace enum columns with string fields across migrations
- add TodoStatus, KassenbuchEntryType, and AudiobookEpisodeStatus enums and cast models
- adjust controllers, views, and tests to use new enum-backed strings

## Testing
- `DB_CONNECTION=sqlite DB_DATABASE=':memory:' ./vendor/bin/phpunit tests/Feature/TodoControllerTest.php` *(fails: HTTP request returned status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd616c6edc832ea74f0f5064feaf62