### PR TITLE
AG leaders can add members with Mitwirkender role

### DIFF
--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -66,6 +66,10 @@ class JetstreamServiceProvider extends ServiceProvider
             'read',
         ])->description('Bestätigtes Vereinsmitglied.');
 
+        Jetstream::role('Mitwirkender', 'Mitwirkender', [
+            'read',
+        ])->description('Mitglied einer Arbeitsgruppe ohne Verwaltungsrechte.');
+
         Jetstream::role('Ehrenmitglied', 'Ehrenmitglied', [
             'read',
         ])->description('Ehrenmitglied mit denselben Zugriffsrechten wie ein reguläres Mitglied.');

--- a/resources/views/arbeitsgruppen/edit.blade.php
+++ b/resources/views/arbeitsgruppen/edit.blade.php
@@ -71,6 +71,26 @@
                     <button type="submit" class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#8B0116] dark:focus:ring-[#FF6B81]">Speichern</button>
                 </div>
             </form>
+
+            <div class="mt-6">
+                <h3 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">Mitglieder</h3>
+                <ul class="mb-4 list-disc list-inside">
+                    @foreach($team->users as $member)
+                        <li class="text-gray-700 dark:text-gray-300">{{ $member->name }}</li>
+                    @endforeach
+                </ul>
+
+                @can('addTeamMember', $team)
+                    <form action="{{ route('arbeitsgruppen.add-member', $team) }}" method="POST" class="flex flex-col sm:flex-row sm:items-center gap-2">
+                        @csrf
+                        <input type="email" name="email" placeholder="E-Mail des Mitglieds" required class="flex-1 rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50">
+                        <button type="submit" class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#8B0116] dark:focus:ring-[#FF6B81]">Hinzufügen</button>
+                    </form>
+                    @error('email', 'addTeamMember')
+                        <p class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                @endcan
+            </div>
         </div>
     </x-member-page>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -132,6 +132,7 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::post('/', 'store')->name('store');
         Route::get('{team}/bearbeiten', 'edit')->name('edit');
         Route::put('{team}', 'update')->name('update');
+        Route::post('{team}/mitglied-hinzufuegen', 'addMember')->name('add-member');
     });
 
     Route::get('/ag', [ArbeitsgruppenController::class, 'leaderIndex'])->name('ag.index');


### PR DESCRIPTION
This pull request introduces the ability to add members to an Arbeitsgruppe (AG) with the new "Mitwirkender" role, enforces a maximum of five members per AG, and updates both the UI and backend logic accordingly. It also includes tests to ensure correct behavior and permission enforcement.

**Feature: Add AG Members with Role and Limit**

* Added `addMember` method to `ArbeitsgruppenController` to allow AG leaders and admins to add members by email, assigning them the "Mitwirkender" role and enforcing a maximum of five members per AG.
* Registered a new route for adding members to an AG (`arbeitsgruppen.add-member`).
* Introduced the "Mitwirkender" role in Jetstream with appropriate permissions.

**UI/UX Improvements**

* Updated the AG edit view to display current members and provide a form for adding new members, including error handling for member addition.
* Ensured the edit page loads AG users for display.

**Testing and Validation**

* Added feature tests covering member addition, role assignment, enforcement of the five-member limit, and visibility of members.

**Dependency and Import Updates**

* Imported necessary Laravel and application classes for validation and member addition logic.