### PR TITLE
Add PDF export for character editor

### DIFF
--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Spatie\LaravelPdf\Facades\Pdf;
 
 class RpgCharEditorController extends Controller
@@ -20,8 +21,12 @@ class RpgCharEditorController extends Controller
      */
     public function pdf(Request $request)
     {
+        $request->validate([
+            'portrait' => 'nullable|image|max:2048',
+        ]);
+
         $portrait = null;
-        if ($request->hasFile('portrait')) {
+        if ($request->hasFile('portrait') && $request->file('portrait')->isValid()) {
             $portrait = 'data:' . $request->file('portrait')->getMimeType() . ';base64,' . base64_encode($request->file('portrait')->get());
         }
 
@@ -34,7 +39,7 @@ class RpgCharEditorController extends Controller
             'portrait' => $portrait,
         ];
 
-        $name = $request->input('character_name', 'charakter');
+        $name = Str::slug($request->input('character_name', 'charakter')) ?: 'charakter';
 
         return Pdf::view('rpg.char-sheet', $data)->download($name . '.pdf');
     }

--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\Request;
+use Spatie\LaravelPdf\Facades\Pdf;
+
 class RpgCharEditorController extends Controller
 {
     /**
@@ -10,5 +13,29 @@ class RpgCharEditorController extends Controller
     public function index()
     {
         return view('rpg.char-editor');
+    }
+
+    /**
+     * Generate a character sheet PDF.
+     */
+    public function pdf(Request $request)
+    {
+        $portrait = null;
+        if ($request->hasFile('portrait')) {
+            $portrait = 'data:' . $request->file('portrait')->getMimeType() . ';base64,' . base64_encode($request->file('portrait')->get());
+        }
+
+        $data = [
+            'character' => $request->all(),
+            'attributes' => $request->input('attributes', []),
+            'skills' => $request->input('skills', []),
+            'advantages' => $request->input('advantages', []),
+            'disadvantages' => $request->input('disadvantages', []),
+            'portrait' => $portrait,
+        ];
+
+        $name = $request->input('character_name', 'charakter');
+
+        return Pdf::view('rpg.char-sheet', $data)->download($name . '.pdf');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/scout": "^10.14",
         "laravel/tinker": "^2.10.1",
         "livewire/livewire": "^3.6",
+        "spatie/laravel-pdf": "*",
         "spatie/laravel-sitemap": "^7.3",
         "teamtnt/laravel-scout-tntsearch-driver": "^15.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6e763a36d6bf171d969b409ab26a197a",
+    "content-hash": "77cd8094e317f81817867f95c0715c87",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -4345,6 +4345,92 @@
                 }
             ],
             "time": "2025-07-17T15:46:43+00:00"
