### PR TITLE
Mock Nominatim requests in tests

### DIFF
--- a/tests/Feature/MitgliederKarteFeatureTest.php
+++ b/tests/Feature/MitgliederKarteFeatureTest.php
@@ -38,7 +38,7 @@ class MitgliederKarteFeatureTest extends TestCase
     {
         Cache::flush();
         $count = 0;
-        $responses = ['12345' => ['lat' => '48.0', 'lon' => '11.0']];
+        $responses = ['12345' => ['lat' => self::DEFAULT_LAT, 'lon' => self::DEFAULT_LON]];
         Http::swap(new \Illuminate\Http\Client\Factory());
         Http::fake([
             'nominatim.openstreetmap.org/*' => function ($request) use (&$count, $responses) {
@@ -97,7 +97,7 @@ class MitgliederKarteFeatureTest extends TestCase
         Cache::flush();
         Http::swap(new \Illuminate\Http\Client\Factory());
         Http::fake([
-            'nominatim.openstreetmap.org/*' => Http::response([['lat' => '48.0', 'lon' => '11.0']], 200),
+            'nominatim.openstreetmap.org/*' => Http::response([['lat' => self::DEFAULT_LAT, 'lon' => self::DEFAULT_LON]], 200),
         ]);
 
         $user = $this->actingMember('Mitglied', ['plz' => '12345', 'land' => 'Deutschland']);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,14 +7,20 @@ use Illuminate\Support\Facades\Http;
 
 abstract class TestCase extends BaseTestCase
 {
+    /**
+     * Default coordinates used for stubbed Nominatim responses (Munich).
+     */
+    protected const DEFAULT_LAT = '48.0';
+    protected const DEFAULT_LON = '11.0';
+
     protected function setUp(): void
     {
         parent::setUp();
 
         Http::fake([
             'nominatim.openstreetmap.org/*' => Http::response([[
-                'lat' => '48.0',
-                'lon' => '11.0',
+                'lat' => self::DEFAULT_LAT,
+                'lon' => self::DEFAULT_LON,
             ]], 200),
         ]);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,8 +3,19 @@
 namespace Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Http;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Http::fake([
+            'nominatim.openstreetmap.org/*' => Http::response([[
+                'lat' => '48.0',
+                'lon' => '11.0',
+            ]], 200),
+        ]);
+    }
 }


### PR DESCRIPTION
This pull request refactors how HTTP requests are faked in feature tests involving map data and member coordinates. The main improvement is centralizing the default HTTP fake response setup in the base `TestCase`, while ensuring that individual tests can still override or customize HTTP fakes as needed. This leads to more maintainable and predictable test behavior.

**Testing improvements:**

* Added a `setUp()` method in `tests/TestCase.php` to provide a default HTTP fake for requests to `nominatim.openstreetmap.org`, returning a standard latitude and longitude.

* Updated tests in `MitgliederKarteFeatureTest.php` to explicitly reset the HTTP client and apply their own specific fakes when needed, ensuring that test-specific HTTP responses are used and not overridden by the global setup. [[1]](diffhunk://#diff-d3ac7e081fc0b095b2c173364ec7b7a8d99158e6d1db3e337221e3459f8b0983L42-R50) [[2]](diffhunk://#diff-d3ac7e081fc0b095b2c173364ec7b7a8d99158e6d1db3e337221e3459f8b0983L67-R77) [[3]](diffhunk://#diff-d3ac7e081fc0b095b2c173364ec7b7a8d99158e6d1db3e337221e3459f8b0983L92-R101)