### PR TITLE
Fix footer version test to respect app config

### DIFF
--- a/tests/Feature/FooterVersionTest.php
+++ b/tests/Feature/FooterVersionTest.php
@@ -12,11 +12,11 @@ class FooterVersionTest extends TestCase
 
     public function test_footer_displays_version_and_changelog_link(): void
     {
-        $version = config('app.version');
+        config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
 
-        if ($version === null || $version === '0.0.0') {
-            $version = '0.0.0';
+        $version = config('app.version', '0.0.0');
 
+        if ($version === '0.0.0') {
             $revList = Process::run(['git', 'rev-list', '--tags', '--max-count=1']);
 
             if ($revList->successful()) {
@@ -26,7 +26,11 @@ class FooterVersionTest extends TestCase
                     $describe = Process::run(['git', 'describe', '--tags', $commit]);
 
                     if ($describe->successful()) {
-                        $version = trim($describe->output());
+                        $gitVersion = trim($describe->output());
+
+                        if ($gitVersion !== '') {
+                            $version = $gitVersion;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This pull request updates the `FooterVersionTest` to ensure the application version is correctly set for testing, even when the configuration value is missing or set to a default placeholder. The main change is to improve the reliability of the test by handling cases where the version is not explicitly defined.

Test robustness improvements:

* In `tests/Feature/FooterVersionTest.php`, updated the `test_footer_displays_version_and_changelog_link` method to check if `config('app.version')` is `null` or `'0.0.0'`, and only then run the logic to determine the version from git tags, ensuring the test works correctly regardless of the configuration state. [[1]](diffhunk://#diff-5162b51c51b8036907d07d36883a59ac1077dfea6a155145da31504f2d67dc9bR15-R17) [[2]](diffhunk://#diff-5162b51c51b8036907d07d36883a59ac1077dfea6a155145da31504f2d67dc9bR33)