### PR TITLE
Chore: Upgrade puppeteer and related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^1.2.0",
                 "postcss": "^8.4.32",
-                "puppeteer": "^23.11.1",
+                "puppeteer": "^24.20.0",
                 "simple-datatables": "^9.2.2",
                 "tailwindcss": "^3.4.0",
                 "vite": "^6.0.11",
@@ -1556,9 +1556,9 @@
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.30",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz",
-            "integrity": "sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -1645,19 +1645,18 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
-            "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+            "version": "2.10.9",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.9.tgz",
+            "integrity": "sha512-kUGHwABarVhvMP+zhW5zvDA7LmGcd4TwrTEBwcTQic5EebUqaK5NjC0UXLJepIFVGsr2N/Z8NJQz2JYGo1ZwxA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "debug": "^4.4.0",
+                "debug": "^4.4.1",
                 "extract-zip": "^2.0.1",
                 "progress": "^2.0.3",
                 "proxy-agent": "^6.5.0",
-                "semver": "^7.6.3",
-                "tar-fs": "^3.0.6",
-                "unbzip2-stream": "^1.4.3",
+                "semver": "^7.7.2",
+                "tar-fs": "^3.1.0",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -3021,11 +3020,19 @@
             }
         },
         "node_modules/b4a": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.0.tgz",
+            "integrity": "sha512-KtsH1alSKomfNi/yDAFaD8PPFfi0LxJCEbPuzogcXrMF+yH40Z1ykTDo2vyxuQfN1FLjv0LFM7CadLHEPrVifw==",
             "dev": true,
-            "license": "Apache-2.0"
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "react-native-b4a": "^0.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react-native-b4a": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/babel-jest": {
             "version": "30.1.2",
@@ -3138,9 +3145,9 @@
             "optional": true
         },
         "node_modules/bare-fs": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.3.2.tgz",
-            "integrity": "sha512-FAJ00JF69O6/oKAP+oiJYgdem1biZoGAR0NbRkBRQZ26shA87DmdHWbpeY3EVKPrAzHByLoLo+hAzTT6NTJWCg==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.3.3.tgz",
+            "integrity": "sha512-W+ZpiQx1i0dm073So22v3jColDtvyqSTyUYEnooYwKcl+SHuqnQGKyuHdwigQffWJV5ghKtskVH7ydAkBVKQZQ==",
             "dev": true,
             "license": "Apache-2.0",
             "optional": true,
@@ -3148,20 +3155,17 @@
                 "bare-events": "^2.5.4",
                 "bare-path": "^3.0.0",
                 "bare-stream": "^2.6.4",
-                "bare-url": "^2.2.2"
+                "bare-url": "^2.2.2",
+                "fast-fifo": "^1.3.2"
             },
             "engines": {
                 "bare": ">=1.16.0"
             },
             "peerDependencies": {
-                "bare-buffer": "*",
-                "bare-url": "*"
+                "bare-buffer": "*"
             },
             "peerDependenciesMeta": {
                 "bare-buffer": {
-                    "optional": true
-                },
-                "bare-url": {
                     "optional": true
                 }
             }
@@ -3221,27 +3225,6 @@
             "dependencies": {
                 "bare-path": "^3.0.0"
             }
-        },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/basic-ftp": {
             "version": "5.0.5",
@@ -3326,31 +3309,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "node-int64": "^0.4.0"
-            }
-        },
-        "node_modules/buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
             }
         },
         "node_modules/buffer-crc32": {
@@ -3567,14 +3525,14 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
-            "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.0.0.tgz",
+            "integrity": "sha512-d1VmE0FD7lxZQHzcDUCKZSNRtRwISXDsdg4HjdTR5+Ll5nQ/vzU12JeNmupD6VWffrPSlrnGhEWlLESKH3VO+g==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "mitt": "3.0.1",
-                "zod": "3.23.8"
+                "mitt": "^3.0.1",
+                "zod": "^3.24.1"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
@@ -3985,9 +3943,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1367902",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
-            "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+            "version": "0.0.1495869",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
+            "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
             "dev": true,
             "license": "BSD-3-Clause"
         },
