### PR TITLE
Add PDF print button to character editor

### DIFF
--- a/resources/js/char-editor.js
+++ b/resources/js/char-editor.js
@@ -30,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const attributePointsEl = document.getElementById('attribute-points');
     const skillPointsEl = document.getElementById('skill-points');
     const submitButton = document.getElementById('submit-button');
+    const pdfButton = document.getElementById('pdf-button');
     const advantagesSelect = document.getElementById('advantages');
     const disadvantagesSelect = document.getElementById('disadvantages');
     const advantageInput = document.getElementById('available_advantage_points');
@@ -459,13 +460,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateSubmitButton(valid) {
-        if (!submitButton) return;
-        submitButton.disabled = !valid;
-        submitButton.classList.toggle('cursor-not-allowed', !valid);
-        submitButton.classList.toggle('bg-gray-400', !valid);
-        submitButton.classList.toggle('bg-gray-600', !valid);
-        submitButton.classList.toggle('bg-[#8B0116]', valid);
-        submitButton.classList.toggle('dark:bg-red-400', valid);
+        [submitButton, pdfButton].forEach(btn => {
+            if (!btn) return;
+            btn.disabled = !valid;
+            btn.classList.toggle('cursor-not-allowed', !valid);
+            btn.classList.toggle('bg-gray-400', !valid);
+            btn.classList.toggle('bg-gray-600', !valid);
+            btn.classList.toggle('bg-[#8B0116]', valid);
+            btn.classList.toggle('dark:bg-red-400', valid);
+        });
     }
 
     function updateAddSkillButton(fpRemaining) {

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -173,7 +173,10 @@
                     <textarea name="equipment" id="equipment" rows="4" aria-labelledby="equipment-heading" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50"></textarea>
                 </div>
 
-                <div class="flex justify-end">
+                <div class="flex justify-end space-x-2">
+                    <button id="pdf-button" type="button" disabled class="inline-flex items-center px-4 py-2 bg-gray-400 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-white cursor-not-allowed">
+                        PDF drucken
+                    </button>
                     <button id="submit-button" type="submit" disabled class="inline-flex items-center px-4 py-2 bg-gray-400 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-white cursor-not-allowed">
                         Speichern
                     </button>

--- a/tests/Jest/char-editor.test.js
+++ b/tests/Jest/char-editor.test.js
@@ -16,6 +16,7 @@ const BASE_HTML = `
   <span id="attribute-points"></span>
   <span id="skill-points"></span>
   <button id="submit-button"></button>
+  <button id="pdf-button"></button>
   <button id="add-skill"></button>
   <div id="barbar-combat-toggle" class="hidden">
     <select id="barbar-combat-select">


### PR DESCRIPTION
This pull request introduces a new "PDF drucken" (Print PDF) button to the character editor interface and ensures that both the submit and PDF buttons are enabled or disabled together based on form validity. The changes affect both the frontend JavaScript logic and the Blade template, as well as the related Jest test setup.

**UI Enhancements:**
* Added a new `pdf-button` to the character editor interface, styled and placed next to the submit button in `char-editor.blade.php`.
* Updated the test HTML in `char-editor.test.js` to include the new `pdf-button`, ensuring tests reflect the latest UI.

**Logic Updates:**
* Updated the JavaScript logic in `char-editor.js` so that both the submit and PDF buttons are enabled or disabled together, and their styles are updated consistently based on form validity. [[1]](diffhunk://#diff-7438a413b83ecd16d538486287b615a7d8d3cab9e7ab59e1547cdbd10eec5498R33) [[2]](diffhunk://#diff-7438a413b83ecd16d538486287b615a7d8d3cab9e7ab59e1547cdbd10eec5498L462-R471)