+        },
+        {
+            "name": "spatie/laravel-pdf",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-pdf.git",
+                "reference": "e85001a3e3941da752751b3d4c2b356c06aad248"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-pdf/zipball/e85001a3e3941da752751b3d4c2b356c06aad248",
+                "reference": "e85001a3e3941da752751b3d4c2b356c06aad248",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "php": "^8.2",
+                "spatie/browsershot": "^4.0|^5.0",
+                "spatie/laravel-package-tools": "^1.16.1",
+                "spatie/temporary-directory": "^2.2.1"
+            },
+            "require-dev": {
+                "ext-imagick": "*",
+                "larastan/larastan": "^2.7.0|^3.0",
+                "laravel/pint": "^1.13.7",
+                "nunomaduro/collision": "^7.10|^8.0",
+                "orchestra/testbench": "^8.18|^10.0",
+                "pestphp/pest": "^2.30|^3.7",
+                "pestphp/pest-plugin-arch": "^2.5|^3.0",
+                "pestphp/pest-plugin-laravel": "^2.2|^3.1",
+                "phpstan/extension-installer": "^1.3.1",
+                "phpstan/phpstan-deprecation-rules": "^1.1.4|^2.0",
+                "phpstan/phpstan-phpunit": "^1.3.15|^2.0",
+                "spatie/image": "^3.3.2",
+                "spatie/invade": "^2.1",
+                "spatie/laravel-ray": "^1.33",
+                "spatie/pdf-to-image": "^2.2|^3.1",
+                "spatie/pdf-to-text": "^1.52.1",
+                "spatie/pest-expectations": "^1.5",
+                "spatie/pest-plugin-snapshots": "^2.1",
+                "spatie/pixelmatch-php": "^1.0",
+                "wnx/sidecar-browsershot": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "LaravelPdf": "Pdf"
+                    },
+                    "providers": [
+                        "Spatie\\LaravelPdf\\PdfServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Support/functions.php"
+                ],
+                "psr-4": {
+                    "Spatie\\LaravelPdf\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Create PDFs in Laravel apps",
+            "homepage": "https://github.com/spatie/laravel-pdf",
+            "keywords": [
+                "laravel",
+                "laravel-pdf",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-pdf/issues",
+                "source": "https://github.com/spatie/laravel-pdf/tree/1.7.1"
+            },
+            "time": "2025-08-29T09:35:58+00:00"
         },
         {
             "name": "spatie/laravel-sitemap",

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -174,7 +174,7 @@
                 </div>
 
                 <div class="flex justify-end space-x-2">
-                    <button id="pdf-button" type="button" disabled class="inline-flex items-center px-4 py-2 bg-gray-400 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-white cursor-not-allowed">
+                    <button id="pdf-button" type="submit" formaction="{{ route('rpg.char-editor.pdf') }}" formtarget="_blank" disabled class="inline-flex items-center px-4 py-2 bg-gray-400 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-white cursor-not-allowed">
                         PDF drucken
                     </button>
                     <button id="submit-button" type="submit" disabled class="inline-flex items-center px-4 py-2 bg-gray-400 dark:bg-gray-600 border border-transparent rounded-md font-semibold text-white cursor-not-allowed">

--- a/resources/views/rpg/char-sheet.blade.php
+++ b/resources/views/rpg/char-sheet.blade.php
@@ -65,13 +65,13 @@
     <div class="section">
         <strong>Vorteile</strong>
         <ul>
-            @foreach($advantages as $adv)
+            @foreach($advantages ?? [] as $adv)
                 <li>{{ $adv }}</li>
             @endforeach
         </ul>
         <strong>Nachteile</strong>
         <ul>
-            @foreach($disadvantages as $dis)
+            @foreach($disadvantages ?? [] as $dis)
                 <li>{{ $dis }}</li>
             @endforeach
         </ul>

--- a/resources/views/rpg/char-sheet.blade.php
+++ b/resources/views/rpg/char-sheet.blade.php
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Charakterbogen</title>
+    <style>
+        body { font-family: sans-serif; font-size: 12px; }
+        .section { margin-bottom: 12px; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+        .portrait { width: 120px; height: 120px; object-fit: cover; }
+    </style>
+</head>
+<body>
+    <h1>Charakterbogen</h1>
+    @if($portrait)
+        <img class="portrait" src="{{ $portrait }}" alt="Portrait">
+    @endif
+
+    <div class="section">
+        <strong>Spieler:</strong> {{ $character['player_name'] ?? '' }}<br>
+        <strong>Charakter:</strong> {{ $character['character_name'] ?? '' }}<br>
+        <strong>Rasse:</strong> {{ $character['race'] ?? '' }}<br>
+        <strong>Kultur:</strong> {{ $character['culture'] ?? '' }}
+    </div>
+
+    <div class="section">
+        <strong>Beschreibung</strong>
+        <p>{{ $character['description'] ?? '' }}</p>
+    </div>
+
+    @if($attributes)
+    <div class="section">
+        <strong>Attribute</strong>
+        <table>
+            <tr>
+                @foreach($attributes as $key => $val)
+                    <th>{{ strtoupper($key) }}</th>
+                @endforeach
+            </tr>
+            <tr>
+                @foreach($attributes as $val)
+                    <td>{{ $val }}</td>
+                @endforeach
+            </tr>
+        </table>
+    </div>
+    @endif
+
+    @if($skills)
+    <div class="section">
+        <strong>Fertigkeiten</strong>
+        <table>
+            <tr><th>Name</th><th>FW</th></tr>
+            @foreach($skills as $skill)
+                <tr>
+                    <td>{{ $skill['name'] ?? '' }}</td>
+                    <td>{{ $skill['value'] ?? '' }}</td>
+                </tr>
+            @endforeach
+        </table>
+    </div>
+    @endif
+
+    <div class="section">
+        <strong>Vorteile</strong>
+        <ul>
+            @foreach($advantages as $adv)
+                <li>{{ $adv }}</li>
+            @endforeach
+        </ul>
+        <strong>Nachteile</strong>
+        <ul>
+            @foreach($disadvantages as $dis)
+                <li>{{ $dis }}</li>
+            @endforeach
+        </ul>
+    </div>
+
+    <div class="section">
+        <strong>Ausrüstung</strong>
+        <p>{{ $character['equipment'] ?? '' }}</p>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -161,6 +161,10 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         ->name('rpg.char-editor')
         ->middleware('admin');
 
+    Route::post('/rpg/char-editor/pdf', [RpgCharEditorController::class, 'pdf'])
+        ->name('rpg.char-editor.pdf')
+        ->middleware('admin');
+
     Route::prefix('romantauschboerse')->name('romantausch.')->controller(RomantauschController::class)->group(function () {
         Route::get('/', 'index')->name('index');
         Route::get('angebot-erstellen', 'createOffer')->name('create-offer');

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Spatie\LaravelPdf\Facades\Pdf;
+use Tests\TestCase;
+
+class RpgCharEditorPdfTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function adminUser(): User
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => 'Admin']);
+        return $user;
+    }
+
+    public function test_pdf_downloads_with_sanitized_filename(): void
+    {
+        $admin = $this->adminUser();
+        Pdf::shouldReceive('view')->once()->with('rpg.char-sheet', \Mockery::type('array'))
+            ->andReturn(new class extends \Spatie\LaravelPdf\PdfBuilder {
+                public function toResponse($request): \Illuminate\Http\Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->actingAs($admin)->post('/rpg/char-editor/pdf', [
+            'character_name' => 'Foo/Bar',
+            'portrait' => UploadedFile::fake()->image('avatar.jpg'),
+        ]);
+
+        $this->assertStringContainsString('foobar.pdf', $response->headers->get('content-disposition'));
+    }
+
+    public function test_rejects_non_image_portrait(): void
+    {
+        $admin = $this->adminUser();
+
+        $response = $this->actingAs($admin)->post('/rpg/char-editor/pdf', [
+            'portrait' => UploadedFile::fake()->create('bad.exe', 10, 'application/octet-stream'),
+        ]);
+
+        $response->assertSessionHasErrors('portrait');
+    }
+}

--- a/tests/Jest/char-editor.test.js
+++ b/tests/Jest/char-editor.test.js
@@ -83,4 +83,10 @@ describe('char-editor module', () => {
     expect(zaeh.disabled).toBe(true);
     expect(document.getElementById('attribute-points').textContent).toBe('Verfügbare Attributspunkte: 3');
   });
+
+  test('pdf button disabled by default', async () => {
+    await loadEditor();
+    const pdfBtn = document.getElementById('pdf-button');
+    expect(pdfBtn.disabled).toBe(true);
+  });
 });

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const BASE_HTML = `
+  <input id="player_name" />
+  <input id="character_name" />
+  <select id="race"><option value=""></option><option value="Barbar">Barbar</option></select>
+  <select id="culture"><option value=""></option><option value="Landbewohner">Landbewohner</option></select>
+  <select id="advantages" multiple>
+    <option value="Zäh">Zäh</option>
+  </select>
+  <select id="disadvantages" multiple>
+    <option value="Arm">Arm</option>
+  </select>
+  <input id="available_advantage_points" />
+  <span id="attribute-points"></span>
+  <span id="skill-points"></span>
+  <button id="submit-button"></button>
+  <button id="pdf-button"></button>
+  <button id="add-skill"></button>
+  <div id="barbar-combat-toggle" class="hidden">
+    <select id="barbar-combat-select">
+      <option value="Nahkampf">Nahkampf</option>
+    </select>
+  </div>
+  <div id="skills-container"></div>
+  <datalist id="skills-list">
+    <option value="Überleben"></option>
+  </datalist>
+  <button id="continue-button" class="hidden"></button>
+  <fieldset id="advanced-fields"></fieldset>
+  <input id="st" />
+  <input id="ge" />
+  <input id="ro" />
+  <input id="wi" />
+  <input id="wa" />
+  <input id="in" />
+  <input id="au" />
+`;
+
+async function loadEditor(values = {}) {
+  vi.resetModules();
+  document.body.innerHTML = BASE_HTML;
+  for (const [id, value] of Object.entries(values)) {
+    const el = document.getElementById(id);
+    if (el) el.value = value;
+  }
+  await import('@/js/char-editor.js');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+}
+
+describe('char-editor pdf button', () => {
+  it('is disabled on load', async () => {
+    await loadEditor();
+    const pdfBtn = document.getElementById('pdf-button');
+    expect(pdfBtn.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
This pull request adds PDF export functionality to the RPG character editor, allowing users to generate and download a character sheet as a PDF. It introduces a new controller action, Blade template, route, and tests to support this feature. The implementation also ensures that only valid image files can be uploaded as portraits and that filenames are properly sanitized.

**PDF Export Feature:**

* Added a new `pdf` method to `RpgCharEditorController` to handle PDF generation, including validation for portrait image uploads and filename sanitization using `Str::slug`.
* Introduced a new Blade view `rpg/char-sheet.blade.php` to render the character sheet for PDF export, displaying character details, attributes, skills, advantages, disadvantages, and portrait.
* Updated the character editor view (`char-editor.blade.php`) to enable the PDF button and submit the form to the new PDF export route.
* Added a new route `/rpg/char-editor/pdf` for PDF generation, protected by the `admin` middleware.
* Required the `spatie/laravel-pdf` package in `composer.json` to support PDF generation.

**Testing:**

* Added a feature test (`RpgCharEditorPdfTest.php`) to verify PDF download with sanitized filenames and to ensure that only valid image files are accepted as portraits.
* Added frontend tests in both Jest and Vitest to check that the PDF button is disabled by default in the character editor UI. [[1]](diffhunk://#diff-9f95f78ec5bbb988afb97229968ae336ab00d7e35a02a684932513324cd7613eR86-R91) [[2]](diffhunk://#diff-fb18f83cf98be37a88d19828a9e35f53c1e003d762ea98aab19f3e4e301b364bR1-R57)