@@ -4034,9 +3992,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.215",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.215.tgz",
-            "integrity": "sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ==",
+            "version": "1.5.217",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.217.tgz",
+            "integrity": "sha512-Pludfu5iBxp9XzNl0qq2G87hdD17ZV7h5T4n6rQXDi3nCyloBV3jreE9+8GC6g4X/5yxqVgXEURpcLtM0WS4jA==",
             "license": "ISC"
         },
         "node_modules/emittery": {
@@ -4859,27 +4817,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "BSD-3-Clause"
         },
         "node_modules/import-fresh": {
             "version": "3.3.1",
@@ -7081,19 +7018,18 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "23.11.1",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-23.11.1.tgz",
-            "integrity": "sha512-53uIX3KR5en8l7Vd8n5DUv90Ae9QDQsyIthaUFVzwV6yU750RjqRznEtNMBT20VthqAdemnJN+hxVdmMHKt7Zw==",
-            "deprecated": "< 24.10.2 is no longer supported",
+            "version": "24.20.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.20.0.tgz",
+            "integrity": "sha512-iLnLV9oHKKAujmxiSxRWKfcT1q2COu0g1N9iU2TCp1MlmsyjgNAkcBOR3cAOqKb5UTiVPIGG4z5PO5yfpYZ6jA==",
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.6.1",
-                "chromium-bidi": "0.11.0",
+                "@puppeteer/browsers": "2.10.9",
+                "chromium-bidi": "8.0.0",
                 "cosmiconfig": "^9.0.0",
-                "devtools-protocol": "0.0.1367902",
-                "puppeteer-core": "23.11.1",
+                "devtools-protocol": "0.0.1495869",
+                "puppeteer-core": "24.20.0",
                 "typed-query-selector": "^2.12.0"
             },
             "bin": {
@@ -7104,18 +7040,19 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "23.11.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
-            "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
+            "version": "24.20.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.20.0.tgz",
+            "integrity": "sha512-n0y/f8EYyZt4yEJkjP3Vrqf9A4qa3uYpKYdsiedIY4bxIfTw1aAJSpSVPmWBPlr1LO4cNq2hGNIBWKPhvBF68w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "2.6.1",
-                "chromium-bidi": "0.11.0",
-                "debug": "^4.4.0",
-                "devtools-protocol": "0.0.1367902",
+                "@puppeteer/browsers": "2.10.9",
+                "chromium-bidi": "8.0.0",
+                "debug": "^4.4.1",
+                "devtools-protocol": "0.0.1495869",
                 "typed-query-selector": "^2.12.0",
-                "ws": "^8.18.0"
+                "webdriver-bidi-protocol": "0.2.8",
+                "ws": "^8.18.3"
             },
             "engines": {
                 "node": ">=18"
@@ -8025,13 +7962,6 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/through": {
-            "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/tinybench": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8235,17 +8165,6 @@
             "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/unbzip2-stream": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-            "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
-            }
         },
         "node_modules/undici-types": {
             "version": "7.10.0",
@@ -8585,6 +8504,13 @@
                 "makeerror": "1.0.12"
             }
         },
+        "node_modules/webdriver-bidi-protocol": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.2.8.tgz",
+            "integrity": "sha512-KPvtVAIX8VHjLZH1KHT5GXoOaPeb0Ju+JlAcdshw6Z/gsmRtLoxt0Hw99PgJwZta7zUQaAUIHHWDRkzrPHsQTQ==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/webidl-conversions": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -8923,9 +8849,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.23.8",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
             "license": "MIT",
             "funding": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.2.0",
         "postcss": "^8.4.32",
+        "puppeteer": "^24.20.0",
         "simple-datatables": "^9.2.2",
         "tailwindcss": "^3.4.0",
         "vite": "^6.0.11",
-        "vitest": "^3.2.4",
-        "puppeteer": "^23.11.1"
+        "vitest": "^3.2.4"
     },
     "dependencies": {
         "@alpinejs/focus": "^3.14.9",


### PR DESCRIPTION
This pull request updates the `package.json` file to upgrade the `puppeteer` dependency and remove a duplicate entry. The main change is to ensure only the latest version of `puppeteer` is listed as a dev dependency.

Dependency management:

* Upgraded `puppeteer` from version `^23.11.1` to `^24.20.0` and removed the duplicate entry in the devDependencies section of `package.json`.