### PR TITLE
refactor controllers to use TeamPointService for user points

### DIFF
--- a/app/Http/Controllers/DownloadsController.php
+++ b/app/Http/Controllers/DownloadsController.php
@@ -6,9 +6,13 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use App\Models\User;
+use App\Services\TeamPointService;
 
 class DownloadsController extends Controller
 {
+    public function __construct(private TeamPointService $teamPointService)
+    {
+    }
     /**
      * Gesamte Download‑Konfiguration (Kategorie → Dateien).
      * Jede Datei enthält den Titel, den Dateinamen im privaten Storage
@@ -43,8 +47,7 @@ class DownloadsController extends Controller
     {
         /** @var User $user */
         $user = Auth::user();
-        $currentTeam = $user->currentTeam;
-        $userPoints = $currentTeam ? $user->totalPointsForTeam($currentTeam) : 0;
+        $userPoints = $this->teamPointService->getUserPoints($user);
 
         return view('pages.downloads', [
             'downloads' => $this->downloads,
@@ -70,8 +73,7 @@ class DownloadsController extends Controller
 
         /** @var User $user */
         $user = Auth::user();
-        $currentTeam = $user->currentTeam;
-        $userPoints = $currentTeam ? $user->totalPointsForTeam($currentTeam) : 0;
+        $userPoints = $this->teamPointService->getUserPoints($user);
 
         if ($userPoints < $meta['punkte']) {
             return back()->withErrors('Du hast nicht genügend Punkte für diesen Download.');

--- a/app/Http/Controllers/KompendiumController.php
+++ b/app/Http/Controllers/KompendiumController.php
@@ -10,9 +10,14 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\View\View;
 use App\Models\RomanExcerpt;
+use App\Services\TeamPointService;
 
 class KompendiumController extends Controller
 {
+    public function __construct(private TeamPointService $teamPointService)
+    {
+    }
+
     /** Mindest-Punktzahl für die Suche */
     private const REQUIRED_POINTS = 100;
 
@@ -22,8 +27,7 @@ class KompendiumController extends Controller
     public function index(Request $request): View
     {
         $user = Auth::user();
-        $currentTeam = $user->currentTeam;
-        $userPoints = $currentTeam ? $user->totalPointsForTeam($currentTeam) : 0;
+        $userPoints = $this->teamPointService->getUserPoints($user);
 
         return view('pages.kompendium', [
             'userPoints' => $userPoints,
@@ -39,8 +43,7 @@ class KompendiumController extends Controller
     {
         /* ----- Punkte-Check ------------------------------------------------ */
         $user = Auth::user();
-        $currentTeam = $user->currentTeam;
-        $userPoints = $currentTeam ? $user->totalPointsForTeam($currentTeam) : 0;
+        $userPoints = $this->teamPointService->getUserPoints($user);
 
         if ($userPoints < self::REQUIRED_POINTS) {
             return response()->json([

--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -7,9 +7,13 @@ use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
+use App\Services\TeamPointService;
 
 class StatistikController extends Controller
 {
+    public function __construct(private TeamPointService $teamPointService)
+    {
+    }
     /**
      * Zeigt die Statistik-Unterseite.
      *
@@ -21,7 +25,7 @@ class StatistikController extends Controller
         /** @var \App\Models\User $user */
         $user = Auth::user();
         $currentTeam = $user->currentTeam;
-        $userPoints = $currentTeam ? $user->totalPointsForTeam($currentTeam) : 0;
+        $userPoints = $this->teamPointService->getUserPoints($user);
 
         // ── JSON einlesen ──────────────────────────────────────────────────────────
         $jsonPath = storage_path('app/private/maddrax.json');

--- a/tests/Feature/RewardControllerTest.php
+++ b/tests/Feature/RewardControllerTest.php
@@ -73,6 +73,20 @@ class RewardControllerTest extends TestCase
         $response->assertSee('Statistik - Bewertungen der Hardcover');
     }
 
+    public function test_hardcover_reward_hidden_when_points_insufficient(): void
+    {
+        $user = $this->actingMember(39);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $rewards = $response->viewData('rewards');
+        $reward = collect($rewards)->firstWhere('title', 'Statistik - Bewertungen der Hardcover');
+        $this->assertNotNull($reward);
+        $this->assertEquals(0, $reward['percentage']);
+    }
+
     public function test_hardcover_author_reward_visible(): void
     {
         $user = $this->actingMember(41);
@@ -84,6 +98,20 @@ class RewardControllerTest extends TestCase
         $response->assertSee('Statistik - Maddrax-Hardcover je Autor:in');
     }
 
+    public function test_hardcover_author_reward_hidden_when_points_insufficient(): void
+    {
+        $user = $this->actingMember(40);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $rewards = $response->viewData('rewards');
+        $reward = collect($rewards)->firstWhere('title', 'Statistik - Maddrax-Hardcover je Autor:in');
+        $this->assertNotNull($reward);
+        $this->assertEquals(0, $reward['percentage']);
+    }
+
     public function test_top20_themes_reward_visible(): void
     {
         $user = $this->actingMember(42);
@@ -93,5 +121,19 @@ class RewardControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Statistik - TOP20 Maddrax-Themen');
+    }
+
+    public function test_top20_themes_reward_hidden_when_points_insufficient(): void
+    {
+        $user = $this->actingMember(41);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $rewards = $response->viewData('rewards');
+        $reward = collect($rewards)->firstWhere('title', 'Statistik - TOP20 Maddrax-Themen');
+        $this->assertNotNull($reward);
+        $this->assertEquals(0, $reward['percentage']);
     }
 }


### PR DESCRIPTION
This pull request refactors how user points are retrieved across several controllers by introducing and utilizing a new `TeamPointService`. It replaces repeated logic with service calls, improving code maintainability and consistency. Additionally, it adds new feature tests to ensure that rewards are correctly hidden when users lack sufficient points.

### Refactoring: Centralizing User Points Logic

* Injected `TeamPointService` into `DownloadsController`, `KompendiumController`, and `StatistikController` and replaced direct point calculation logic with calls to `getUserPoints()` from the service. This removes duplicated code and centralizes the logic for determining user points. [[1]](diffhunk://#diff-848cf5a982d074af6e38eef5a7f5dd9a108b0dad709aa54c104b6b88d9e7f0b7R9-R15) [[2]](diffhunk://#diff-848cf5a982d074af6e38eef5a7f5dd9a108b0dad709aa54c104b6b88d9e7f0b7L46-R50) [[3]](diffhunk://#diff-848cf5a982d074af6e38eef5a7f5dd9a108b0dad709aa54c104b6b88d9e7f0b7L73-R76) [[4]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173R13-R20) [[5]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173L25-R30) [[6]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173L42-R46) [[7]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR10-R16) [[8]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cL24-R28)

### Testing: Reward Visibility Based on Points

* Added new feature tests in `RewardControllerTest` to verify that specific rewards are hidden (i.e., their percentage is set to 0) when users do not have enough points. These tests cover different types of rewards and ensure correct behavior for users with insufficient points. [[1]](diffhunk://#diff-367775f3775fb00da2c433adc54c91953f314ee73ddf58ce2783b03ddf48bde5R76-R89) [[2]](diffhunk://#diff-367775f3775fb00da2c433adc54c91953f314ee73ddf58ce2783b03ddf48bde5R101-R114) [[3]](diffhunk://#diff-367775f3775fb00da2c433adc54c91953f314ee73ddf58ce2783b03ddf48bde5R125-R138)