### PR TITLE
Refactor validation into FormRequests

### DIFF
--- a/app/Http/Controllers/RezensionController.php
+++ b/app/Http/Controllers/RezensionController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ReviewRequest;
 use Illuminate\Http\Request;
 use App\Models\Book;
 use App\Enums\BookType;
@@ -213,7 +214,7 @@ class RezensionController extends Controller
     /**
      * Speichern einer neuen Rezension.
      */
-    public function store(Request $request, Book $book)
+    public function store(ReviewRequest $request, Book $book)
     {
         $user = Auth::user();
         $role = $this->getRoleInMemberTeam();
@@ -228,14 +229,7 @@ class RezensionController extends Controller
             abort(403);
         }
 
-        $request->merge([
-            'content' => preg_replace('/^\\s*#+\\s*/m', '', (string) $request->input('content')),
-        ]);
-
-        $data = $request->validate([
-            'title' => 'required|string|max:255',
-            'content' => 'required|string|min:140',
-        ]);
+        $data = $request->validated();
 
         $review = Review::create([
             'team_id' => $teamId,
@@ -296,20 +290,13 @@ class RezensionController extends Controller
     /**
      * Aktualisieren einer Rezension.
      */
-    public function update(Request $request, Review $review)
+    public function update(ReviewRequest $request, Review $review)
     {
         $user = Auth::user();
         $role = $this->getRoleInMemberTeam();
 
         if ($review->user_id === $user->id || in_array($role, [Role::Vorstand, Role::Admin], true)) {
-            $request->merge([
-                'content' => preg_replace('/^\\s*#+\\s*/m', '', (string) $request->input('content')),
-            ]);
-
-            $data = $request->validate([
-                'title' => 'required|string|max:255',
-                'content' => 'required|string|min:140',
-            ]);
+            $data = $request->validated();
 
             $review->update($data);
 

--- a/app/Http/Controllers/TodoController.php
+++ b/app/Http/Controllers/TodoController.php
@@ -10,6 +10,7 @@ use App\Models\TodoCategory;
 use App\Models\UserPoint;
 use App\Services\TeamPointService;
 use Illuminate\Http\Request;
+use App\Http\Requests\TodoRequest;
 use Illuminate\Support\Facades\Auth;
 use App\Enums\Role;
 use App\Services\UserRoleService;
@@ -113,7 +114,7 @@ class TodoController extends Controller
     /**
      * Speichert ein neues Todo.
      */
-    public function store(Request $request)
+    public function store(TodoRequest $request)
     {
         $user = Auth::user();
         $memberTeam = Team::membersTeam();
@@ -125,20 +126,15 @@ class TodoController extends Controller
 
         $this->authorize('create', Todo::class);
 
-        $request->validate([
-            'title' => 'required|string|max:255',
-            'description' => 'nullable|string',
-            'points' => 'required|integer|min:1|max:1000',
-            'category_id' => 'required|exists:todo_categories,id',
-        ]);
+        $data = $request->validated();
 
         Todo::create([
             'team_id' => $memberTeam->id,
             'created_by' => $user->id,
-            'title' => $request->title,
-            'description' => $request->description,
-            'points' => $request->points,
-            'category_id' => $request->category_id,
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'points' => $data['points'],
+            'category_id' => $data['category_id'],
             'status' => 'open',
         ]);
 
@@ -209,7 +205,7 @@ class TodoController extends Controller
     /**
      * Aktualisiert ein Todo.
      */
-    public function update(Request $request, Todo $todo)
+    public function update(TodoRequest $request, Todo $todo)
     {
         $user = Auth::user();
         $memberTeam = Team::membersTeam();
@@ -221,18 +217,13 @@ class TodoController extends Controller
 
         $this->authorize('update', $todo);
 
-        $request->validate([
-            'title' => 'required|string|max:255',
-            'description' => 'nullable|string',
-            'points' => 'required|integer|min:1|max:1000',
-            'category_id' => 'required|exists:todo_categories,id',
-        ]);
+        $data = $request->validated();
 
         $todo->update([
-            'title' => $request->title,
-            'description' => $request->description,
-            'points' => $request->points,
-            'category_id' => $request->category_id,
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'points' => $data['points'],
+            'category_id' => $data['category_id'],
         ]);
 
         return redirect()->route('todos.show', $todo)

--- a/app/Http/Requests/AudiobookEpisodeRequest.php
+++ b/app/Http/Requests/AudiobookEpisodeRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\AudiobookEpisodeStatus;
+use App\Rules\ValidReleaseTime;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class AudiobookEpisodeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $episodeId = $this->route('episode')?->id;
+
+        return [
+            'episode_number' => [
+                'required',
+                'string',
+                'max:10',
+                Rule::unique('audiobook_episodes', 'episode_number')->ignore($episodeId),
+            ],
+            'title' => 'required|string|max:255',
+            'author' => 'required|string|max:255',
+            'planned_release_date' => ['required', 'string', new ValidReleaseTime],
+            'status' => 'required|in:' . implode(',', AudiobookEpisodeStatus::values()),
+            'responsible_user_id' => 'nullable|exists:users,id',
+            'progress' => 'required|integer|min:0|max:100',
+            'notes' => 'nullable|string',
+            'roles' => 'array',
+            'roles.*.name' => 'required|string|max:255',
+            'roles.*.description' => 'nullable|string|max:1000',
+            'roles.*.takes' => 'required|integer|min:0',
+            'roles.*.member_id' => 'nullable|exists:users,id',
+            'roles.*.member_name' => 'nullable|string|max:255',
+        ];
+    }
+}

--- a/app/Http/Requests/AudiobookPreviousSpeakerRequest.php
+++ b/app/Http/Requests/AudiobookPreviousSpeakerRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AudiobookPreviousSpeakerRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+        ];
+    }
+}

--- a/app/Http/Requests/ReviewRequest.php
+++ b/app/Http/Requests/ReviewRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReviewRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'content' => preg_replace('/^\\s*#+\\s*/m', '', (string) $this->input('content')),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'content' => 'required|string|min:140',
+        ];
+    }
+}

