### PR TITLE
Use persistent SQLite database for GitHub Actions tests

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,7 +21,7 @@ jobs:
     
     env:
       DB_CONNECTION: sqlite
-      DB_DATABASE: ':memory:'
+      DB_DATABASE: database/database.sqlite
       BROADCAST_DRIVER: log
       CACHE_DRIVER: array
       QUEUE_CONNECTION: sync
@@ -67,6 +67,11 @@ jobs:
 
     - name: Build assets
       run: npm run build
+
+    - name: Prepare database file
+      run: |
+        mkdir -p database
+        touch database/database.sqlite
 
     - name: Prepare Laravel Application
       run: |
@@ -129,7 +134,7 @@ jobs:
     
     env:
       DB_CONNECTION: sqlite
-      DB_DATABASE: ':memory:'
+      DB_DATABASE: database/database.sqlite
       BROADCAST_DRIVER: log
       CACHE_DRIVER: array
       QUEUE_CONNECTION: sync
@@ -163,6 +168,11 @@ jobs:
 
     - name: Install Composer dependencies
       run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
+
+    - name: Prepare database file
+      run: |
+        mkdir -p database
+        touch database/database.sqlite
 
     - name: Prepare Laravel Application
       run: |


### PR DESCRIPTION
This pull request updates the PHPUnit GitHub Actions workflow to use a file-based SQLite database instead of an in-memory database. The main changes involve updating environment variables and adding steps to ensure the database file exists before running tests.

Database configuration updates:

* Changed the `DB_DATABASE` environment variable from `':memory:'` to `database/database.sqlite` to use a file-based SQLite database for both workflow jobs. [[1]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L24-R24) [[2]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L132-R137)

Workflow preparation steps:

* Added a step to create the `database` directory and the `database.sqlite` file before preparing the Laravel application in both workflow jobs, ensuring the database file exists for the tests. [[1]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510R71-R75) [[2]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510R172-R176)