### PR TITLE
test: expand Jest coverage for editor and statistics

### DIFF
--- a/tests/Jest/char-editor.test.js
+++ b/tests/Jest/char-editor.test.js
@@ -119,4 +119,72 @@ describe('char-editor module', () => {
     const pdfBtn = document.getElementById('pdf-button');
     expect(pdfBtn.disabled).toBe(true);
   });
+
+  test('attribute inputs respect caps and available points', async () => {
+    await loadEditor({ player_name: 'A', character_name: 'B' });
+    const race = document.getElementById('race');
+    race.value = 'Barbar';
+    race.dispatchEvent(new Event('change'));
+    const st = document.getElementById('st');
+    st.value = '3';
+    st.dispatchEvent(new Event('input'));
+    expect(st.value).toBe('2');
+    const ge = document.getElementById('ge');
+    ge.value = '2';
+    ge.dispatchEvent(new Event('input'));
+    expect(ge.value).toBe('1');
+    expect(document.getElementById('attribute-points').textContent).toBe('Verfügbare Attributspunkte: 0');
+  });
+
+  test('advantage selection is limited by free points', async () => {
+    jest.resetModules();
+    document.body.innerHTML = BASE_HTML;
+    const adv = document.getElementById('advantages');
+    ['Extra1', 'Extra2'].forEach(v => {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = v;
+      adv.appendChild(opt);
+    });
+    await import('../../resources/js/char-editor.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    adv.options[1].selected = true; // Kind zweier Welten
+    adv.dispatchEvent(new Event('change'));
+    adv.options[2].selected = true; // Extra1
+    adv.dispatchEvent(new Event('change'));
+    adv.options[3].selected = true; // Extra2 - should be rejected
+    adv.dispatchEvent(new Event('change'));
+    expect(adv.options[3].selected).toBe(false);
+    expect(adv.options[3].disabled).toBe(true);
+    expect(document.getElementById('available_advantage_points').value).toBe('0');
+  });
+
+  test('bildung skill disabled when intuition > 0 without special advantage', async () => {
+    await loadEditor({ player_name: 'A', character_name: 'B' });
+    const addBtn = document.getElementById('add-skill');
+    addBtn.click();
+    let rows = document.querySelectorAll('.skill-row');
+    const intRow = rows[0];
+    const intName = intRow.querySelector('.skill-name');
+    const intVal = intRow.querySelector('input[type="number"]');
+    intName.value = 'Intuition';
+    intName.dispatchEvent(new Event('input', { bubbles: true }));
+    intVal.value = '1';
+    intVal.dispatchEvent(new Event('input', { bubbles: true }));
+    addBtn.click();
+    rows = document.querySelectorAll('.skill-row');
+    const bildRow = rows[1];
+    const bildName = bildRow.querySelector('.skill-name');
+    const bildVal = bildRow.querySelector('input[type="number"]');
+    bildName.value = 'Bildung';
+    bildName.dispatchEvent(new Event('input', { bubbles: true }));
+    bildVal.value = '1';
+    bildVal.dispatchEvent(new Event('input', { bubbles: true }));
+    document.getElementById('skills-container').dispatchEvent(new Event('input'));
+    rows = document.querySelectorAll('.skill-row');
+    const finalBildVal = rows[1].querySelector('input[type="number"]');
+    const finalIntVal = rows[0].querySelector('input[type="number"]');
+    expect(finalBildVal.value).toBe('0');
+    expect(finalIntVal.value).toBe('1');
+  });
 });

--- a/tests/Jest/char-editor.test.js
+++ b/tests/Jest/char-editor.test.js
@@ -137,8 +137,7 @@ describe('char-editor module', () => {
   });
 
   test('advantage selection is limited by free points', async () => {
-    jest.resetModules();
-    document.body.innerHTML = BASE_HTML;
+    await loadEditor();
     const adv = document.getElementById('advantages');
     ['Extra1', 'Extra2'].forEach(v => {
       const opt = document.createElement('option');
@@ -146,8 +145,6 @@ describe('char-editor module', () => {
       opt.textContent = v;
       adv.appendChild(opt);
     });
-    await import('../../resources/js/char-editor.js');
-    document.dispatchEvent(new Event('DOMContentLoaded'));
     adv.options[1].selected = true; // Kind zweier Welten
     adv.dispatchEvent(new Event('change'));
     adv.options[2].selected = true; // Extra1

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -53,6 +53,22 @@ describe('statistik module', () => {
     expect(config.data.datasets[1].data).toEqual([5, 5, 5]);
   });
 
+  test('drawAuthorChart does nothing when canvas missing', () => {
+    drawAuthorChart('missing', ['A'], [1]);
+    expect(mockChart).not.toHaveBeenCalled();
+  });
+
+  test('drawCycleChart replaces data with random values when user points too low', () => {
+    document.body.innerHTML = '<div data-min-points="5"><canvas id="cycle"></canvas></div>';
+    window.userPoints = 0;
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    drawCycleChart('cycle', ['A', 'B'], [1, 2]);
+    const config = mockChart.mock.calls[0][1];
+    expect(config.data.datasets[0].data).toEqual([3, 3]);
+    Math.random.mockRestore();
+    delete window.userPoints;
+  });
+
   test('DOMContentLoaded draws hardcover chart', async () => {
     jest.resetModules();
     const chartModule = await import('chart.js/auto');


### PR DESCRIPTION
This pull request adds new tests to improve coverage and validation of important UI behaviors in both the character editor and statistics modules. The new tests ensure that attribute and advantage input constraints are respected, skill logic is enforced, and chart rendering functions behave correctly under specific conditions.

**Character Editor Tests:**

* Added a test to verify that attribute input fields enforce caps and available points, ensuring users cannot exceed allowed values.
* Added a test to confirm that selecting advantages is limited by the number of free points, and that UI elements are disabled appropriately when limits are reached.
* Added a test to ensure the "Bildung" skill is disabled when "Intuition" is greater than zero without the required special advantage.

**Statistics Module Tests:**

* Added a test to check that `drawAuthorChart` does nothing if the target canvas element is missing.
* Added a test to verify that `drawCycleChart` replaces data with random values when the user's points are too low, ensuring fallback behavior works as intended.