### PR TITLE
Allow AG Fanhörbücher to access Hörbücher dashboard

### DIFF
--- a/app/Http/Middleware/EnsureHoerbuchAccess.php
+++ b/app/Http/Middleware/EnsureHoerbuchAccess.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureHoerbuchAccess
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = Auth::user();
+
+        if ($user && ($user->hasVorstandRole() || $user->isMemberOfTeam('AG Fanhörbücher'))) {
+            return $next($request);
+        }
+
+        abort(403);
+    }
+}

--- a/app/Http/Middleware/EnsureHoerbuchManage.php
+++ b/app/Http/Middleware/EnsureHoerbuchManage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureHoerbuchManage
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = Auth::user();
+
+        if ($user && ($user->hasVorstandRole() || $user->isOwnerOfTeam('AG Fanhörbücher'))) {
+            return $next($request);
+        }
+
+        abort(403);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -229,4 +229,20 @@ class User extends Authenticatable
             || $this->hasRole('Vorstand')
             || $this->hasRole('Kassenwart');
     }
+
+    /**
+     * Check if the user is a member of the given team.
+     */
+    public function isMemberOfTeam(string $teamName): bool
+    {
+        return $this->teams()->where('name', $teamName)->exists();
+    }
+
+    /**
+     * Check if the user owns the given team.
+     */
+    public function isOwnerOfTeam(string $teamName): bool
+    {
+        return $this->ownedTeams()->where('name', $teamName)->exists();
+    }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'admin' => \App\Http\Middleware\EnsureAdmin::class,
             'vorstand' => \App\Http\Middleware\EnsureVorstand::class,
             'admin-or-vorstand' => \App\Http\Middleware\EnsureAdminOrVorstand::class,
+            'hoerbuch-access' => \App\Http\Middleware\EnsureHoerbuchAccess::class,
+            'hoerbuch-manage' => \App\Http\Middleware\EnsureHoerbuchManage::class,
         ]);
         $middleware->appendToGroup('web', \App\Http\Middleware\UpdateLastActivity::class);
         $middleware->appendToGroup('web', \App\Http\Middleware\LogPageVisit::class);

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -7,7 +7,7 @@
         @endif
         <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6 flex justify-between items-center">
             <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">Hörbuchfolgen</h2>
-            @if(auth()->user()->hasRole('Admin') || auth()->user()->hasRole('Vorstand'))
+            @if(auth()->user()->hasVorstandRole() || auth()->user()->isOwnerOfTeam('AG Fanhörbücher'))
                 <a href="{{ route('hoerbuecher.create') }}" class="inline-flex items-center px-4 py-2 bg-[#8B0116] dark:bg-[#C41E3A] border border-transparent rounded-md font-semibold text-white hover:bg-[#A50019] dark:hover:bg-[#D63A4D] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#8B0116] dark:focus:ring-[#FF6B81]">
                     Neue Folge
                 </a>

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -64,10 +64,12 @@
                 </div>
             </div>
 
+            @if(auth()->user()->hasVorstandRole() || auth()->user()->isOwnerOfTeam('AG Fanhörbücher'))
             <div class="mt-6 flex justify-end space-x-3">
                 <a href="{{ route('hoerbuecher.edit', $episode) }}" class="text-blue-600 dark:text-blue-400 hover:underline">Bearbeiten</a>
                 <x-confirm-delete :action="route('hoerbuecher.destroy', $episode)" />
             </div>
+            @endif
             <div class="mt-6">
                 <a href="{{ route('hoerbuecher.index') }}" class="text-gray-600 dark:text-gray-400 hover:underline">&laquo; Zurück zur Übersicht</a>
             </div>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -58,23 +58,18 @@
                                 <x-dropdown-link href="{{ route('statistik.index') }}">Statistik</x-dropdown-link>
                             </div>
                         </div>
-                        @vorstand
-                        <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
-                            <button id="vorstand-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="vorstand-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
-                                Vorstand
-                            </button>
-                            <div id="vorstand-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="vorstand-button">
-                                <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
-                            </div>
-                        </div>
-                        @endvorstand
-                        @if(Auth::user()->ownedTeams()->where('personal_team', false)->exists())
+                        @if(Auth::user()->teams()->where('personal_team', false)->exists() || Auth::user()->hasVorstandRole())
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
                             <button id="ag-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="ag-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
                                 AG
                             </button>
                             <div id="ag-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu">
-                                <x-dropdown-link href="{{ route('ag.index') }}">AG verwalten</x-dropdown-link>
+                                @if(Auth::user()->hasVorstandRole() || Auth::user()->isMemberOfTeam('AG Fanhörbücher'))
+                                    <x-dropdown-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-dropdown-link>
+                                @endif
+                                @if(Auth::user()->ownedTeams()->where('personal_team', false)->exists())
+                                    <x-dropdown-link href="{{ route('ag.index') }}">AG verwalten</x-dropdown-link>
+                                @endif
                             </div>
                         </div>
                         @endif
@@ -181,18 +176,16 @@
                 <x-responsive-nav-link href="{{ route('kompendium.index') }}">Kompendium</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('statistik.index') }}">Statistik</x-responsive-nav-link>
             </div>
