### PR TITLE
refactor: centralize user role lookup

### DIFF
--- a/app/Http/Controllers/KassenbuchController.php
+++ b/app/Http/Controllers/KassenbuchController.php
@@ -10,23 +10,21 @@ use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use App\Enums\Role;
+use App\Services\UserRoleService;
 
 class KassenbuchController extends Controller
 {
+    public function __construct(private UserRoleService $userRoleService)
+    {
+    }
+
     public function index()
     {
         $user = Auth::user();
         $team = $user->currentTeam;
 
         // Benutzerrolle ermitteln
-        $userRole = Role::from(
-            $team->users()
-                ->where('user_id', $user->id)
-                ->first()
-                ->membership
-                ->role
-        );
+        $userRole = $this->userRoleService->getRole($user, $team);
 
         // Aktuellen Kassenstand abrufen
         $kassenstand = Kassenstand::where('team_id', $team->id)->first();

--- a/app/Http/Controllers/MitgliederController.php
+++ b/app/Http/Controllers/MitgliederController.php
@@ -9,9 +9,14 @@ use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use App\Enums\Role;
 use Illuminate\Validation\Rule;
+use App\Services\UserRoleService;
 
 class MitgliederController extends Controller
 {
+    public function __construct(private UserRoleService $userRoleService)
+    {
+    }
+
     public function index(Request $request)
     {
         $user = Auth::user();
@@ -61,13 +66,7 @@ class MitgliederController extends Controller
         }
 
         // Korrekte Ermittlung der Rolle des eingeloggten Nutzers
-        $userRole = Role::from(
-            $team->users()
-                ->where('user_id', $user->id)
-                ->first()
-                ->membership
-                ->role
-        );
+        $userRole = $this->userRoleService->getRole($user, $team);
 
         // Prüft, ob der aktuelle Benutzer erweiterte Rechte hat
         $canViewDetails = $user->can('manage', User::class);
@@ -109,22 +108,10 @@ class MitgliederController extends Controller
         $this->authorize('manage', User::class);
 
         // Korrekte Ermittlung der Rolle des eingeloggten Nutzers
-        $currentUserRole = Role::from(
-            $team->users()
-                ->where('user_id', $currentUser->id)
-                ->first()
-                ->membership
-                ->role
-        );
+        $currentUserRole = $this->userRoleService->getRole($currentUser, $team);
 
         // Rolle des zu ändernden Nutzers
-        $memberRole = Role::from(
-            $team->users()
-                ->where('user_id', $user->id)
-                ->first()
-                ->membership
-                ->role
-        );
+        $memberRole = $this->userRoleService->getRole($user, $team);
 
         // Rollenrangfolge festlegen (höhere Zahl = höherer Rang)
         $roleRanks = [
@@ -164,22 +151,10 @@ class MitgliederController extends Controller
         $this->authorize('manage', User::class);
 
         // Korrekte Ermittlung der Rolle des eingeloggten Nutzers
-        $currentUserRole = Role::from(
-            $team->users()
-                ->where('user_id', $currentUser->id)
-                ->first()
-                ->membership
-                ->role
-        );
+        $currentUserRole = $this->userRoleService->getRole($currentUser, $team);
 
         // Rolle des zu entfernenden Nutzers
-        $memberRole = Role::from(
-            $team->users()
-                ->where('user_id', $user->id)
-                ->first()
-                ->membership
-                ->role
-        );
+        $memberRole = $this->userRoleService->getRole($user, $team);
 
         // Rollenrangfolge festlegen (höhere Zahl = höherer Rang)
         $roleRanks = [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use App\Jobs\GeocodeUser;
 use Illuminate\Support\Facades\Schema;
 use App\Enums\Role;
+use App\Models\Membership;
 
 /**
  * @property-read Team|null $currentTeam
@@ -203,11 +204,11 @@ class User extends Authenticatable
             return null;
         }
 
-        $membership = $this->teams()
-            ->wherePivot('team_id', $this->currentTeam->id)
+        $membership = Membership::where('team_id', $this->currentTeam->id)
+            ->where('user_id', $this->id)
             ->first();
 
-        return Role::tryFrom($membership->membership->role ?? null);
+        return Role::tryFrom($membership->role ?? null);
     }
 
     /**

--- a/app/Services/UserRoleService.php
+++ b/app/Services/UserRoleService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\Role;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class UserRoleService
+{
+    /**
+     * Determine the role of a user within a given team.
+     *
+     * @throws ModelNotFoundException if the user is not a member of the team.
+     */
+    public function getRole(User $user, Team $team): Role
+    {
+        $membership = $team->users()
+            ->where('user_id', $user->id)
+            ->first();
+
+        if (! $membership) {
+            throw new ModelNotFoundException('Team membership not found.');
+        }
+
+        $role = Role::tryFrom($membership->membership->role);
+
+        if (! $role) {
+            throw new ModelNotFoundException('Role not found for user in team.');
+        }
+
+        return $role;
+    }
+}
+

--- a/app/Services/UserRoleService.php
+++ b/app/Services/UserRoleService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Enums\Role;
+use App\Models\Membership;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -16,7 +17,7 @@ class UserRoleService
      */
     public function getRole(User $user, Team $team): Role
     {
-        $membership = $team->users()
+        $membership = Membership::where('team_id', $team->id)
             ->where('user_id', $user->id)
             ->first();
 
@@ -24,7 +25,7 @@ class UserRoleService
             throw new ModelNotFoundException('Team membership not found.');
         }
 
-        $role = Role::tryFrom($membership->membership->role);
+        $role = Role::tryFrom($membership->role);
 
         if (! $role) {
             throw new ModelNotFoundException('Role not found for user in team.');

--- a/tests/Unit/UserRoleServiceTest.php
+++ b/tests/Unit/UserRoleServiceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\Role;
+use App\Models\Team;
+use App\Models\User;
+use App\Services\UserRoleService;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserRoleServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_role_returns_members_role(): void
+    {
+        $team = Team::membersTeam();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => Role::Admin->value]);
+
+        $service = new UserRoleService();
+
+        $this->assertSame(Role::Admin, $service->getRole($user, $team));
+    }
+
+    public function test_get_role_throws_when_membership_missing(): void
+    {
+        $team = Team::membersTeam();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+
+        $service = new UserRoleService();
+
+        $this->expectException(ModelNotFoundException::class);
+
+        $service->getRole($user, $team);
+    }
+
+    public function test_get_role_throws_on_invalid_role(): void
+    {
+        $team = Team::membersTeam();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => 'Gast']);
+
+        $service = new UserRoleService();
+
+        $this->expectException(ModelNotFoundException::class);
+
+        $service->getRole($user, $team);
+    }
+}
+


