### PR TITLE
fix: restore char editor PDF preview

### DIFF
--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -41,6 +41,6 @@ class RpgCharEditorController extends Controller
 
         $name = Str::slug($request->input('character_name', 'charakter')) ?: 'charakter';
 
-        return Pdf::view('rpg.char-sheet', $data)->download($name . '.pdf');
+        return Pdf::view('rpg.char-sheet', $data)->inline($name . '.pdf');
     }
 }

--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'browsershot' => [
+        'node_binary' => env('LARAVEL_PDF_NODE_BINARY'),
+        'npm_binary' => env('LARAVEL_PDF_NPM_BINARY'),
+        'include_path' => env('LARAVEL_PDF_INCLUDE_PATH'),
+        'chrome_path' => env('LARAVEL_PDF_CHROME_PATH'),
+        // Ensure Browsershot can locate Puppeteer and Chromium
+        'node_modules_path' => base_path('node_modules'),
+        'bin_path' => env('LARAVEL_PDF_BIN_PATH'),
+        'temp_path' => env('LARAVEL_PDF_TEMP_PATH'),
+        'write_options_to_file' => env('LARAVEL_PDF_WRITE_OPTIONS_TO_FILE', false),
+    ],
+];

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -71,4 +71,9 @@ class RpgCharEditorPdfTest extends TestCase
 
         $response->assertOk();
     }
+
+    public function test_laravel_pdf_is_configured(): void
+    {
+        $this->assertSame(base_path('node_modules'), config('laravel-pdf.browsershot.node_modules_path'));
+    }
 }


### PR DESCRIPTION
## Summary
- show character editor PDFs in browser instead of forcing a download
- configure laravel-pdf to find Puppeteer/Chromium in node_modules
- cover PDF configuration with a feature test

## Testing
- `./vendor/bin/phpunit --no-coverage`
- `npm test`
- `npm run test:vitest`


------
https://chatgpt.com/codex/tasks/task_e_68c1d542fa78832e9a29a4989f1a20e6