### PR TITLE
test: add coverage for app and changelog

### DIFF
--- a/tests/Jest/app.test.js
+++ b/tests/Jest/app.test.js
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+
+const originalMatchMedia = window.matchMedia;
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
+async function loadApp(matches) {
+  jest.resetModules();
+  document.documentElement.className = '';
+  let handler;
+  window.matchMedia = jest.fn().mockReturnValue({
+    matches,
+    addEventListener: (event, cb) => {
+      if (event === 'change') handler = cb;
+    },
+  });
+  await jest.unstable_mockModule('../../resources/js/bootstrap.js', () => ({}));
+  await jest.unstable_mockModule('../../resources/js/chronik.js', () => ({}));
+  await jest.unstable_mockModule('../../resources/js/char-editor.js', () => ({}));
+  await jest.unstable_mockModule('leaflet', () => ({ default: {} }));
+  await import('../../resources/js/app.js');
+  return handler;
+}
+
+describe('app module', () => {
+  test('applies dark class based on preference', async () => {
+    const handler = await loadApp(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    handler({ matches: false });
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  test('adds dark class when preference changes to dark', async () => {
+    const handler = await loadApp(false);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    handler({ matches: true });
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/tests/Jest/app.test.js
+++ b/tests/Jest/app.test.js
@@ -1,5 +1,9 @@
 import { jest } from '@jest/globals';
 
+// Using jest.unstable_mockModule because Jest's stable mock API currently
+// lacks full support for mocking ES modules loaded via dynamic import. This
+// lets us stub out side-effect-heavy dependencies when testing app.js.
+
 const originalMatchMedia = window.matchMedia;
 
 afterEach(() => {

--- a/tests/Jest/changelog.test.js
+++ b/tests/Jest/changelog.test.js
@@ -41,4 +41,16 @@ describe('changelog module', () => {
     await domContentLoaded();
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  test('shows error message on fetch failure', async () => {
+    document.body.innerHTML = '<div id="release-notes"></div>';
+    global.fetch.mockRejectedValue(new Error('fail'));
+    await import('../../resources/js/changelog.js');
+    await domContentLoaded();
+    await Promise.resolve();
+    expect(global.fetch).toHaveBeenCalledWith('/changelog.json');
+    const container = document.getElementById('release-notes');
+    const text = container.innerText || container.textContent;
+    expect(text).toBe('Fehler beim Laden des Changelogs.');
+  });
 });


### PR DESCRIPTION
This pull request adds new automated tests for both the `app` and `changelog` modules to improve test coverage, especially around user interface behavior and error handling.

**New tests for UI behavior and error handling:**

* Added a new test suite for the `app` module that verifies the application of the `dark` class to the document based on user preference and responds to changes in the preference using `window.matchMedia`. (`tests/Jest/app.test.js`)
* Added a test to the `changelog` module to check that an appropriate error message is shown in the UI when fetching the changelog fails. (`tests/Jest/changelog.test.js`)