### PR TITLE
Add membership and page content feature tests

### DIFF
--- a/tests/Feature/MitgliedschaftControllerTest.php
+++ b/tests/Feature/MitgliedschaftControllerTest.php
@@ -33,7 +33,7 @@ class MitgliedschaftControllerTest extends TestCase
             'verein_gefunden' => 'Internet',
         ];
 
-        $response = $this->post(route('mitglied.store'), $data);
+        $response = $this->postJson(route('mitglied.store'), $data);
 
         $response->assertOk()->assertJson(['success' => true]);
 

--- a/tests/Feature/MitgliedschaftControllerTest.php
+++ b/tests/Feature/MitgliedschaftControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\MitgliedAntragEingereicht;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class MitgliedschaftControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_membership_application_creates_user_and_assigns_anwaerter_role(): void
+    {
+        Mail::fake();
+
+        $data = [
+            'vorname' => 'Max',
+            'nachname' => 'Mustermann',
+            'strasse' => 'Musterstraße',
+            'hausnummer' => '1',
+            'plz' => '12345',
+            'stadt' => 'Musterstadt',
+            'land' => 'Deutschland',
+            'mail' => 'max@example.com',
+            'passwort' => 'secret123',
+            'passwort_confirmation' => 'secret123',
+            'mitgliedsbeitrag' => 12,
+            'telefon' => '0123456789',
+            'verein_gefunden' => 'Internet',
+        ];
+
+        $response = $this->post(route('mitglied.store'), $data);
+
+        $response->assertOk()->assertJson(['success' => true]);
+
+        $user = User::where('email', 'max@example.com')->first();
+        $this->assertNotNull($user);
+
+        $team = Team::where('name', 'Mitglieder')->first();
+        $this->assertTrue($team->users()->where('user_id', $user->id)->wherePivot('role', 'Anwärter')->exists());
+
+        Mail::assertQueued(MitgliedAntragEingereicht::class, function ($mail) use ($user) {
+            return $mail->hasTo($user->email);
+        });
+    }
+
+    public function test_membership_application_requires_first_name(): void
+    {
+        Mail::fake();
+
+        $data = [
+            'nachname' => 'Mustermann',
+            'strasse' => 'Musterstraße',
+            'hausnummer' => '1',
+            'plz' => '12345',
+            'stadt' => 'Musterstadt',
+            'land' => 'Deutschland',
+            'mail' => 'max@example.com',
+            'passwort' => 'secret123',
+            'passwort_confirmation' => 'secret123',
+            'mitgliedsbeitrag' => 12,
+        ];
+
+        $response = $this->postJson(route('mitglied.store'), $data);
+
+        $response->assertStatus(422)->assertJsonValidationErrors(['vorname']);
+    }
+}

--- a/tests/Feature/PageContentTest.php
+++ b/tests/Feature/PageContentTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PageContentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_termine_page_contains_calendar_links(): void
+    {
+        $this->get('/termine')
+            ->assertOk()
+            ->assertSee('calendar.google.com/calendar/embed')
+            ->assertSee('calendar.google.com/calendar/u/0?cid=');
+    }
+
+    public function test_changelog_page_contains_release_notes_container(): void
+    {
+        $this->get('/changelog')
+            ->assertOk()
+            ->assertSee('release-notes');
+    }
+}


### PR DESCRIPTION
This pull request adds new feature tests to improve test coverage of the membership application process and the presence of key content on specific pages. The main changes are the addition of two new test classes, each focused on a different area of the application.

**Feature tests for membership application:**

* Added `MitgliedschaftControllerTest` to verify that submitting a membership application creates a user, assigns the "Anwärter" role in the "Mitglieder" team, and queues the appropriate notification email. It also checks that the first name is required for the application.

**Feature tests for page content:**

* Added `PageContentTest` to ensure the `/termine` page contains Google Calendar links and the `/changelog` page contains a release notes container.