### PR TITLE
Add feature tests for public pages and components

### DIFF
--- a/tests/Feature/PageComponentRenderingTest.php
+++ b/tests/Feature/PageComponentRenderingTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PageComponentRenderingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_public_page_component_renders_with_default_classes(): void
+    {
+        $this->get('/chronik')
+            ->assertOk()
+            ->assertSee('max-w-6xl', false)
+            ->assertSee('bg-gray-100', false);
+    }
+
+    public function test_member_page_component_renders_for_dashboard(): void
+    {
+        $team = Team::where('name', 'Mitglieder')->first();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => 'Mitglied']);
+
+        $this->actingAs($user)
+            ->get('/dashboard')
+            ->assertOk()
+            ->assertSee('max-w-7xl', false);
+    }
+}
+

--- a/tests/Feature/PublicPagesContentTest.php
+++ b/tests/Feature/PublicPagesContentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PublicPagesContentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_chronik_page_shows_heading(): void
+    {
+        $this->get('/chronik')
+            ->assertOk()
+            ->assertSee('Chronik des Offiziellen MADDRAX Fanclub e. V.');
+    }
+
+    public function test_ehrenmitglieder_page_shows_member_names(): void
+    {
+        $this->get('/ehrenmitglieder')
+            ->assertOk()
+            ->assertSee('Ehrenmitglieder')
+            ->assertSee('Michael Edelbrock');
+    }
+
+    public function test_satzung_page_shows_sections(): void
+    {
+        $this->get('/satzung')
+            ->assertOk()
+            ->assertSee('Satzung des Offiziellen MADDRAX Fanclub e.V.')
+            ->assertSee('§1 Name', false);
+    }
+
+    public function test_mitglied_werden_page_shows_form_fields(): void
+    {
+        $this->get('/mitglied-werden')
+            ->assertOk()
+            ->assertSee('Mitglied werden')
+            ->assertSee('Vorname')
+            ->assertSee('Nachname');
+    }
+
+    public function test_mitglied_werden_erfolgreich_page_shows_success_message(): void
+    {
+        $this->get('/mitglied-werden/erfolgreich')
+            ->assertOk()
+            ->assertSee('Antrag erfolgreich eingereicht');
+    }
+
+    public function test_mitglied_werden_bestaetigt_page_shows_confirmation_message(): void
+    {
+        $this->get('/mitglied-werden/bestaetigt')
+            ->assertOk()
+            ->assertSee('Vielen Dank für deine Bestätigung!');
+    }
+}
+

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ abstract class TestCase extends BaseTestCase
     protected function setUp(): void
     {
         parent::setUp();
+        config(['app.key' => 'base64:' . base64_encode(random_bytes(32))]);
 
         Http::fake([
             'nominatim.openstreetmap.org/*' => Http::response([[


### PR DESCRIPTION
This pull request adds new feature tests to improve coverage of public page content and page component rendering, and ensures a unique application key is set up for each test run. These changes help verify that the application's public-facing pages display the correct content and that page components render as expected for both guests and authenticated users. Additionally, setting a random app key in tests increases test isolation and reliability.

**Testing improvements:**

* Added `PageComponentRenderingTest` to verify that public and member-specific pages render with the correct CSS classes and layout, ensuring the UI is consistent for different user roles.
* Added `PublicPagesContentTest` to check that key public pages (such as `/chronik`, `/ehrenmitglieder`, `/satzung`, `/mitglied-werden`, and related confirmation pages) display the correct headings, member names, form fields, and messages, improving confidence in the user-facing content.

**Test reliability:**

* Updated the `TestCase` base class to set a random application key (`app.key`) during test setup, ensuring each test run uses a unique key and reducing the risk of cross-test interference.