-            @vorstand
-            <button id="vorstand-mobile-button" type="button" @click="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'vorstand' }" :aria-expanded="openMenu === 'vorstand'" aria-controls="vorstand-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')" @keydown.space.prevent="openMenu = (openMenu === 'vorstand' ? null : 'vorstand')">
-            Vorstand</button>
-            <div id="vorstand-mobile-menu" x-show="openMenu === 'vorstand'" x-cloak class="italic" aria-labelledby="vorstand-mobile-button">
-                <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
-            </div>
-            @endvorstand
-            @if(Auth::user()->ownedTeams()->where('personal_team', false)->exists())
+            @if(Auth::user()->teams()->where('personal_team', false)->exists() || Auth::user()->hasVorstandRole())
             <button id="ag-mobile-button" type="button" @click="openMenu = (openMenu === 'ag' ? null : 'ag')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'ag' }" :aria-expanded="openMenu === 'ag'" aria-controls="ag-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'ag' ? null : 'ag')" @keydown.space.prevent="openMenu = (openMenu === 'ag' ? null : 'ag')">
             AG</button>
             <div id="ag-mobile-menu" x-show="openMenu === 'ag'" x-cloak class="italic">
-                <x-responsive-nav-link href="{{ route('ag.index') }}">AG verwalten</x-responsive-nav-link>
+                @if(Auth::user()->hasVorstandRole() || Auth::user()->isMemberOfTeam('AG Fanhörbücher'))
+                    <x-responsive-nav-link href="{{ route('hoerbuecher.index') }}">EARDRAX Dashboard</x-responsive-nav-link>
+                @endif
+                @if(Auth::user()->ownedTeams()->where('personal_team', false)->exists())
+                    <x-responsive-nav-link href="{{ route('ag.index') }}">AG verwalten</x-responsive-nav-link>
+                @endif
             </div>
             @endif
             @if(Auth::user()->hasRole('Admin'))

--- a/routes/web.php
+++ b/routes/web.php
@@ -113,17 +113,16 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::post('{todo}/freigeben', 'release')->name('release');
     });
     Route::prefix('hoerbuecher')->name('hoerbuecher.')->controller(HoerbuchController::class)->group(function () {
-        Route::get('/', 'index')->name('index')->middleware('vorstand');
-
-        Route::middleware('admin-or-vorstand')->group(function () {
+        Route::get('/', 'index')->name('index')->middleware('hoerbuch-access');
+        Route::get('previous-speaker', 'previousSpeaker')->name('previous-speaker')->middleware('hoerbuch-manage');
+        Route::middleware('hoerbuch-manage')->group(function () {
             Route::get('erstellen', 'create')->name('create');
             Route::post('/', 'store')->name('store');
-            Route::get('previous-speaker', 'previousSpeaker')->name('previous-speaker');
-            Route::get('{episode}', 'show')->name('show');
             Route::get('{episode}/bearbeiten', 'edit')->name('edit');
             Route::put('{episode}', 'update')->name('update');
             Route::delete('{episode}', 'destroy')->name('destroy');
         });
+        Route::get('{episode}', 'show')->name('show')->middleware('hoerbuch-access');
     });
 
     Route::prefix('admin/arbeitsgruppen')->name('arbeitsgruppen.')->controller(ArbeitsgruppenController::class)->middleware('auth')->group(function () {


### PR DESCRIPTION
This pull request introduces more granular access control for the "Hörbuch" (audiobook) section, allowing permissions based on team membership and ownership, rather than just global roles. It adds new middleware, updates navigation and authorization logic, and expands test coverage to reflect these changes.

**Access Control Improvements:**

* Introduced `EnsureHoerbuchAccess` and `EnsureHoerbuchManage` middleware to restrict access to audiobook routes based on whether a user is a member or owner of the `AG Fanhörbücher` team, or has a Vorstand role. (`app/Http/Middleware/EnsureHoerbuchAccess.php`, `app/Http/Middleware/EnsureHoerbuchManage.php`, `bootstrap/app.php`, `routes/web.php`) [[1]](diffhunk://#diff-2641cc7149b25488bede73d626a1791cfe59dc7f9271e81df9411d8fb2acf9c1R1-R27) [[2]](diffhunk://#diff-a07a7d839ad2808e9e94cb71fca607e75cd8c574a489a7582caa03041e46a36bR1-R27) [[3]](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518R21-R22) [[4]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL116-R125)
* Added `isMemberOfTeam` and `isOwnerOfTeam` methods to the `User` model to support the new middleware checks. (`app/Models/User.php`)

**Navigation and View Updates:**

* Updated navigation menus and views to show or hide links (such as "EARDRAX Dashboard" and create/edit options) based on the new team-based permissions, replacing previous role-based checks. (`resources/views/navigation-menu.blade.php`, `resources/views/hoerbuecher/index.blade.php`, `resources/views/hoerbuecher/show.blade.php`) [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL61-R72) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL184-R188) [[3]](diffhunk://#diff-62028215bf1b51ad419e1ba1ed5fc53eac5411544afb5da3fd5718deb40c541fL10-R10) [[4]](diffhunk://#diff-3a89ef24b9c79efccdef51ca4d7a67fab3d01dd6e100d6b08f8b821b8334ffcfR67-R72)

**Testing Enhancements:**

* Added test helpers to create AG Fanhörbücher teams and assign users as members or leaders, and expanded feature tests to verify access and visibility for AG members and leaders. (`tests/Feature/HoerbuchControllerTest.php`) [[1]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1R26-R56) [[2]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1R646-R654) [[3]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1R680-R724)