### PR TITLE
ci: cache npm dependencies and skip composer scripts

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -45,7 +45,18 @@ jobs:
       uses: actions/setup-node@v5
       with:
         node-version: '22'
-        cache: 'npm'
+
+    - name: Get npm cache directory
+      id: npm-cache
+      run: echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+
+    - name: Cache npm dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
 
     - name: Get composer cache directory
       id: composer-cache
@@ -60,7 +71,7 @@ jobs:
           ${{ runner.os }}-php-${{ matrix.php-version }}-composer-
 
     - name: Install Composer dependencies
-      run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
+      run: composer install --no-progress --prefer-dist --no-scripts --optimize-autoloader --no-interaction
 
     - name: Install NPM dependencies
       run: npm ci
@@ -167,7 +178,7 @@ jobs:
           ${{ runner.os }}-php-${{ matrix.php-version }}-composer-
 
     - name: Install Composer dependencies
-      run: composer install --no-progress --prefer-dist --optimize-autoloader --no-interaction
+      run: composer install --no-progress --prefer-dist --no-scripts --optimize-autoloader --no-interaction
 
     - name: Prepare database file
       run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for PHPUnit to improve dependency caching and Composer installation steps. The main focus is on optimizing CI performance and reliability.

Dependency caching improvements:
* Added steps to cache npm dependencies using the `actions/cache` action, which should speed up future workflow runs by reusing previously installed npm packages.

Composer installation changes:
* Updated the Composer install command to include the `--no-scripts` flag, preventing Composer scripts from running during dependency installation. This change was applied in both relevant job steps. [[1]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L63-R74) [[2]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L170-R181)