--- a/app/Http/Requests/TodoRequest.php
+++ b/app/Http/Requests/TodoRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TodoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'points' => 'required|integer|min:1|max:1000',
+            'category_id' => 'required|exists:todo_categories,id',
+        ];
+    }
+}

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -165,6 +165,18 @@ class HoerbuchControllerTest extends TestCase
         $this->assertEquals(1, AudiobookEpisode::where('episode_number', 'F30')->count());
     }
 
+    public function test_store_validation_errors(): void
+    {
+        $user = $this->actingMember('Admin');
+
+        $response = $this->actingAs($user)
+            ->from(route('hoerbuecher.create'))
+            ->post(route('hoerbuecher.store'), []);
+
+        $response->assertRedirect(route('hoerbuecher.create', [], false));
+        $response->assertSessionHasErrors(['episode_number', 'title', 'author', 'planned_release_date', 'status', 'progress']);
+    }
+
     public function test_member_cannot_view_create_form(): void
     {
         $user = $this->actingMember('Mitglied');
@@ -538,6 +550,37 @@ class HoerbuchControllerTest extends TestCase
             'roles_filled' => 1,
             'notes' => 'Aktualisiert',
         ]);
+    }
+
+    public function test_update_validation_errors(): void
+    {
+        $user = $this->actingMember('Admin');
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F2',
+            'title' => 'Alt',
+            'author' => 'Autor',
+            'planned_release_date' => '12.2025',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'roles_total' => 0,
+            'roles_filled' => 0,
+            'notes' => null,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->from(route('hoerbuecher.edit', $episode))
+            ->put(route('hoerbuecher.update', $episode), [
+                'episode_number' => '',
+                'title' => '',
+                'author' => '',
+                'planned_release_date' => '',
+                'status' => '',
+                'progress' => 200,
+            ]);
+
+        $response->assertRedirect(route('hoerbuecher.edit', $episode, false));
+        $response->assertSessionHasErrors(['episode_number', 'title', 'author', 'planned_release_date', 'status', 'progress']);
     }
 
     public function test_admin_can_delete_episode(): void

--- a/tests/Feature/RezensionControllerTest.php
+++ b/tests/Feature/RezensionControllerTest.php
@@ -275,6 +275,33 @@ class RezensionControllerTest extends TestCase
         $this->assertSoftDeleted('reviews', ['id' => $review->id]);
     }
 
