### PR TITLE
chore: ensure app key for tests

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -24,7 +24,9 @@ jobs:
     - name: Install Dependencies
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
     - name: Generate key
-      run: php artisan key:generate
+      run: |
+        php artisan key:generate
+        php artisan key:generate --env=testing
     - name: Directory Permissions
       run: chmod -R 777 storage bootstrap/cache
     - name: Create Database


### PR DESCRIPTION
This pull request makes a small change to the PHPUnit GitHub Actions workflow to ensure the application key is generated for both the default and testing environments.

* Updated the "Generate key" step in `.github/workflows/phpunit.yml` to run `php artisan key:generate` for both the default and `testing` environments, improving environment setup reliability.