### PR TITLE
Seed default data for tests

### DIFF
--- a/tests/Feature/MitgliederKarteFeatureTest.php
+++ b/tests/Feature/MitgliederKarteFeatureTest.php
@@ -88,7 +88,11 @@ class MitgliederKarteFeatureTest extends TestCase
         $memberCenterLat = $response->viewData('membersCenterLat');
         $memberCenterLon = $response->viewData('membersCenterLon');
 
-        $this->assertEqualsWithDelta(51.6666666667, $memberCenterLat, 0.0001);
+        // The seeded admin user has coordinates (48.0, 11.0) provided by the
+        // default HTTP stubs in the test case. Together with the two members
+        // created above (50/8 and 52/10), the expected center is the average
+        // of all three sets of coordinates.
+        $this->assertEqualsWithDelta(50.0, $memberCenterLat, 0.0001);
         $this->assertEqualsWithDelta(9.6666666667, $memberCenterLon, 0.0001);
     }
 

--- a/tests/Feature/ProfileInformationTest.php
+++ b/tests/Feature/ProfileInformationTest.php
@@ -38,12 +38,12 @@ class ProfileInformationTest extends TestCase
                 'land' => 'Deutschland',
                 'telefon' => '01234',
                 'mitgliedsbeitrag' => 12.00,
-                'email' => 'test@example.com',
+                'email' => 'new@example.com',
             ])
             ->call('updateProfileInformation');
 
         $this->assertEquals('Test', $user->fresh()->vorname);
         $this->assertEquals('Name', $user->fresh()->nachname);
-        $this->assertEquals('test@example.com', $user->fresh()->email);
+        $this->assertEquals('new@example.com', $user->fresh()->email);
     }
 }

--- a/tests/Feature/ProfileViewControllerTest.php
+++ b/tests/Feature/ProfileViewControllerTest.php
@@ -148,8 +148,14 @@ class ProfileViewControllerTest extends TestCase
         $admin = $this->createMember('Admin');
         $member = $this->createMember();
 
-        $general = TodoCategory::create(['name' => 'General', 'slug' => Str::slug('General')]);
-        $maddraxikon = TodoCategory::create(['name' => 'AG Maddraxikon', 'slug' => Str::slug('AG Maddraxikon')]);
+        $general = TodoCategory::firstOrCreate(
+            ['slug' => Str::slug('General')],
+            ['name' => 'General']
+        );
+        $maddraxikon = TodoCategory::firstOrCreate(
+            ['slug' => Str::slug('AG Maddraxikon')],
+            ['name' => 'AG Maddraxikon']
+        );
 
         $this->createTodoWithPoints($member, $general, 5);
         $this->createTodoWithPoints($member, $maddraxikon, 3);

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -37,7 +37,8 @@ class RegistrationTest extends TestCase
             'plz' => '12345',
             'stadt' => 'Teststadt',
             'land' => 'Deutschland',
-            'mail' => 'test@example.com',
+            // Use a unique email to avoid clashing with seeded users
+            'mail' => 'newuser@example.com',
             'passwort' => 'password',
             'passwort_confirmation' => 'password',
             'mitgliedsbeitrag' => 12.00,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,6 +13,7 @@ abstract class TestCase extends BaseTestCase
     protected const DEFAULT_LAT = '48.0';
     protected const DEFAULT_LON = '11.0';
 
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -23,5 +24,10 @@ abstract class TestCase extends BaseTestCase
                 'lon' => self::DEFAULT_LON,
             ]], 200),
         ]);
+
+        // Seed the database so default entities such as the "Mitglieder" team
+        // are available to the tests. Seeding occurs after HTTP calls are
+        // faked to avoid real network requests.
+        $this->seed();
     }
 }


### PR DESCRIPTION
This pull request primarily updates and improves the test suite for user profile, registration, and member-related features. The main changes ensure test reliability by using unique test data, clarify test expectations, and improve test setup to avoid side effects from network calls. Below are the most important changes grouped by theme:

**Test Data Consistency and Reliability:**

* Updated registration and profile update tests to use unique email addresses, preventing conflicts with seeded users and ensuring tests are isolated. [[1]](diffhunk://#diff-cf20a0c15dacdcb11cf6a69fb582160dc4dee713a3303419610b48ffaa8b0ce9L40-R41) [[2]](diffhunk://#diff-cb1107d11f3cda960df1ea711a6c245c8770060b27e6b4c09dacfdaf1ffd19e1L41-R47)
* Changed the expected member center latitude in `MitgliederKarteFeatureTest` to account for the seeded admin user, clarifying the test logic and expected outcome.

**Test Setup Improvements:**

* Modified the test case setup to seed the database after HTTP calls are faked, ensuring that required entities exist for tests without triggering real network requests.
* Added a blank line for readability in the `TestCase` class.

**Test Robustness:**

* Switched from `create` to `firstOrCreate` for `TodoCategory` in `ProfileViewControllerTest` to prevent duplicate category creation and make tests idempotent.