### PR TITLE
Compare enums directly in todo tests

### DIFF
--- a/tests/Feature/ActivityFeedTest.php
+++ b/tests/Feature/ActivityFeedTest.php
@@ -15,6 +15,7 @@ use App\Models\Todo;
 use App\Models\TodoCategory;
 use App\Models\ReviewComment;
 use App\Enums\BookType;
+use App\Enums\TodoStatus;
 use Illuminate\Support\Facades\Mail;
 
 class ActivityFeedTest extends TestCase
@@ -197,10 +198,13 @@ class ActivityFeedTest extends TestCase
             'title' => 'Challenge',
             'points' => 5,
             'category_id' => $category->id,
-            'status' => 'open',
+            'status' => TodoStatus::Open->value,
         ]);
 
         $this->post(route('todos.assign', $todo));
+
+        $todo->refresh();
+        $this->assertSame(TodoStatus::Assigned, $todo->status);
 
         $this->assertDatabaseHas('activities', [
             'user_id' => $user->id,
@@ -222,11 +226,14 @@ class ActivityFeedTest extends TestCase
             'title' => 'Challenge',
             'points' => 5,
             'category_id' => $category->id,
-            'status' => 'completed',
+            'status' => TodoStatus::Completed->value,
             'completed_at' => now(),
         ]);
 
         $this->actingAs($admin)->post(route('todos.verify', $todo));
+
+        $todo->refresh();
+        $this->assertSame(TodoStatus::Verified, $todo->status);
 
         $this->assertDatabaseHas('activities', [
             'user_id' => $assignee->id,

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -8,6 +8,7 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Support\Facades\Mail;
 use App\Mail\MitgliedGenehmigtMail;
+use App\Enums\TodoStatus;
 
 class DashboardControllerTest extends TestCase
 {
@@ -101,7 +102,7 @@ class DashboardControllerTest extends TestCase
             'created_by' => $admin->id,
             'title' => 'Open',
             'points' => 5,
-            'status' => 'open',
+            'status' => TodoStatus::Open->value,
             'category_id' => $category->id,
         ]);
         \App\Models\Todo::create([
@@ -109,7 +110,7 @@ class DashboardControllerTest extends TestCase
             'created_by' => $admin->id,
             'title' => 'Pending',
             'points' => 3,
-            'status' => 'completed',
+            'status' => TodoStatus::Completed->value,
             'category_id' => $category->id,
         ]);
 

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -169,8 +169,8 @@ class TodoControllerTest extends TestCase
         $user = $this->actingMember();
         $other = $this->actingMember();
         $todoOpen = $this->createTodo($user);
-        $todoAssigned = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => 'assigned']);
-        $todoCompleted = $this->createTodo($user, ['assigned_to' => $other->id, 'status' => 'completed']);
+        $todoAssigned = $this->createTodo($user, ['assigned_to' => $user->id, 'status' => TodoStatus::Assigned->value]);
+        $todoCompleted = $this->createTodo($user, ['assigned_to' => $other->id, 'status' => TodoStatus::Completed->value]);
 
         \App\Models\UserPoint::create([
             'user_id' => $user->id,


### PR DESCRIPTION
This pull request updates test assertions in `tests/Feature/TodoControllerTest.php` to directly compare the `TodoStatus` enum instances rather than their `value` properties. This change helps ensure that the tests are accurately verifying the enum type, not just the underlying value.

Test assertion improvements:

* Updated assertions in `test_member_can_assign_todo` and `test_assigned_user_can_complete_todo` to compare the `TodoStatus` enum objects directly instead of their `value` properties. [[1]](diffhunk://#diff-669cfc3d38315de73b5673ec24d0cd9fd372b85892c838739f395885b034fef7L52-R52) [[2]](diffhunk://#diff-669cfc3d38315de73b5673ec24d0cd9fd372b85892c838739f395885b034fef7L66-R66)