### PR TITLE
Add coverage for public pages

### DIFF
--- a/tests/Feature/PageAccessibilityTest.php
+++ b/tests/Feature/PageAccessibilityTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\Models\Team;
 use App\Models\User;
@@ -20,6 +19,7 @@ class PageAccessibilityTest extends TestCase
             '/chronik',
             '/ehrenmitglieder',
             '/termine',
+            '/arbeitsgruppen',
             '/mitglied-werden',
             '/spenden',
             '/impressum',
@@ -44,5 +44,46 @@ class PageAccessibilityTest extends TestCase
         $response = $this->get('/');
         $response->assertOk();
         $response->assertSee('2');
+    }
+
+    public function test_impressum_page_shows_contact_information(): void
+    {
+        $this->get('/impressum')
+            ->assertOk()
+            ->assertSee('info@maddrax-fanclub.de')
+            ->assertSee('Angaben gemäß §5 TMG');
+    }
+
+    public function test_datenschutz_page_displays_data_protection_details(): void
+    {
+        $this->get('/datenschutz')
+            ->assertOk()
+            ->assertSee('Datenschutzerklärung')
+            ->assertSee('Verantwortlicher')
+            ->assertSee('Zweck der Verarbeitung');
+    }
+
+    public function test_spenden_page_contains_paypal_form(): void
+    {
+        $this->get('/spenden')
+            ->assertOk()
+            ->assertSee('kassenwart@maddrax-fanclub.de')
+            ->assertSee('paypal.com');
+    }
+
+    public function test_arbeitsgruppen_page_shows_ag_info(): void
+    {
+        $leader = User::factory()->create();
+        Team::factory()->create([
+            'name' => 'AG Test',
+            'user_id' => $leader->id,
+            'personal_team' => false,
+            'description' => 'Beschreibung der AG',
+        ]);
+
+        $this->get('/arbeitsgruppen')
+            ->assertOk()
+            ->assertSee('AG Test')
+            ->assertSee('Beschreibung der AG');
     }
 }

--- a/tests/Feature/PageAccessibilityTest.php
+++ b/tests/Feature/PageAccessibilityTest.php
@@ -39,7 +39,7 @@ class PageAccessibilityTest extends TestCase
         $team = Team::where('name', 'Mitglieder')->first();
 
         $team->users()->attach(User::factory()->create(), ['role' => 'Mitglied']);
-        $team->users()->attach(User::factory()->create(), ['role' => 'Anw\xC3\xA4rter']);
+        $team->users()->attach(User::factory()->create(), ['role' => 'Anwärter']);
 
         $response = $this->get('/');
         $response->assertOk();


### PR DESCRIPTION
This pull request enhances the feature test coverage for public pages by adding new tests to verify the accessibility and content of several key pages, and updates the list of tested routes. The changes ensure that important information is present on pages such as Impressum, Datenschutz, Spenden, and Arbeitsgruppen.

**Test coverage improvements:**

* Added new tests to verify that the `/impressum`, `/datenschutz`, `/spenden`, and `/arbeitsgruppen` pages display the expected content, such as contact information, data protection details, PayPal form, and Arbeitsgruppen (working group) information.
* Added `/arbeitsgruppen` to the list of public pages checked for accessibility.

**Code cleanup:**

* Removed the unused `WithFaker` import from `PageAccessibilityTest.php`.