### PR TITLE
Use MembersTeamProvider service for member team access

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -6,7 +6,6 @@ use App\Mail\MitgliedGenehmigtMail;
 use App\Models\Activity;
 use App\Models\Review;
 use App\Models\ReviewComment;
-use App\Models\Team;
 use App\Models\Todo;
 use App\Models\User;
 use App\Models\UserPoint;
@@ -16,12 +15,15 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use App\Enums\Role;
 use App\Services\UserRoleService;
+use App\Services\MembersTeamProvider;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class DashboardController extends Controller
 {
-    public function __construct(private UserRoleService $userRoleService)
-    {
+    public function __construct(
+        private UserRoleService $userRoleService,
+        private MembersTeamProvider $membersTeamProvider
+    ) {
     }
 
     public function index()
@@ -60,7 +62,7 @@ class DashboardController extends Controller
         }
 
         // ToDo-Statistiken abrufen
-        $memberTeam = Team::membersTeam();
+        $memberTeam = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         // Initialisierung der Variablen
         $openTodos = 0;

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -29,7 +29,7 @@ class DashboardController extends Controller
     public function index()
     {
         $user = Auth::user();
-        $team = $user->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         $cacheFor = now()->addMinutes(10);
 
@@ -62,7 +62,6 @@ class DashboardController extends Controller
         }
 
         // ToDo-Statistiken abrufen
-        $memberTeam = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         // Initialisierung der Variablen
         $openTodos = 0;
@@ -74,91 +73,89 @@ class DashboardController extends Controller
         $myReviews = 0;
         $myReviewComments = 0;
 
-        if ($memberTeam) {
-            // Offene Aufgaben
-            $openTodos = Cache::remember(
-                "open_todos_{$memberTeam->id}",
+        // Offene Aufgaben
+        $openTodos = Cache::remember(
+            "open_todos_{$team->id}",
+            $cacheFor,
+            fn () => Todo::where('team_id', $team->id)
+                ->where('status', 'open')
+                ->count()
+        );
+
+        // Punkte des angemeldeten Nutzers
+        $userPoints = Cache::remember(
+            "user_points_{$team->id}_{$user->id}",
+            $cacheFor,
+            fn () => UserPoint::where('user_id', $user->id)
+                ->where('team_id', $team->id)
+                ->sum('points')
+        );
+
+        // Abgeschlossene Aufgaben des Nutzers
+        $completedTodos = Cache::remember(
+            "completed_todos_{$team->id}_{$user->id}",
+            $cacheFor,
+            fn () => UserPoint::where('user_id', $user->id)
+                ->where('team_id', $team->id)
+                ->count()
+        );
+
+        // Aufgaben, die auf Verifizierung warten (nur für Admins sichtbar)
+        if (in_array($userRole, $allowedRoles, true)) {
+            $pendingVerification = Cache::remember(
+                "pending_verification_{$team->id}",
                 $cacheFor,
-                fn () => Todo::where('team_id', $memberTeam->id)
-                    ->where('status', 'open')
+                fn () => Todo::where('team_id', $team->id)
+                    ->where('status', 'completed')
                     ->count()
-            );
-
-            // Punkte des angemeldeten Nutzers
-            $userPoints = Cache::remember(
-                "user_points_{$memberTeam->id}_{$user->id}",
-                $cacheFor,
-                fn () => UserPoint::where('user_id', $user->id)
-                    ->where('team_id', $memberTeam->id)
-                    ->sum('points')
-            );
-
-            // Abgeschlossene Aufgaben des Nutzers
-            $completedTodos = Cache::remember(
-                "completed_todos_{$memberTeam->id}_{$user->id}",
-                $cacheFor,
-                fn () => UserPoint::where('user_id', $user->id)
-                    ->where('team_id', $memberTeam->id)
-                    ->count()
-            );
-
-            // Aufgaben, die auf Verifizierung warten (nur für Admins sichtbar)
-            if (in_array($userRole, $allowedRoles, true)) {
-                $pendingVerification = Cache::remember(
-                    "pending_verification_{$memberTeam->id}",
-                    $cacheFor,
-                    fn () => Todo::where('team_id', $memberTeam->id)
-                        ->where('status', 'completed')
-                        ->count()
-                );
-            }
-
-            // TOP3 Nutzer mit den meisten Punkten
-            $topUsers = Cache::remember(
-                "top_users_{$memberTeam->id}",
-                $cacheFor,
-                function () use ($memberTeam) {
-                    return UserPoint::where('team_id', $memberTeam->id)
-                        ->select('user_id', DB::raw('SUM(points) as total_points'))
-                        ->groupBy('user_id')
-                        ->orderBy('total_points', 'desc')
-                        ->limit(3)
-                        ->get()
-                        ->map(function ($item) {
-                            $user = User::find($item->user_id);
-
-                            return [
-                                'id' => $user->id,
-                                'name' => $user->name,
-                                'profile_photo_url' => $user->profile_photo_url,
-                                'points' => $item->total_points,
-                            ];
-                        });
-                }
             );
         }
 
+        // TOP3 Nutzer mit den meisten Punkten
+        $topUsers = Cache::remember(
+            "top_users_{$team->id}",
+            $cacheFor,
+            function () use ($team) {
+                return UserPoint::where('team_id', $team->id)
+                    ->select('user_id', DB::raw('SUM(points) as total_points'))
+                    ->groupBy('user_id')
+                    ->orderBy('total_points', 'desc')
+                    ->limit(3)
+                    ->get()
+                    ->map(function ($item) {
+                        $user = User::find($item->user_id);
+
+                        return [
+                            'id' => $user->id,
+                            'name' => $user->name,
+                            'profile_photo_url' => $user->profile_photo_url,
+                            'points' => $item->total_points,
+                        ];
+                    });
+            }
+        );
+
         // Rezensionen zählen
         $allReviews = Cache::remember(
-            "all_reviews_{$memberTeam->id}",
+            "all_reviews_{$team->id}",
             $cacheFor,
-            fn () => Review::where('team_id', $memberTeam->id)->count()
+            fn () => Review::where('team_id', $team->id)->count()
         );
         $myReviews = Cache::remember(
-            "my_reviews_{$memberTeam->id}_{$user->id}",
+            "my_reviews_{$team->id}_{$user->id}",
             $cacheFor,
-            fn () => Review::where('team_id', $memberTeam->id)
+            fn () => Review::where('team_id', $team->id)
                 ->where('user_id', $user->id)
                 ->count()
         );
 
         // Eigene Kommentare auf Rezensionen
         $myReviewComments = Cache::remember(
-            "my_review_comments_{$memberTeam->id}_{$user->id}",
+            "my_review_comments_{$team->id}_{$user->id}",
             $cacheFor,
             fn () => ReviewComment::where('user_id', $user->id)
-                ->whereHas('review', function ($query) use ($memberTeam) {
-                    $query->where('team_id', $memberTeam->id);
+                ->whereHas('review', function ($query) use ($team) {
+                    $query->where('team_id', $team->id);
                 })
                 ->count()
         );
@@ -187,7 +184,7 @@ class DashboardController extends Controller
 
     public function approveAnwaerter(User $user)
     {
-        $team = $user->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
         $team->users()->updateExistingPivot($user->id, ['role' => Role::Mitglied->value]);
         // Mitgliedsdatum setzen
         $user->mitglied_seit = now()->toDateString();
@@ -209,7 +206,7 @@ class DashboardController extends Controller
 
     public function rejectAnwaerter(User $user)
     {
-        $team = $user->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
         $team->users()->detach($user->id);
         $user->delete();
 

--- a/app/Http/Controllers/KassenbuchController.php
+++ b/app/Http/Controllers/KassenbuchController.php
@@ -11,17 +11,20 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use App\Services\UserRoleService;
+use App\Services\MembersTeamProvider;
 
 class KassenbuchController extends Controller
 {
-    public function __construct(private UserRoleService $userRoleService)
-    {
+    public function __construct(
+        private UserRoleService $userRoleService,
+        private MembersTeamProvider $membersTeamProvider
+    ) {
     }
 
     public function index()
     {
         $user = Auth::user();
-        $team = $user->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         // Benutzerrolle ermitteln
         $userRole = $this->userRoleService->getRole($user, $team);
@@ -88,7 +91,7 @@ class KassenbuchController extends Controller
         ]);
 
         $currentUser = Auth::user();
-        $team = $currentUser->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         $this->authorize('manage', KassenbuchEntry::class);
 
@@ -112,7 +115,7 @@ class KassenbuchController extends Controller
         ]);
 
         $user = Auth::user();
-        $team = $user->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         $this->authorize('manage', KassenbuchEntry::class);
 

--- a/app/Http/Controllers/MitgliederController.php
+++ b/app/Http/Controllers/MitgliederController.php
@@ -10,17 +10,20 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use App\Enums\Role;
 use Illuminate\Validation\Rule;
 use App\Services\UserRoleService;
+use App\Services\MembersTeamProvider;
 
 class MitgliederController extends Controller
 {
-    public function __construct(private UserRoleService $userRoleService)
-    {
+    public function __construct(
+        private UserRoleService $userRoleService,
+        private MembersTeamProvider $membersTeamProvider
+    ) {
     }
 
     public function index(Request $request)
     {
         $user = Auth::user();
-        $team = $user->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         // Sortierparameter auslesen
         $sortBy = $request->input('sort', 'nachname'); // Standardsortierung: Nachname
@@ -103,7 +106,7 @@ class MitgliederController extends Controller
         ]);
 
         $currentUser = Auth::user();
-        $team = $currentUser->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         $this->authorize('manage', User::class);
 
@@ -146,7 +149,7 @@ class MitgliederController extends Controller
     public function removeMember(User $user)
     {
         $currentUser = Auth::user();
-        $team = $currentUser->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         $this->authorize('manage', User::class);
 
@@ -190,7 +193,7 @@ class MitgliederController extends Controller
     public function exportCsv(Request $request)
     {
         $user = Auth::user();
-        $team = $user->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         $this->authorize('manage', User::class);
 
@@ -278,7 +281,7 @@ class MitgliederController extends Controller
     public function getAllEmails()
     {
         $user = Auth::user();
-        $team = $user->currentTeam;
+        $team = $this->membersTeamProvider->getMembersTeamOrAbort();
 
         $this->authorize('manage', User::class);
 

--- a/app/Services/MembersTeamProvider.php
+++ b/app/Services/MembersTeamProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Team;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class MembersTeamProvider
+{
+    public function getMembersTeamOrAbort(): Team
+    {
+        $team = Team::membersTeam();
+
+        if (! $team) {
+            throw new HttpResponseException(
+                redirect('/')->with('error', 'Team "Mitglieder" nicht gefunden.')
+            );
+        }
+
+        return $team;
+    }
+}

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Mail;
 use App\Mail\MitgliedGenehmigtMail;
 use App\Enums\TodoStatus;
 use App\Enums\Role;
+use App\Services\MembersTeamProvider;
 
 class DashboardControllerTest extends TestCase
 {
@@ -152,5 +153,18 @@ class DashboardControllerTest extends TestCase
 
         $response->assertRedirect('/');
         $response->assertSessionHas('error');
+    }
+
+    public function test_index_uses_members_team_provider(): void
+    {
+        $team = Team::membersTeam();
+        $user = $this->actingAdmin();
+        $this->actingAs($user);
+
+        $this->mock(MembersTeamProvider::class, function ($mock) use ($team) {
+            $mock->shouldReceive('getMembersTeamOrAbort')->once()->andReturn($team);
+        });
+
+        $this->get('/dashboard')->assertOk();
     }
 }

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -167,4 +167,37 @@ class DashboardControllerTest extends TestCase
 
         $this->get('/dashboard')->assertOk();
     }
+
+    public function test_approve_uses_members_team_provider(): void
+    {
+        Mail::fake();
+        $admin = $this->actingAdmin();
+        $applicant = $this->createApplicant();
+        $team = Team::membersTeam();
+        $this->actingAs($admin);
+
+        $this->mock(MembersTeamProvider::class, function ($mock) use ($team) {
+            $mock->shouldReceive('getMembersTeamOrAbort')->once()->andReturn($team);
+        });
+
+        $this->from('/dashboard')
+            ->post(route('anwaerter.approve', $applicant))
+            ->assertRedirect('/dashboard');
+    }
+
+    public function test_reject_uses_members_team_provider(): void
+    {
+        $admin = $this->actingAdmin();
+        $applicant = $this->createApplicant();
+        $team = Team::membersTeam();
+        $this->actingAs($admin);
+
+        $this->mock(MembersTeamProvider::class, function ($mock) use ($team) {
+            $mock->shouldReceive('getMembersTeamOrAbort')->once()->andReturn($team);
+        });
+
+        $this->from('/dashboard')
+            ->post(route('anwaerter.reject', $applicant))
+            ->assertRedirect('/dashboard');
+    }
 }

--- a/tests/Feature/KassenbuchControllerTest.php
+++ b/tests/Feature/KassenbuchControllerTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Enums\Role;
+use App\Services\MembersTeamProvider;
 
 class KassenbuchControllerTest extends TestCase
 {
@@ -201,5 +202,18 @@ class KassenbuchControllerTest extends TestCase
 
         $response->assertRedirect('/kassenbuch');
         $response->assertSessionHasErrors(['buchungsdatum', 'betrag', 'beschreibung', 'typ']);
+    }
+
+    public function test_index_uses_members_team_provider(): void
+    {
+        $team = Team::membersTeam();
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $this->mock(MembersTeamProvider::class, function ($mock) use ($team) {
+            $mock->shouldReceive('getMembersTeamOrAbort')->once()->andReturn($team);
+        });
+
+        $this->get('/kassenbuch')->assertOk();
     }
 }

--- a/tests/Feature/MitgliederControllerTest.php
+++ b/tests/Feature/MitgliederControllerTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use App\Enums\Role;
+use App\Services\MembersTeamProvider;
 
 class MitgliederControllerTest extends TestCase
 {
@@ -342,5 +343,18 @@ class MitgliederControllerTest extends TestCase
         $members = $response->viewData('members');
         $this->assertCount(1, $members);
         $this->assertTrue($members->contains('id', $online->id));
+    }
+
+    public function test_index_uses_members_team_provider(): void
+    {
+        $team = Team::membersTeam();
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $this->mock(MembersTeamProvider::class, function ($mock) use ($team) {
+            $mock->shouldReceive('getMembersTeamOrAbort')->once()->andReturn($team);
+        });
+
+        $this->get('/mitglieder')->assertOk();
     }
 }

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -9,6 +9,7 @@ use App\Models\TodoCategory;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Services\MembersTeamProvider;
 
 class TodoControllerTest extends TestCase
 {
@@ -280,5 +281,18 @@ class TodoControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertViewIs('todos.edit');
+    }
+
+    public function test_index_uses_members_team_provider(): void
+    {
+        $team = Team::membersTeam();
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $this->mock(MembersTeamProvider::class, function ($mock) use ($team) {
+            $mock->shouldReceive('getMembersTeamOrAbort')->once()->andReturn($team);
+        });
+
+        $this->get('/aufgaben')->assertOk();
     }
 }

--- a/tests/Unit/MembersTeamProviderTest.php
+++ b/tests/Unit/MembersTeamProviderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Team;
+use App\Services\MembersTeamProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Tests\TestCase;
+
+class MembersTeamProviderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_team_when_exists(): void
+    {
+        $service = new MembersTeamProvider();
+        $team = $service->getMembersTeamOrAbort();
+
+        $this->assertInstanceOf(Team::class, $team);
+        $this->assertSame('Mitglieder', $team->name);
+    }
+
+    public function test_redirects_when_team_missing(): void
+    {
+        Team::query()->where('name', 'Mitglieder')->delete();
+        Team::clearMembersTeamCache();
+        session()->start();
+
+        $service = new MembersTeamProvider();
+
+        try {
+            $service->getMembersTeamOrAbort();
+            $this->fail('Expected HttpResponseException not thrown');
+        } catch (HttpResponseException $e) {
+            $this->assertEquals('/', $e->getResponse()->headers->get('Location'));
+            $this->assertEquals('Team "Mitglieder" nicht gefunden.', $e->getResponse()->getSession()->get('error'));
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new service, `MembersTeamProvider`, to centralize and standardize access to the "Mitglieder" team throughout the application. Multiple controllers are refactored to use this service instead of directly querying the `Team` model or accessing `currentTeam`, improving code consistency and error handling. Additionally, the change is thoroughly tested with new and updated feature and unit tests.

**Core refactoring and service introduction:**

* Introduced the new service `MembersTeamProvider` with a `getMembersTeamOrAbort()` method, which retrieves the "Mitglieder" team or aborts with a redirect and error message if not found. (`app/Services/MembersTeamProvider.php`)
* Refactored `DashboardController`, `KassenbuchController`, `MitgliederController`, and `TodoController` to use dependency injection for `MembersTeamProvider` and replaced all direct calls to `Team::membersTeam()` or `$user->currentTeam` with the new service method. [[1]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bR18-R26) [[2]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL63-R65) [[3]](diffhunk://#diff-f126f13827761bec8194474e511e016693890b35b80b5e29e5531ec33fc95a0dR14-R27) [[4]](diffhunk://#diff-f126f13827761bec8194474e511e016693890b35b80b5e29e5531ec33fc95a0dL91-R94) [[5]](diffhunk://#diff-f126f13827761bec8194474e511e016693890b35b80b5e29e5531ec33fc95a0dL115-R118) [[6]](diffhunk://#diff-32e3609e5ae73a9edc203be7ab91eaeb10c5e704a6d7025815e7bb561470177bR13-R26) [[7]](diffhunk://#diff-32e3609e5ae73a9edc203be7ab91eaeb10c5e704a6d7025815e7bb561470177bL106-R109) [[8]](diffhunk://#diff-32e3609e5ae73a9edc203be7ab91eaeb10c5e704a6d7025815e7bb561470177bL149-R152) [[9]](diffhunk://#diff-32e3609e5ae73a9edc203be7ab91eaeb10c5e704a6d7025815e7bb561470177bL193-R196) [[10]](diffhunk://#diff-32e3609e5ae73a9edc203be7ab91eaeb10c5e704a6d7025815e7bb561470177bL281-R284) [[11]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L7-R23) [[12]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L33-R33) [[13]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L97-R88) [[14]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L120-R106) [[15]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L151-R134) [[16]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L188-R171) [[17]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L211-R194) [[18]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L239-R222) [[19]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L296-R279)

**Testing improvements:**

* Added a unit test for `MembersTeamProvider` to verify correct retrieval and error handling when the team is missing. (`tests/Unit/MembersTeamProviderTest.php`)
* Updated feature tests for all affected controllers to mock and assert the use of `MembersTeamProvider`. (`tests/Feature/DashboardControllerTest.php`, `tests/Feature/KassenbuchControllerTest.php`, `tests/Feature/MitgliederControllerTest.php`, `tests/Feature/TodoControllerTest.php`) [[1]](diffhunk://#diff-8e47be296d24cc8e024bdf269c048da270c837709c1a080daa0fd209a18a5a49R157-R169) [[2]](diffhunk://#diff-2889f222aeb97d9921f9ac83748605da022b1ac3360d4f022c2d5f5a799a0a8fR206-R218) [[3]](diffhunk://#diff-184829af18e38beeddf5af13eeebd4cb6e5348777b7115f62b8281e91c8518faR347-R359) [[4]](diffhunk://#diff-669cfc3d38315de73b5673ec24d0cd9fd372b85892c838739f395885b034fef7R285-R297)

These changes improve maintainability, ensure consistent error handling, and make the codebase easier to test and extend.