### PR TITLE
test: add tests for chronik and hoerbuecher

### DIFF
--- a/tests/Jest/chronik.test.js
+++ b/tests/Jest/chronik.test.js
@@ -1,0 +1,63 @@
+import { jest } from '@jest/globals';
+
+describe('chronik module', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '';
+  });
+
+  test('opens modal and populates sources on image click', async () => {
+    document.body.innerHTML = `
+      <div id="chronik-modal" class="hidden">
+        <picture>
+          <source id="chronik-modal-avif" />
+          <source id="chronik-modal-webp" />
+          <img id="chronik-modal-img" />
+        </picture>
+        <button id="chronik-modal-close"></button>
+      </div>
+      <a class="chronik-image" data-avif="a.avif" data-webp="b.webp"><img alt="alt text" /></a>
+    `;
+    await import('../../resources/js/chronik.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const trigger = document.querySelector('.chronik-image');
+    trigger.click();
+
+    const modal = document.getElementById('chronik-modal');
+    expect(modal.classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('chronik-modal-img').src).toContain('b.webp');
+    expect(document.getElementById('chronik-modal-avif').srcset).toBe('a.avif');
+    expect(document.getElementById('chronik-modal-webp').srcset).toBe('b.webp');
+  });
+
+  test('hides modal on overlay click and escape key', async () => {
+    document.body.innerHTML = `
+      <div id="chronik-modal" class="hidden">
+        <picture>
+          <source id="chronik-modal-avif" />
+          <source id="chronik-modal-webp" />
+          <img id="chronik-modal-img" />
+        </picture>
+        <button id="chronik-modal-close"></button>
+      </div>
+      <a class="chronik-image" data-avif="a.avif" data-webp="b.webp"><img alt="alt" /></a>
+    `;
+    await import('../../resources/js/chronik.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const trigger = document.querySelector('.chronik-image');
+    const modal = document.getElementById('chronik-modal');
+    trigger.click();
+    expect(modal.classList.contains('hidden')).toBe(false);
+
+    modal.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(modal.classList.contains('hidden')).toBe(true);
+
+    trigger.click();
+    expect(modal.classList.contains('hidden')).toBe(false);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(modal.classList.contains('hidden')).toBe(true);
+  });
+});
+

--- a/tests/Jest/hoerbuch-role-form.test.js
+++ b/tests/Jest/hoerbuch-role-form.test.js
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+
+describe('hoerbuch role form module', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({ speaker: 'Bob' }) })
+    );
+    window.roleFormData = {
+      members: [{ id: 1, name: 'Alice' }],
+      previousSpeakerUrl: '/prev',
+      roleIndex: 0,
+    };
+    document.body.innerHTML = `
+      <meta name="csrf-token" content="TOKEN" />
+      <div id="roles_list">
+        <div class="role-row">
+          <input type="text" list="members" />
+          <input type="hidden" />
+          <input type="text" name="roles[0][name]" />
+          <div class="previous-speaker"></div>
+          <button type="button"></button>
+        </div>
+      </div>
+      <datalist id="members"></datalist>
+      <button id="add_role"></button>
+    `;
+    await import('../../resources/js/hoerbuch-role-form.js');
+    fetch.mockClear();
+  });
+
+  afterEach(() => {
+    delete window.roleFormData;
+    delete global.fetch;
+  });
+
+  test('member input sets hidden member id', () => {
+    const memberInput = document.querySelector('input[list]');
+    const hidden = document.querySelector('input[type="hidden"]');
+    memberInput.value = 'Alice';
+    memberInput.dispatchEvent(new Event('input'));
+    expect(hidden.value).toBe('1');
+  });
+
+  test('role name blur fetches previous speaker and updates hint', async () => {
+    const roleNameInput = document.querySelector('input[name$="[name]"]');
+    const hint = document.querySelector('.previous-speaker');
+    roleNameInput.value = 'Hero';
+    roleNameInput.dispatchEvent(new Event('blur'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetch).toHaveBeenCalled();
+    const calledUrl = fetch.mock.calls[0][0];
+    expect(calledUrl.toString()).toContain('name=Hero');
+    await fetch.mock.results[0].value;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(hint.textContent).toBe('Bisheriger Sprecher: Bob');
+  });
+
+  test('add_role appends new role row', () => {
+    const addBtn = document.getElementById('add_role');
+    addBtn.click();
+    const rows = document.querySelectorAll('#roles_list .role-row');
+    expect(rows.length).toBe(2);
+  });
+});
+

