### PR TITLE
Increase Jest coverage for UI modules

### DIFF
--- a/tests/Jest/changelog.test.js
+++ b/tests/Jest/changelog.test.js
@@ -53,4 +53,24 @@ describe('changelog module', () => {
     const text = container.innerText || container.textContent;
     expect(text).toBe('Fehler beim Laden des Changelogs.');
   });
+
+  test('applies correct badge classes for note types', async () => {
+    document.body.innerHTML = '<div id="release-notes"></div>';
+    global.fetch.mockResolvedValue({
+      json: () => Promise.resolve([
+        {
+          version: '1.0.1',
+          pub_date: '2024-02-03',
+          notes: ['[Fixed] bug', '[Changed] tweak', '[Other] misc'],
+        },
+      ]),
+    });
+    await import('../../resources/js/changelog.js');
+    await domContentLoaded();
+    const items = Array.from(document.querySelectorAll('#release-notes li'));
+    const classes = items.map((li) => li.querySelector('span')?.className || '');
+    expect(classes[0]).toContain('bg-red-600');
+    expect(classes[1]).toContain('bg-blue-600');
+    expect(classes[2]).toContain('bg-gray-600');
+  });
 });

--- a/tests/Jest/chronik.test.js
+++ b/tests/Jest/chronik.test.js
@@ -59,5 +59,35 @@ describe('chronik module', () => {
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     expect(modal.classList.contains('hidden')).toBe(true);
   });
+
+  test('close button hides modal', async () => {
+    document.body.innerHTML = `
+      <div id="chronik-modal" class="hidden">
+        <picture>
+          <source id="chronik-modal-avif" />
+          <source id="chronik-modal-webp" />
+          <img id="chronik-modal-img" />
+        </picture>
+        <button id="chronik-modal-close"></button>
+      </div>
+      <a class="chronik-image" data-avif="a.avif" data-webp="b.webp"><img alt="alt" /></a>
+    `;
+    await import('../../resources/js/chronik.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    document.querySelector('.chronik-image').click();
+    document.getElementById('chronik-modal-close').click();
+    expect(document.getElementById('chronik-modal').classList.contains('hidden')).toBe(true);
+  });
+
+  test('ignores clicks without trigger and handles missing modal', async () => {
+    await import('../../resources/js/chronik.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+    div.click();
+    expect(document.querySelector('#chronik-modal')).toBeNull();
+  });
 });
 

--- a/tests/Jest/hoerbuch-role-form.test.js
+++ b/tests/Jest/hoerbuch-role-form.test.js
@@ -64,5 +64,35 @@ describe('hoerbuch role form module', () => {
     const rows = document.querySelectorAll('#roles_list .role-row');
     expect(rows.length).toBe(2);
   });
+
+  test('remove button deletes role row', () => {
+    const row = document.querySelector('#roles_list .role-row');
+    row.querySelector('button').click();
+    expect(document.querySelectorAll('#roles_list .role-row').length).toBe(0);
+  });
+
+  test('shows unauthorized error message', async () => {
+    fetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    const roleNameInput = document.querySelector('input[name$="[name]"]');
+    const hint = document.querySelector('.previous-speaker');
+    roleNameInput.value = 'Hero';
+    roleNameInput.dispatchEvent(new Event('blur'));
+    await fetch.mock.results[0].value;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(hint.textContent).toBe('Nicht berechtigt');
+  });
+
+  test('shows generic error message on failure', async () => {
+    fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    const roleNameInput = document.querySelector('input[name$="[name]"]');
+    const hint = document.querySelector('.previous-speaker');
+    roleNameInput.value = 'Hero';
+    roleNameInput.dispatchEvent(new Event('blur'));
+    await fetch.mock.results[0].value;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(hint.textContent).toBe('Fehler beim Laden des bisherigen Sprechers');
+  });
 });
 


### PR DESCRIPTION
This pull request adds new unit tests to improve coverage and verify UI behaviors for the `changelog`, `chronik`, and `hoerbuch role form` modules. These tests focus on ensuring correct UI responses to user interactions and error conditions.

**Changelog module tests:**
- Added a test to verify that the correct badge classes are applied to different note types in the changelog UI.

**Chronik module tests:**
- Added a test to confirm that clicking the close button hides the modal dialog.
- Added a test to ensure that clicks without a trigger and missing modal elements are handled gracefully without errors.

**Hoerbuch role form module tests:**
- Added a test to verify that the remove button deletes a role row from the list.
- Added tests to check that appropriate error messages are shown for unauthorized (401) and generic (500) fetch errors when validating role names.