### PR TITLE
Allow admins to add members to any AG

### DIFF
--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -47,7 +47,7 @@ class TeamPolicy
      */
     public function addTeamMember(User $user, Team $team): bool
     {
-        return $user->ownsTeam($team);
+        return $user->hasRole('Admin') || $user->ownsTeam($team);
     }
 
     /**

--- a/tests/Feature/ArbeitsgruppenControllerTest.php
+++ b/tests/Feature/ArbeitsgruppenControllerTest.php
@@ -153,6 +153,30 @@ class ArbeitsgruppenControllerTest extends TestCase
         $this->assertTrue($newUser->fresh()->hasTeamRole($ag->fresh(), 'Mitwirkender'));
     }
 
+    public function test_admin_can_add_member_to_any_ag(): void
+    {
+        $admin = $this->createMemberWithRole('Admin');
+        $leader = $this->createMemberWithRole();
+        $ag = Team::factory()->create([
+            'user_id' => $leader->id,
+            'personal_team' => false,
+            'name' => 'AG Test',
+        ]);
+        $ag->users()->attach($leader, ['role' => 'Mitglied']);
+
+        $newUser = $this->createMemberWithRole();
+
+        $this->actingAs($admin);
+
+        $response = $this->post(route('arbeitsgruppen.add-member', $ag), [
+            'user_id' => $newUser->id,
+        ]);
+
+        $response->assertRedirect(route('arbeitsgruppen.edit', $ag));
+        $this->assertTrue($ag->fresh()->hasUser($newUser));
+        $this->assertTrue($newUser->fresh()->hasTeamRole($ag->fresh(), 'Mitwirkender'));
+    }
+
     public function test_ag_leader_cannot_add_more_than_five_members(): void
     {
         $leader = $this->createMemberWithRole();

--- a/tests/Feature/TeamPolicyTest.php
+++ b/tests/Feature/TeamPolicyTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\User;
 use App\Policies\TeamPolicy;
+use App\Models\Team;
 
 class TeamPolicyTest extends TestCase
 {
@@ -19,6 +20,10 @@ class TeamPolicyTest extends TestCase
         $team->users()->attach($member, ['role' => 'Member']);
         $outsider = User::factory()->create();
 
+        $adminTeam = Team::where('name', 'Mitglieder')->first();
+        $admin = User::factory()->create(['current_team_id' => $adminTeam->id]);
+        $adminTeam->users()->attach($admin, ['role' => 'Admin']);
+
         $policy = new TeamPolicy();
 
         $this->assertTrue($policy->viewAny($member));
@@ -30,6 +35,7 @@ class TeamPolicyTest extends TestCase
 
         $this->assertTrue($policy->addTeamMember($owner, $team));
         $this->assertFalse($policy->addTeamMember($member, $team));
+        $this->assertTrue($policy->addTeamMember($admin, $team));
 
         $this->assertTrue($policy->updateTeamMember($owner, $team));
         $this->assertFalse($policy->updateTeamMember($member, $team));


### PR DESCRIPTION
This pull request updates the team membership policy to allow users with the 'Admin' role to add members to any team, not just teams they own. It also adds and updates tests to ensure this new behavior is properly covered.

**Policy changes:**

* Updated the `addTeamMember` method in `TeamPolicy` to allow users with the 'Admin' role to add members to any team, in addition to team owners.

**Test coverage improvements:**

* Added a new feature test in `ArbeitsgruppenControllerTest` to verify that an admin can add a member to any team and that the member receives the correct role.
* Updated `TeamPolicyTest` to include an admin user and test that admins are allowed to add team members, ensuring the policy works as intended. [[1]](diffhunk://#diff-b879347ee1d2b10165a915f14eaebbb7f46a7c8ece77f3de5ea4a6a113b02dd2R23-R26) [[2]](diffhunk://#diff-b879347ee1d2b10165a915f14eaebbb7f46a7c8ece77f3de5ea4a6a113b02dd2R38)
* Added missing import for the `Team` model in `TeamPolicyTest`.