### PR TITLE
Fix completed todos filtering for sqlite tests

### DIFF
--- a/app/Http/Controllers/TodoController.php
+++ b/app/Http/Controllers/TodoController.php
@@ -53,8 +53,10 @@ class TodoController extends Controller
 
         $assignedTodos = $todos->where('assigned_to', $user->id);
         $unassignedTodos = $todos->where('status', 'open');
-        $completedTodos = $todos->whereIn('status', ['completed', 'verified'])
-            ->where('assigned_to', '!=', $user->id);
+        $completedTodos = $todos->filter(fn ($todo) =>
+            in_array($todo->status->value, ['completed', 'verified'], true) &&
+            $todo->assigned_to !== $user->id
+        );
 
         $userPoints = UserPoint::where('user_id', $user->id)
             ->where('team_id', $memberTeam->id)


### PR DESCRIPTION
This pull request updates the logic for filtering completed todos in the `index` method of `TodoController.php`. The main change is switching from Eloquent's query builder methods to using a collection filter for determining completed todos not assigned to the current user.

**Todo filtering logic update:**

* Replaced the use of `whereIn` and `where` query builder methods with a collection `filter` to identify completed or verified todos that are not assigned to the current user in the `index` method of `TodoController.php`.