### PR DESCRIPTION
This pull request introduces a new `UserRoleService` to centralize and standardize how user roles are determined within teams, replacing various ad-hoc queries and direct pivot table access throughout the codebase. The change improves maintainability, error handling, and consistency across multiple controllers. Additionally, a unit test for the new service has been added.

**Core refactor: Centralized user role logic**

* Added `UserRoleService` with a `getRole` method to encapsulate logic for retrieving a user's role in a team, throwing a `ModelNotFoundException` if the membership or role is missing or invalid.
* Updated all relevant controllers (`ArbeitsgruppenController`, `DashboardController`, `KassenbuchController`, `MitgliederController`, `ProfileViewController`, `ReviewCommentController`, `RezensionController`, `TodoController`) to use `UserRoleService` for role determination, replacing previous direct queries and pivot table access. [[1]](diffhunk://#diff-16c1c90f92456becebb39bdcfb179196bc4cb0e277f32d70f4d554e36cfa2da7L9-R21) [[2]](diffhunk://#diff-16c1c90f92456becebb39bdcfb179196bc4cb0e277f32d70f4d554e36cfa2da7L130-R143) [[3]](diffhunk://#diff-16c1c90f92456becebb39bdcfb179196bc4cb0e277f32d70f4d554e36cfa2da7L210-R228) [[4]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bR18-R26) [[5]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL39-L49) [[6]](diffhunk://#diff-f126f13827761bec8194474e511e016693890b35b80b5e29e5531ec33fc95a0dL13-R27) [[7]](diffhunk://#diff-32e3609e5ae73a9edc203be7ab91eaeb10c5e704a6d7025815e7bb561470177bR12-R19) [[8]](diffhunk://#diff-32e3609e5ae73a9edc203be7ab91eaeb10c5e704a6d7025815e7bb561470177bL64-R69) [[9]](diffhunk://#diff-32e3609e5ae73a9edc203be7ab91eaeb10c5e704a6d7025815e7bb561470177bL112-R114) [[10]](diffhunk://#diff-32e3609e5ae73a9edc203be7ab91eaeb10c5e704a6d7025815e7bb561470177bL167-R157) [[11]](diffhunk://#diff-0088162d823e0e586b60dacd5b8ac2e1354881980c4cae22fba0331e8ba3d689R17-R25) [[12]](diffhunk://#diff-0088162d823e0e586b60dacd5b8ac2e1354881980c4cae22fba0331e8ba3d689L28-L58) [[13]](diffhunk://#diff-8172677ea5f39753dbec53d4a1601d7cad3f4d09e9cec4a01dd58e1d2aea2cbcL12-R22) [[14]](diffhunk://#diff-8172677ea5f39753dbec53d4a1601d7cad3f4d09e9cec4a01dd58e1d2aea2cbcL32-R47) [[15]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L11-R26) [[16]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L37-R53) [[17]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5R15-R23) [[18]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L39-R47) [[19]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L155-R166)

**Error handling improvements**

* Improved error handling for missing memberships or invalid roles by catching `ModelNotFoundException` and providing user feedback or fallback logic in controllers. [[1]](diffhunk://#diff-16c1c90f92456becebb39bdcfb179196bc4cb0e277f32d70f4d554e36cfa2da7L130-R143) [[2]](diffhunk://#diff-16c1c90f92456becebb39bdcfb179196bc4cb0e277f32d70f4d554e36cfa2da7L210-R228) [[3]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL39-L49) [[4]](diffhunk://#diff-0088162d823e0e586b60dacd5b8ac2e1354881980c4cae22fba0331e8ba3d689L28-L58) [[5]](diffhunk://#diff-8172677ea5f39753dbec53d4a1601d7cad3f4d09e9cec4a01dd58e1d2aea2cbcL32-R47) [[6]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L37-R53) [[7]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L39-R47) [[8]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L155-R166)

**Testing**

* Added `UserRoleServiceTest` to verify correct role retrieval and proper exception handling for missing or invalid roles.

**Model adjustment**

* Updated `User::role()` to use the `Membership` model directly instead of accessing the pivot table via relationships, aligning with the new service logic. [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR18) [[2]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbL206-R211)