### PR TITLE
test: expand Jest coverage

### DIFF
--- a/tests/Jest/char-editor.test.js
+++ b/tests/Jest/char-editor.test.js
@@ -30,6 +30,9 @@ const BASE_HTML = `
     <option value="Intuition"></option>
     <option value="Nahkampf"></option>
     <option value="Fernkampf"></option>
+    <option value="Beruf: Viehzüchter"></option>
+    <option value="Beruf: Landwirt"></option>
+    <option value="Kunde: Wetter"></option>
   </datalist>
   <button id="continue-button" class="hidden"></button>
   <fieldset id="advanced-fields"></fieldset>
@@ -82,5 +85,32 @@ describe('char-editor module', () => {
     expect(zaeh.selected).toBe(true);
     expect(zaeh.disabled).toBe(true);
     expect(document.getElementById('attribute-points').textContent).toBe('Verfügbare Attributspunkte: 3');
+  });
+
+  test('changing barbar combat skill replaces previous skill', async () => {
+    await loadEditor({ player_name: 'Alice', character_name: 'Bob' });
+    const race = document.getElementById('race');
+    race.value = 'Barbar';
+    race.dispatchEvent(new Event('change'));
+    const combatSelect = document.getElementById('barbar-combat-select');
+    combatSelect.value = 'Fernkampf';
+    combatSelect.dispatchEvent(new Event('change'));
+    const skillNames = Array.from(document.querySelectorAll('.skill-row .skill-name')).map(i => i.value);
+    expect(skillNames).toEqual(expect.arrayContaining(['Fernkampf']));
+    expect(skillNames).not.toEqual(expect.arrayContaining(['Nahkampf']));
+  });
+
+  test('selecting Landbewohner culture adds culture skills', async () => {
+    await loadEditor({ player_name: 'Alice', character_name: 'Bob' });
+    const race = document.getElementById('race');
+    race.value = 'Barbar';
+    race.dispatchEvent(new Event('change'));
+    const culture = document.getElementById('culture');
+    culture.value = 'Landbewohner';
+    culture.dispatchEvent(new Event('change'));
+    const skillNames = Array.from(document.querySelectorAll('.skill-row .skill-name')).map(i => i.value);
+    expect(skillNames).toEqual(
+      expect.arrayContaining(['Beruf: Viehzüchter', 'Beruf: Landwirt', 'Kunde: Wetter'])
+    );
   });
 });

--- a/tests/Jest/char-editor.test.js
+++ b/tests/Jest/char-editor.test.js
@@ -112,7 +112,8 @@ describe('char-editor module', () => {
     expect(skillNames).toEqual(
       expect.arrayContaining(['Beruf: Viehzüchter', 'Beruf: Landwirt', 'Kunde: Wetter'])
     );
-    
+  });
+
   test('pdf button disabled by default', async () => {
     await loadEditor();
     const pdfBtn = document.getElementById('pdf-button');

--- a/tests/Jest/hoerbuch-role-form.test.js
+++ b/tests/Jest/hoerbuch-role-form.test.js
@@ -58,6 +58,20 @@ describe('hoerbuch role form module', () => {
     expect(hint.textContent).toBe('Bisheriger Sprecher: Bob');
   });
 
+  test('role name input uses debounce before fetching', async () => {
+    jest.useFakeTimers();
+    const roleNameInput = document.querySelector('input[name$="[name]"]');
+    roleNameInput.value = 'Hero';
+    roleNameInput.dispatchEvent(new Event('input'));
+    expect(fetch).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(300);
+    await Promise.resolve();
+    await fetch.mock.results[0].value;
+    await Promise.resolve();
+    expect(fetch).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
   test('add_role appends new role row', () => {
     const addBtn = document.getElementById('add_role');
     addBtn.click();

--- a/tests/Jest/hoerbuecher.test.js
+++ b/tests/Jest/hoerbuecher.test.js
@@ -41,6 +41,17 @@ describe('hoerbuecher module', () => {
     expect(rows[1].style.display).toBe('none');
   });
 
+  test('row click and Enter key navigate to dataset href', () => {
+    const rows = document.querySelectorAll('tr[data-href]');
+    rows[0].dataset.href = '#/1';
+    rows[1].dataset.href = '#/2';
+    rows[0].click();
+    expect(window.location.hash).toBe('#/1');
+    window.location.hash = '';
+    rows[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(window.location.hash).toBe('#/2');
+  });
+
   test('roles and rolesUnfilled filters are mutually exclusive', () => {
     const roles = document.getElementById('roles-filter');
     const rolesUnfilled = document.getElementById('roles-unfilled-filter');
@@ -58,6 +69,10 @@ describe('hoerbuecher module', () => {
     rolesUnfilled.dispatchEvent(new Event('change'));
     expect(roles.checked).toBe(false);
     expect(roles.disabled).toBe(true);
+
+    rolesUnfilled.checked = false;
+    rolesUnfilled.dispatchEvent(new Event('change'));
+    expect(roles.disabled).toBe(false);
   });
 
   test('clicking cardNextEvent filters only matching episode', () => {
@@ -90,6 +105,21 @@ describe('hoerbuecher module', () => {
     expect(rows[2].style.display).toBe('');
     const statusFilter = document.getElementById('status-filter');
     expect(statusFilter.value).toBe('Rollenbesetzung');
+  });
+
+  test('card-unfilled-roles handles missing roles-unfilled filter', async () => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <table>
+        <tr data-href="/1" data-status="done" data-type="A" data-year="2024" data-roles-filled="1" data-episode-id="1"></tr>
+      </table>
+      <select id="status-filter"><option value=""></option></select>
+      <div id="card-unfilled-roles"></div>
+    `;
+    await import('../../resources/js/hoerbuecher.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    const card = document.getElementById('card-unfilled-roles');
+    expect(() => card.click()).not.toThrow();
   });
 });
 


### PR DESCRIPTION
This pull request adds new tests and enhances existing ones across several modules, focusing on improved UI behavior, interaction handling, and robustness. The changes primarily ensure that new features and edge cases are well-covered by tests, particularly for character editor skills, table row navigation, debounced input handling, and filter logic.

**Char Editor Enhancements:**
- Added new skill options (`Beruf: Viehzüchter`, `Beruf: Landwirt`, `Kunde: Wetter`) to the datalist in test HTML, and introduced tests to verify that selecting the "Landbewohner" culture adds the correct culture skills, and that changing the barbar combat skill replaces the previous skill. [[1]](diffhunk://#diff-9f95f78ec5bbb988afb97229968ae336ab00d7e35a02a684932513324cd7613eR33-R35) [[2]](diffhunk://#diff-9f95f78ec5bbb988afb97229968ae336ab00d7e35a02a684932513324cd7613eR90-R116)

**Hoerbuch Role Form Improvements:**
- Added a test to ensure the role name input uses a debounce before triggering a fetch, verifying that unnecessary requests are avoided.

**Hoerbuecher Module UI and Filter Logic:**
- Added a test to verify that clicking on a table row or pressing Enter navigates to the correct dataset href, improving accessibility and navigation.
- Improved filter logic tests to ensure that the roles and roles-unfilled filters are mutually exclusive and that toggling them updates their enabled/disabled state correctly.
- Added a test to confirm that the `card-unfilled-roles` component handles the absence of the `roles-unfilled` filter gracefully, increasing robustness against missing elements.