### PR TITLE
Add additional Jest coverage for frontend components

### DIFF
--- a/tests/Jest/app.test.js
+++ b/tests/Jest/app.test.js
@@ -5,14 +5,17 @@ import { jest } from '@jest/globals';
 // lets us stub out side-effect-heavy dependencies when testing app.js.
 
 const originalMatchMedia = window.matchMedia;
+const originalL = window.L;
 
 afterEach(() => {
   window.matchMedia = originalMatchMedia;
+  window.L = originalL;
 });
 
 async function loadApp(matches) {
   jest.resetModules();
   document.documentElement.className = '';
+  delete window.L;
   let handler;
   window.matchMedia = jest.fn().mockReturnValue({
     matches,
@@ -41,5 +44,10 @@ describe('app module', () => {
     expect(document.documentElement.classList.contains('dark')).toBe(false);
     handler({ matches: true });
     expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  test('exposes Leaflet globally', async () => {
+    await loadApp(true);
+    expect(window.L).toEqual({});
   });
 });

--- a/tests/Jest/changelog.test.js
+++ b/tests/Jest/changelog.test.js
@@ -54,6 +54,19 @@ describe('changelog module', () => {
     expect(text).toBe('Fehler beim Laden des Changelogs.');
   });
 
+  test('renders note without type as plain text', async () => {
+    document.body.innerHTML = '<div id="release-notes"></div>';
+    global.fetch.mockResolvedValue({
+      json: () => Promise.resolve([
+        { version: '1.0.0', pub_date: '2024-01-02', notes: ['plain note'] },
+      ]),
+    });
+    await import('../../resources/js/changelog.js');
+    await domContentLoaded();
+    const item = document.querySelector('#release-notes li');
+    expect(item.textContent).toBe('plain note');
+  });
+
   test('applies correct badge classes for note types', async () => {
     document.body.innerHTML = '<div id="release-notes"></div>';
     global.fetch.mockResolvedValue({

--- a/tests/Jest/hoerbuch-role-form.test.js
+++ b/tests/Jest/hoerbuch-role-form.test.js
@@ -110,3 +110,13 @@ describe('hoerbuch role form module', () => {
   });
 });
 
+describe('hoerbuch role form without initial data', () => {
+  test('skips initialization when roleFormData missing', async () => {
+    jest.resetModules();
+    delete window.roleFormData;
+    document.body.innerHTML = '<div id="roles_list"></div><button id="add_role"></button>';
+    await expect(import('../../resources/js/hoerbuch-role-form.js')).resolves.not.toThrow();
+    expect(document.querySelectorAll('#roles_list .role-row').length).toBe(0);
+  });
+});
+

--- a/tests/Jest/hoerbuecher.test.js
+++ b/tests/Jest/hoerbuecher.test.js
@@ -83,6 +83,21 @@ describe('hoerbuecher module', () => {
     expect(rows[1].style.display).toBe('');
   });
 
+  test('cardNextEvent resets other filters', () => {
+    const roles = document.getElementById('roles-filter');
+    const rolesUnfilled = document.getElementById('roles-unfilled-filter');
+    const statusFilter = document.getElementById('status-filter');
+    roles.checked = true;
+    roles.dispatchEvent(new Event('change'));
+    statusFilter.value = 'open';
+    document.getElementById('card-next-event').click();
+    expect(roles.checked).toBe(false);
+    expect(roles.disabled).toBe(false);
+    expect(rolesUnfilled.checked).toBe(false);
+    expect(rolesUnfilled.disabled).toBe(false);
+    expect(statusFilter.value).toBe('');
+  });
+
   test('card-unfilled-roles shows only rows without roles filled', () => {
     const card = document.getElementById('card-unfilled-roles');
     card.click();

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -69,6 +69,15 @@ describe('statistik module', () => {
     delete window.userPoints;
   });
 
+  test('drawCycleChart keeps data when user points sufficient', () => {
+    document.body.innerHTML = '<div data-min-points="5"><canvas id="cycle"></canvas></div>';
+    window.userPoints = 5;
+    drawCycleChart('cycle', ['A', 'B'], [1, 2]);
+    const config = mockChart.mock.calls[0][1];
+    expect(config.data.datasets[0].data).toEqual([1, 2]);
+    delete window.userPoints;
+  });
+
   test('DOMContentLoaded draws hardcover chart', async () => {
     jest.resetModules();
     const chartModule = await import('chart.js/auto');


### PR DESCRIPTION
This pull request adds new tests across several modules to improve coverage and ensure correct behavior in edge cases. The main focus is on verifying global exposure of dependencies, correct UI rendering, and proper handling of user interactions and missing data.

**Testing improvements:**

* Added a test to `app.test.js` to verify that the Leaflet library (`window.L`) is exposed globally after loading the app module.
* Added a test to `changelog.test.js` to ensure that changelog notes without a type are rendered as plain text.
* Added a test to `hoerbuch-role-form.test.js` to check that the form initialization is skipped gracefully if `roleFormData` is missing, preventing errors when no initial data is present.
* Added a test to `hoerbuecher.test.js` to verify that the `cardNextEvent` action correctly resets other filters in the UI.
* Added a test to `statistik.test.js` to confirm that `drawCycleChart` retains data when the user has sufficient points.

**Test setup and teardown improvements:**

* Updated `app.test.js` to save and restore the original `window.L` global variable in test setup/teardown, ensuring test isolation and preventing side effects.