### PR TITLE
Refactor points handling with TeamPointService

### DIFF
--- a/app/Http/Controllers/TodoController.php
+++ b/app/Http/Controllers/TodoController.php
@@ -8,12 +8,17 @@ use App\Models\Team;
 use App\Models\Todo;
 use App\Models\TodoCategory;
 use App\Models\UserPoint;
+use App\Services\TeamPointService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Enums\Role;
 
 class TodoController extends Controller
 {
+    public function __construct(private TeamPointService $teamPointService)
+    {
+    }
+
     /**
      * Zeigt die Übersicht der Todos an.
      */
@@ -59,9 +64,7 @@ class TodoController extends Controller
             $todo->assigned_to !== $user->id
         );
 
-        $userPoints = UserPoint::where('user_id', $user->id)
-            ->where('team_id', $memberTeam->id)
-            ->sum('points');
+        $userPoints = $this->teamPointService->getUserPoints($user);
 
         return view('todos.index', [
             'todos' => $todos,

--- a/app/Services/TeamPointService.php
+++ b/app/Services/TeamPointService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Facades\Auth;
+
+class TeamPointService
+{
+    /**
+     * Get the total points of a user in their current team.
+     */
+    public function getUserPoints(User $user): int
+    {
+        $team = $user->currentTeam;
+
+        return $team ? $user->totalPointsForTeam($team) : 0;
+    }
+
+    /**
+     * Ensure the authenticated user has at least the required points.
+     *
+     * @throws AuthorizationException
+     */
+    public function assertMinPoints(int $required): void
+    {
+        /** @var User|null $user */
+        $user = Auth::user();
+        if (! $user) {
+            throw new AuthorizationException('Nicht authentifiziert.');
+        }
+
+        if ($this->getUserPoints($user) < $required) {
+            throw new AuthorizationException("Mindestens {$required} Baxx erforderlich.");
+        }
+    }
+}
+

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -39,6 +39,18 @@ class TodoControllerTest extends TestCase
         ], $attrs));
     }
 
+    public function test_index_displays_user_points(): void
+    {
+        $user = $this->actingMember();
+        $user->incrementTeamPoints(3);
+        $this->actingAs($user);
+
+        $response = $this->get('/aufgaben');
+
+        $response->assertOk();
+        $response->assertViewHas('userPoints', 3);
+    }
+
     public function test_member_can_assign_todo(): void
     {
         $user = $this->actingMember();

--- a/tests/Unit/TeamPointServiceTest.php
+++ b/tests/Unit/TeamPointServiceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\Role;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\TeamPointService;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TeamPointServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private TeamPointService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new TeamPointService();
+    }
+
+    private function memberWithPoints(int $points = 0): User
+    {
+        $team = Team::membersTeam();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => Role::Mitglied->value]);
+        if ($points > 0) {
+            $user->incrementTeamPoints($points);
+        }
+        return $user;
+    }
+
+    public function test_get_user_points_returns_team_points(): void
+    {
+        $user = $this->memberWithPoints(7);
+        $this->assertSame(7, $this->service->getUserPoints($user));
+    }
+
+    public function test_assert_min_points_passes_when_enough(): void
+    {
+        $user = $this->memberWithPoints(10);
+        $this->actingAs($user);
+        $this->service->assertMinPoints(5);
+        $this->assertTrue(true);
+    }
+
+    public function test_assert_min_points_throws_when_insufficient(): void
+    {
+        $user = $this->memberWithPoints(2);
+        $this->actingAs($user);
+        $this->expectException(AuthorizationException::class);
+        $this->service->assertMinPoints(5);
+    }
+}
+


### PR DESCRIPTION
This pull request introduces a new `TeamPointService` to centralize and simplify the logic for retrieving and validating user team points across multiple controllers. Several controllers are refactored to use this service, and new tests are added to ensure correctness.

### Introduction of TeamPointService

* Added a new `TeamPointService` class to encapsulate logic for retrieving a user's team points and asserting minimum required points, improving code reuse and maintainability.

### Refactoring Controllers to Use TeamPointService

* Updated `MaddraxiversumController`, `RewardController`, and `TodoController` to inject and use `TeamPointService` for all user point calculations and validations, replacing duplicated logic in each controller. [[1]](diffhunk://#diff-53a5fba91f37ab618b27111450aebcc58e78898c80c3375093bdad153cbef889R5) [[2]](diffhunk://#diff-53a5fba91f37ab618b27111450aebcc58e78898c80c3375093bdad153cbef889R14-R21) [[3]](diffhunk://#diff-53a5fba91f37ab618b27111450aebcc58e78898c80c3375093bdad153cbef889L24-L41) [[4]](diffhunk://#diff-57f93d4a24ef7789c42f6f47b760be30a7b6147ebd67f244539fb620601a3188R6-R15) [[5]](diffhunk://#diff-57f93d4a24ef7789c42f6f47b760be30a7b6147ebd67f244539fb620601a3188L19-R24) [[6]](diffhunk://#diff-57f93d4a24ef7789c42f6f47b760be30a7b6147ebd67f244539fb620601a3188L31-R37) [[7]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5R11-R21) [[8]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L62-R67)

### Testing

* Added a dedicated unit test for `TeamPointService` to verify correct point retrieval and authorization logic.
* Added a new feature test in `TodoControllerTest` to ensure the points are correctly displayed in the todo index view.