### PR TITLE
chore: streamline CI workflows

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -41,12 +41,6 @@ jobs:
         coverage: none
         tools: composer:v2
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v5
-      with:
-        node-version: '22'
-        cache: 'npm'
-
     - name: Get composer cache directory
       id: composer-cache
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
@@ -62,11 +56,6 @@ jobs:
     - name: Install Composer dependencies
       run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
 
-    - name: Install NPM dependencies
-      run: npm ci
-
-    - name: Build assets
-      run: npm run build
 
     - name: Prepare database file
       run: |
@@ -87,18 +76,9 @@ jobs:
       run: |
         php -dxdebug.mode=coverage artisan test tests/Feature --coverage-clover=coverage.xml
 
-    - name: Run Jest tests with coverage
+    - name: Prepare coverage output directory
       if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
-      run: npm test -- --coverage --coverageReporters=json-summary --coverageDirectory=coverage
-
-    - name: Create JS coverage badge
-      if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'
-      run: |
-        mkdir -p output
-        if [ -f "coverage/coverage-summary.json" ]; then
-          npx --yes make-coverage-badge --report-path=coverage/coverage-summary.json --output-path=output/js-coverage.svg
-          sed -i 's/Coverage/JS Coverage/' output/js-coverage.svg
-        fi
+      run: mkdir -p output
 
     - name: Create PHP coverage badge
       if: matrix.php-version == '8.3' && github.ref == 'refs/heads/main'

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Install NPM dependencies
         run: npm ci
+      - name: Build assets
+        run: npm run build
 
       - name: Run Vitest unit tests
         run: npm run test:vitest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both PHPUnit and Vitest to streamline dependency installation and asset building. The most significant changes involve removing Node.js and NPM steps from the PHPUnit workflow, while ensuring asset building is included where needed.

**PHPUnit Workflow Simplification:**

* Removed Node.js setup and all NPM-related steps, including installing NPM dependencies, building assets, and running Jest tests with coverage from `.github/workflows/phpunit.yml`. This makes the PHPUnit workflow focus solely on PHP-related tasks. [[1]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L44-L49) [[2]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L65-L69) [[3]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L90-R81)

**Vitest Workflow Improvement:**

* Added an explicit asset build step (`npm run build`) after installing NPM dependencies in `.github/workflows/vitest.yml`, ensuring that assets are properly built before running Vitest unit tests.