### PR TITLE
Refine dashboard cards to show personal challenge data

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,29 +7,19 @@
                 </div>
             @endif
             <!-- Dashboard Cards Grid -->
-            <div class="grid grid-flow-dense grid-cols-1 md:grid-cols-4 auto-rows-fr gap-6 mb-8">
-                <!-- Mitgliederzahl Card -->
-                <x-bento-card title="Aktuelle Mitgliederzahl" class="md:col-span-2" sr-text="Aktuelle Mitgliederzahl: {{ $memberCount }}">
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
-                        {{ $memberCount }}
-                    </div>
-                </x-bento-card>
-                <!-- Offene Aufgaben Card -->
-                <x-bento-card href="{{ route('todos.index') }}" title="Offene Challenges" class="md:row-span-2" sr-text="Offene Challenges: {{ $openTodos }}">
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+                <!-- Persönliche offene Challenges Card -->
+                <x-bento-card href="{{ route('todos.index') }}" title="Offene Challenges" sr-text="Meine offenen Challenges: {{ $openTodos }}">
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Angenommene, noch nicht abgeschlossene Challenges</p>
+                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto" aria-live="polite">
                         {{ $openTodos }}
                     </div>
                 </x-bento-card>
                 <!-- Baxx Card -->
                 <x-bento-card title="Meine Baxx" sr-text="Meine Baxx: {{ $userPoints }}">
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Aktueller Punktestand für deine Aktivitäten</p>
+                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto" aria-live="polite">
                         {{ $userPoints }}
-                    </div>
-                </x-bento-card>
-                <!-- Erledigte Aufgaben Card -->
-                <x-bento-card title="Abgeschlossene Challenges" class="md:col-span-2" sr-text="Abgeschlossene Challenges: {{ $completedTodos }}">
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
-                        {{ $completedTodos }}
                     </div>
                 </x-bento-card>
             </div>
@@ -118,13 +108,6 @@
             @endif
             <!-- Weitere Dashboard Cards -->
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-                <!-- Gesamtanzahl Rezensionen Card -->
-                <a href="{{ route('reviews.index') }}" class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Alle Rezensionen</h2>
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
-                        {{ $allReviews }}
-                    </div>
-                </a>
                 <!-- Meine Rezensionen Card -->
                 <a href="{{ route('reviews.index') }}" class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
                     <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Meine Rezensionen</h2>

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -24,16 +24,14 @@ class DashboardTest extends TestCase
         $response->assertOk();
 
         $expectedTitles = [
-            'Aktuelle Mitgliederzahl',
             'Offene Challenges',
             'Meine Baxx',
-            'Abgeschlossene Challenges',
         ];
 
         $crawler = new Crawler($response->getContent());
-        $grid = $crawler->filter('div.grid.grid-flow-dense');
+        $grid = $crawler->filter('div.grid')->first();
         $this->assertGreaterThan(0, $grid->count());
-        $this->assertStringContainsString('auto-rows-fr', $grid->first()->attr('class'));
+        $this->assertStringContainsString('md:grid-cols-2', $grid->attr('class'));
         foreach ($expectedTitles as $title) {
             $card = $crawler->filter('[role="region"]')->reduce(function (Crawler $node) use ($title) {
                 return $node->filter('h2')->count() && trim($node->filter('h2')->text()) === $title;


### PR DESCRIPTION
This pull request refactors the dashboard to focus on user-specific statistics, particularly open challenges assigned to the current user, and simplifies the displayed metrics. It also updates related tests to match the new logic and UI structure. The most important changes are grouped below.

### Dashboard Logic and Data Changes

* The dashboard now counts only open challenges (`Todos`) assigned to the current user, instead of all open challenges for the team. This is reflected in both the controller logic and the cache key.
* The following statistics have been removed from the dashboard: total member count, completed challenges, and total number of reviews. Only user-specific and relevant admin metrics remain. [[1]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL36-L42) [[2]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL69-R74) [[3]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL94-L102) [[4]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL138-L143) [[5]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL169-L178)

### Dashboard UI Updates

* The dashboard cards grid has been redesigned: cards for member count and completed challenges have been removed, and the open challenges card now clearly indicates it shows only the current user's accepted, not-yet-completed challenges.
* The card for total reviews has been removed from the UI, leaving only the "Meine Rezensionen" (My Reviews) card.

### Test Adjustments

* Feature tests have been updated to reflect the new dashboard data: assertions for member count, completed challenges, and total reviews have been removed, and tests now verify that only challenges assigned to the current user are counted. [[1]](diffhunk://#diff-8e47be296d24cc8e024bdf269c048da270c837709c1a080daa0fd209a18a5a49L83-R84) [[2]](diffhunk://#diff-8e47be296d24cc8e024bdf269c048da270c837709c1a080daa0fd209a18a5a49L102-L137) [[3]](diffhunk://#diff-71491292b9092a8a2b6800d7e69a10bc281450d09e8797956f4f6cd2029fd14dL27-R34)
* A new test ensures the dashboard only counts open challenges assigned to the logged-in user, not to others.

### Code Clean-up

* Imports in `DashboardController.php` have been reordered for clarity.