### PR TITLE
fix: generate app key during phpunit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Prepare Laravel Application
       run: |
         cp .env.testing .env 2>/dev/null || cp .env.example .env
-        php artisan key:generate
+        php artisan key:generate --env=testing
         chmod -R 755 storage bootstrap/cache
 
     - name: Execute tests
@@ -177,7 +177,7 @@ jobs:
     - name: Prepare Laravel Application
       run: |
         cp .env.testing .env 2>/dev/null || cp .env.example .env
-        php artisan key:generate
+        php artisan key:generate --env=testing
         chmod -R 755 storage bootstrap/cache
 
     - name: Execute tests


### PR DESCRIPTION
This pull request makes a minor but important update to the PHPUnit GitHub Actions workflow. The change ensures the Laravel application key is generated specifically for the testing environment, which can help avoid configuration issues during automated test runs.

- Updated the `php artisan key:generate` command to explicitly use the `--env=testing` flag in the `.github/workflows/phpunit.yml` workflow file. [[1]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L79-R79) [[2]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L180-R180)