### PR TITLE
Use SQLite for Laravel feature tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Directory Permissions
       run: chmod -R 755 storage bootstrap/cache
     - name: Create SQLite database
-      run: touch database/database.sqlite
+      run: mkdir -p database && touch database/database.sqlite
     - name: Run migrations
       run: php artisan migrate --force
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -18,24 +18,9 @@ jobs:
       matrix:
         php-version: ['8.2', '8.3', '8.4']
     
-    services:
-      mysql:
-        image: mysql:8
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: false
-          MYSQL_ROOT_PASSWORD: password
-          MYSQL_DATABASE: laravel_testing
-        ports:
-          - "3306:3306"
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
     env:
-      DB_CONNECTION: mysql
-      DB_HOST: 127.0.0.1
-      DB_PORT: 3306
-      DB_DATABASE: laravel_testing
-      DB_USERNAME: root
-      DB_PASSWORD: password
+      DB_CONNECTION: sqlite
+      DB_DATABASE: database/database.sqlite
 
     name: PHP ${{ matrix.php-version }} - Feature Tests
     
@@ -47,7 +32,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
-        extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, pdo_mysql, xdebug
+        extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, xdebug
         coverage: xdebug
         tools: composer:v2
 
@@ -85,6 +70,8 @@ jobs:
 
     - name: Directory Permissions
       run: chmod -R 755 storage bootstrap/cache
+    - name: Create SQLite database
+      run: touch database/database.sqlite
     - name: Run migrations
       run: php artisan migrate --force
 


### PR DESCRIPTION
This pull request updates the unit test workflow configuration to use SQLite instead of MySQL for running tests in GitHub Actions. This change simplifies the setup by removing the need for a MySQL service and related environment variables, and ensures the SQLite database file is created before running migrations.

**Migration from MySQL to SQLite for Unit Tests:**

* Removed the MySQL service configuration and all related environment variables from `.github/workflows/unittests.yml`, switching the test database to SQLite and updating the relevant environment variables.
* Removed the `pdo_mysql` PHP extension from the list of installed extensions, since MySQL is no longer required for testing.
* Added a step to create the SQLite database file (`database/database.sqlite`) before running migrations, ensuring the database exists for the tests.