--- a/tests/Jest/hoerbuecher.test.js
+++ b/tests/Jest/hoerbuecher.test.js
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+
+describe('hoerbuecher module', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <table>
+        <tr data-href="/1" data-status="done" data-type="A" data-year="2024" data-roles-filled="1" data-episode-id="1"></tr>
+        <tr data-href="/2" data-status="open" data-type="B" data-year="2023" data-roles-filled="0" data-episode-id="2"></tr>
+      </table>
+      <select id="status-filter"><option value=""></option><option value="open">open</option></select>
+      <select id="type-filter"><option value=""></option><option value="A">A</option><option value="B">B</option></select>
+      <select id="year-filter"><option value=""></option><option value="2023">2023</option></select>
+      <input type="checkbox" id="roles-filter" />
+      <input type="checkbox" id="roles-unfilled-filter" />
+      <div id="card-next-event" data-episode-id="2"></div>
+    `;
+    await import('../../resources/js/hoerbuecher.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  test('filters rows by status and type', () => {
+    const statusFilter = document.getElementById('status-filter');
+    statusFilter.value = 'open';
+    statusFilter.dispatchEvent(new Event('change'));
+
+    const rows = document.querySelectorAll('tr[data-href]');
+    expect(rows[0].style.display).toBe('none');
+    expect(rows[1].style.display).toBe('');
+
+    const typeFilter = document.getElementById('type-filter');
+    typeFilter.value = 'B';
+    typeFilter.dispatchEvent(new Event('change'));
+    expect(rows[1].style.display).toBe('');
+
+    typeFilter.value = 'A';
+    typeFilter.dispatchEvent(new Event('change'));
+    expect(rows[1].style.display).toBe('none');
+  });
+
+  test('roles and rolesUnfilled filters are mutually exclusive', () => {
+    const roles = document.getElementById('roles-filter');
+    const rolesUnfilled = document.getElementById('roles-unfilled-filter');
+
+    roles.checked = true;
+    roles.dispatchEvent(new Event('change'));
+    expect(rolesUnfilled.checked).toBe(false);
+    expect(rolesUnfilled.disabled).toBe(true);
+
+    roles.checked = false;
+    roles.dispatchEvent(new Event('change'));
+    expect(rolesUnfilled.disabled).toBe(false);
+
+    rolesUnfilled.checked = true;
+    rolesUnfilled.dispatchEvent(new Event('change'));
+    expect(roles.checked).toBe(false);
+    expect(roles.disabled).toBe(true);
+  });
+
+  test('clicking cardNextEvent filters only matching episode', () => {
+    const cardNextEvent = document.getElementById('card-next-event');
+    cardNextEvent.click();
+    const rows = document.querySelectorAll('tr[data-href]');
+    expect(rows[0].style.display).toBe('none');
+    expect(rows[1].style.display).toBe('');
+  });
+});
+


### PR DESCRIPTION
This pull request adds comprehensive Jest test suites for three frontend modules: `chronik.js`, `hoerbuch-role-form.js`, and `hoerbuecher.js`. The new tests cover user interactions and expected DOM updates, improving the reliability and maintainability of these modules.

**New Jest test suites:**

*Tests for modal image viewer:*
- Added tests for `chronik.js` to verify modal opening, source population, and closing behavior via overlay click and Escape key.

*Tests for role form functionality:*
- Added tests for `hoerbuch-role-form.js` to check member input handling, fetching and displaying previous speaker data on blur, and appending new role rows.

*Tests for audiobook table filtering:*
- Added tests for `hoerbuecher.js` to validate row filtering by status and type, mutual exclusivity of role filters, and filtering by episode via card click.