+    public function test_update_validation_errors(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $book = Book::create([
+            'roman_number' => 1,
+            'title' => 'Test',
+            'author' => 'Autor',
+        ]);
+        $review = Review::create([
+            'team_id' => Team::membersTeam()->id,
+            'user_id' => $admin->id,
+            'book_id' => $book->id,
+            'title' => 'Old',
+            'content' => str_repeat('A', 140),
+        ]);
+
+        $response = $this->actingAs($admin)
+            ->from(route('reviews.edit', $review))
+            ->put(route('reviews.update', $review), [
+                'title' => '',
+                'content' => 'short',
+            ]);
+
+        $response->assertRedirect(route('reviews.edit', $review, false));
+        $response->assertSessionHasErrors(['title', 'content']);
+    }
+
     public function test_show_displays_review_for_author(): void
     {
         $user = $this->actingMember();

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -156,6 +156,23 @@ class TodoControllerTest extends TestCase
         $this->assertSame(10, $todo->points);
     }
 
+    public function test_update_validation_errors(): void
+    {
+        $user = $this->actingMember('Admin');
+        $todo = $this->createTodo($user);
+        $this->actingAs($user);
+
+        $response = $this->from(route('todos.edit', $todo))
+            ->put(route('todos.update', $todo), [
+                'title' => '',
+                'points' => 0,
+                'category_id' => null,
+            ]);
+
+        $response->assertRedirect(route('todos.edit', $todo, false));
+        $response->assertSessionHasErrors(['title', 'points', 'category_id']);
+    }
+
     public function test_non_creator_cannot_update_todo(): void
     {
         $creator = $this->actingMember('Admin');
@@ -225,6 +242,18 @@ class TodoControllerTest extends TestCase
             'title' => 'New Todo',
             'created_by' => $user->id,
         ]);
+    }
+
+    public function test_store_validation_errors(): void
+    {
+        $user = $this->actingMember('Admin');
+        $this->actingAs($user);
+
+        $response = $this->from(route('todos.index'))
+            ->post('/aufgaben', []);
+
+        $response->assertRedirect(route('todos.index', [], false));
+        $response->assertSessionHasErrors(['title', 'points', 'category_id']);
     }
 
     public function test_show_displays_todo_and_permissions(): void


### PR DESCRIPTION
This pull request refactors several controllers to use custom Form Request classes for validation instead of inline validation logic. This change centralizes validation rules, improves code readability, and makes validation more reusable and testable. Additionally, new and more comprehensive validation tests have been added to ensure correct error handling across the application.

**Controller Refactoring:**

* Replaced inline validation in `HoerbuchController`, `RezensionController`, and `TodoController` with dedicated Form Request classes (`AudiobookEpisodeRequest`, `AudiobookPreviousSpeakerRequest`, `ReviewRequest`, and `TodoRequest`). Controller methods now typehint these requests, and use `$request->validated()` for accessing validated input. [[1]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL9-R12) [[2]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL70-R71) [[3]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL130-R133) [[4]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL207-R194) [[5]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL256-R224) [[6]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004R5) [[7]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L216-R217) [[8]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L231-R232) [[9]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L299-R299) [[10]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5R13) [[11]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L116-R117) [[12]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L128-R137) [[13]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L212-R208) [[14]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L224-R226)

**New Form Request Classes:**

* Added `AudiobookEpisodeRequest`, `AudiobookPreviousSpeakerRequest`, `ReviewRequest`, and `TodoRequest` in `app/Http/Requests/`, encapsulating validation rules and, where needed, input preparation logic (e.g., cleaning up review content in `ReviewRequest`). [[1]](diffhunk://#diff-7f98bb8b3d71579f995789d2596a35ab5017b11728da74010d5d8d5c4ffd2e79R1-R43) [[2]](diffhunk://#diff-1c9dd3cb84bf94486218e2177ff292c6cc632d37c4d7cf00bc09979267164db4R1-R20) [[3]](diffhunk://#diff-35e92200ef4152215669175a5556fa0cee3cb9d8b6659d9b20867effc5f6851dR1-R28) [[4]](diffhunk://#diff-3dd6b134e19474183d149070e506de1ec921cef43051df3796638d360a1914daR1-R23)

**Testing Improvements:**

* Added new feature tests to verify validation error handling for storing and updating audiobooks, reviews, and todos. These tests confirm that invalid input redirects appropriately and sets session errors for required fields. [[1]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1R168-R179) [[2]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1R555-R585) [[3]](diffhunk://#diff-c6cb5de1de52446d6a7697a615d2b09851d53cc2bb3c9f9ba83dafa323ff5355R278-R304) [[4]](diffhunk://#diff-669cfc3d38315de73b5673ec24d0cd9fd372b85892c838739f395885b034fef7R159-R175) [[5]](diffhunk://#diff-669cfc3d38315de73b5673ec24d0cd9fd372b85892c838739f395885b034fef7R247-R258)