### PR TITLE
Skip Vite asset lookup during tests

### DIFF
--- a/resources/views/components/application-mark.blade.php
+++ b/resources/views/components/application-mark.blade.php
@@ -1,1 +1,8 @@
-<img src="{{ Vite::asset('resources/images/omxfc-logo.png') }}" alt="{{ config('app.name') }}" class="h-9 w-auto">
+@php
+    try {
+        $logo = Vite::asset('resources/images/omxfc-logo.png');
+    } catch (Throwable $e) {
+        $logo = asset('resources/images/omxfc-logo.png');
+    }
+@endphp
+<img src="{{ $logo }}" alt="{{ config('app.name') }}" class="h-9 w-auto">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -27,7 +27,9 @@
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
     <!-- Styles (NUR CSS) -->
-    @vite(['resources/css/app.css'])
+    @unless(app()->environment('testing'))
+        @vite(['resources/css/app.css'])
+    @endunless
     @livewireStyles
 </head>
 
@@ -60,6 +62,8 @@
     @stack('modals')
 
     <!-- Alpine/JS -->
-    @vite(['resources/js/app.js'])
+    @unless(app()->environment('testing'))
+        @vite(['resources/js/app.js'])
+    @endunless
 </body>
 </html>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -22,7 +22,9 @@
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @unless(app()->environment('testing'))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endunless
 
         <!-- Styles -->
         @livewireStyles


### PR DESCRIPTION
This pull request improves how frontend assets are loaded in Blade templates, especially to better support the testing environment. The main changes ensure that Vite asset loading is skipped during tests and that asset fallback is handled gracefully if Vite is unavailable.

Asset loading improvements:

* Added conditional logic to `resources/views/layouts/app.blade.php` and `resources/views/layouts/guest.blade.php` to prevent loading Vite-managed CSS and JS assets when the application is running in the `testing` environment. This avoids issues during automated tests. [[1]](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7R30-R32) [[2]](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7R65-R67) [[3]](diffhunk://#diff-05ed95a005677b19cdca1e1e1371e90fca89f16d7284070225931eee6ddc2f41R25-R27)

Asset fallback handling:

* Updated `resources/views/components/application-mark.blade.php` to use a try/catch block when loading the logo asset via Vite, falling back to the standard `asset()` helper if Vite fails. This ensures the logo is always displayed even if Vite is not available (e.g., in production or during tests).