### PR TITLE
Add feature tests for home and legal pages

### DIFF
--- a/tests/Feature/HomePageContentTest.php
+++ b/tests/Feature/HomePageContentTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HomePageContentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_home_page_displays_all_sections_and_projects(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk()
+            ->assertSee('Willkommen beim Offiziellen MADDRAX Fanclub e. V.!')
+            ->assertSee('Wer wir sind')
+            ->assertSee('Wir Maddrax-Fans sind eine muntere Gruppe')
+            ->assertSee('Was wir machen')
+            ->assertSee('Wir treffen uns in unterschiedlichen Konstellationen mal online')
+            ->assertSee('Aktuelle Projekte')
+            ->assertSee('Maddraxikon')
+            ->assertSee('EARDRAX')
+            ->assertSee('MAPDRAX')
+            ->assertSee('Fantreffen 2026')
+            ->assertSee('Vorteile einer Mitgliedschaft')
+            ->assertSee('Kostenlose Teilnahme an den jährlichen Fantreffen')
+            ->assertSee('aktive Mitglieder');
+    }
+
+    public function test_home_page_contains_structured_data(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertOk()
+            ->assertSee('@context', false)
+            ->assertSee('SearchAction', false);
+    }
+}

--- a/tests/Feature/HomePageContentTest.php
+++ b/tests/Feature/HomePageContentTest.php
@@ -2,34 +2,12 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class HomePageContentTest extends TestCase
 {
-    public function seed($class = 'Database\\Seeders\\DatabaseSeeder')
-    {
-        // Prevent automatic seeding during TestCase setup
-        return $this;
-    }
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Schema::create('teams', function (Blueprint $table) {
-            $table->id();
-            $table->string('name');
-        });
-    }
-
-    protected function tearDown(): void
-    {
-        Schema::dropIfExists('teams');
-
-        parent::tearDown();
-    }
+    use RefreshDatabase;
 
     public function test_home_page_displays_all_sections_and_projects(): void
     {

--- a/tests/Feature/HomePageContentTest.php
+++ b/tests/Feature/HomePageContentTest.php
@@ -2,12 +2,34 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 class HomePageContentTest extends TestCase
 {
-    use RefreshDatabase;
+    public function seed($class = 'Database\\Seeders\\DatabaseSeeder')
+    {
+        // Prevent automatic seeding during TestCase setup
+        return $this;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('teams', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('teams');
+
+        parent::tearDown();
+    }
 
     public function test_home_page_displays_all_sections_and_projects(): void
     {

--- a/tests/Feature/LegalPagesContentTest.php
+++ b/tests/Feature/LegalPagesContentTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LegalPagesContentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_impressum_page_shows_register_information(): void
+    {
+        $this->get('/impressum')
+            ->assertOk()
+            ->assertSee('Registernummer: 9677')
+            ->assertSee('Vereinsregister');
+    }
+
+    public function test_datenschutz_page_highlights_legal_basis_and_rights(): void
+    {
+        $this->get('/datenschutz')
+            ->assertOk()
+            ->assertSee('Rechtsgrundlage der Verarbeitung')
+            ->assertSee('Art. 6 Abs. 1 lit. b DSGVO', false)
+            ->assertSee('Beschwerderecht bei einer Aufsichtsbehörde')
+            ->assertSee('Datensicherheit');
+    }
+}

--- a/tests/Feature/LegalPagesContentTest.php
+++ b/tests/Feature/LegalPagesContentTest.php
@@ -2,12 +2,15 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class LegalPagesContentTest extends TestCase
 {
-    use RefreshDatabase;
+    public function seed($class = 'Database\\Seeders\\DatabaseSeeder')
+    {
+        // Prevent automatic seeding during TestCase setup
+        return $this;
+    }
 
     public function test_impressum_page_shows_register_information(): void
     {

--- a/tests/Feature/LegalPagesContentTest.php
+++ b/tests/Feature/LegalPagesContentTest.php
@@ -2,15 +2,12 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class LegalPagesContentTest extends TestCase
 {
-    public function seed($class = 'Database\\Seeders\\DatabaseSeeder')
-    {
-        // Prevent automatic seeding during TestCase setup
-        return $this;
-    }
+    use RefreshDatabase;
 
     public function test_impressum_page_shows_register_information(): void
     {


### PR DESCRIPTION
This pull request adds new feature tests to improve coverage of the website's home and legal pages. The tests ensure that important content and structured data are present and visible to users, and that legal information is correctly displayed.

Feature tests for home page:

* Added `HomePageContentTest` to check that all main sections, project names, and membership benefits are displayed on the home page, and to verify that structured data (such as `@context` and `SearchAction`) is present in the HTML. (`tests/Feature/HomePageContentTest.php`)

Feature tests for legal pages:

* Added `LegalPagesContentTest` to verify that the Impressum page shows the register number and association register information, and that the Datenschutz page highlights the legal basis for data processing, specific GDPR articles, user rights, and data security. (`tests/Feature/LegalPagesContentTest.php`)