### PR TITLE
Build Vite assets during CI

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -33,6 +33,15 @@ jobs:
       run: |
         mkdir -p database
         touch database/database.sqlite
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+    - name: Install NPM dependencies
+      run: npm ci
+    - name: Build assets
+      run: npm run build
     - name: Execute tests (Unit and Feature tests) via PHPUnit/Pest
       env:
         DB_CONNECTION: sqlite
@@ -132,5 +141,14 @@ jobs:
         php artisan key:generate --env=testing
         chmod -R 755 storage bootstrap/cache
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+    - name: Install NPM dependencies
+      run: npm ci
+    - name: Build assets
+      run: npm run build
     - name: Execute tests
       run: php artisan test tests/Feature


### PR DESCRIPTION
## Summary
- install Node.js and npm dependencies in phpunit workflow
- build Vite assets before running tests to ensure manifest exists

## Testing
- `npm ci`
- `npm run build`
- `php artisan test tests/Feature/ProfileEhrenmitgliedSettingTest.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf9972a190832eacffcd0f846b668a