### PR TITLE
Add bento card for swap offers

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -11,6 +11,7 @@ use App\Models\ReviewComment;
 use App\Models\Todo;
 use App\Models\User;
 use App\Models\UserPoint;
+use App\Models\BookOffer;
 use App\Models\BookSwap;
 use App\Services\MembersTeamProvider;
 use App\Services\UserRoleService;
@@ -66,6 +67,7 @@ class DashboardController extends Controller
         $myReviews = 0;
         $myReviewComments = 0;
         $romantauschMatches = 0;
+        $romantauschOffers = 0;
 
         // Offene Aufgaben
         $openTodos = Cache::remember(
@@ -154,6 +156,15 @@ class DashboardController extends Controller
                 ->count()
         );
 
+        $romantauschOffers = Cache::remember(
+            "romantausch_offers_{$team->id}_{$user->id}",
+            $cacheFor,
+            fn () => BookOffer::query()
+                ->where('user_id', $user->id)
+                ->where('completed', false)
+                ->count()
+        );
+
         $activities = Activity::with(['user', 'subject'])
             ->latest()
             ->limit(10)
@@ -170,6 +181,7 @@ class DashboardController extends Controller
             'myReviews',
             'myReviewComments',
             'romantauschMatches',
+            'romantauschOffers',
             'activities'
         ));
     }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -29,6 +29,13 @@
                         {{ $romantauschMatches }}
                     </div>
                 </x-bento-card>
+                <!-- Angebote in Tauschbörse Card -->
+                <x-bento-card href="{{ route('romantausch.index') }}" title="Angebote in der Tauschbörse" sr-text="Meine Angebote in der Tauschbörse: {{ $romantauschOffers }}">
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Aktive Angebote, die du für die Community bereitgestellt hast</p>
+                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto" aria-live="polite">
+                        {{ $romantauschOffers }}
+                    </div>
+                </x-bento-card>
             </div>
             <!-- Anwärter-Liste für Kassenwart, Vorstand und Admin -->
             @if($anwaerter->isNotEmpty())

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -169,6 +169,7 @@ class DashboardControllerTest extends TestCase
         $response->assertViewHas('myReviews', 1);
         $response->assertViewHas('myReviewComments', 1);
         $response->assertViewHas('romantauschMatches', 1);
+        $response->assertViewHas('romantauschOffers', 1);
         $topUsers = $response->viewData('topUsers');
         $this->assertEquals($member1->id, $topUsers[0]['id']);
         $anwaerter = $response->viewData('anwaerter');
@@ -212,6 +213,51 @@ class DashboardControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertViewHas('romantauschMatches', 1);
+    }
+
+    public function test_dashboard_counts_only_open_offers_of_current_user(): void
+    {
+        $team = Team::membersTeam();
+        $member = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($member, ['role' => Role::Mitglied->value]);
+
+        $otherMember = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($otherMember, ['role' => Role::Mitglied->value]);
+
+        \App\Models\BookOffer::create([
+            'user_id' => $member->id,
+            'series' => \App\Enums\BookType::MaddraxDieDunkleZukunftDerErde->value,
+            'book_number' => 10,
+            'book_title' => 'Offenes Angebot',
+            'condition' => 'gut',
+            'completed' => false,
+        ]);
+
+        \App\Models\BookOffer::create([
+            'user_id' => $member->id,
+            'series' => \App\Enums\BookType::MaddraxDieDunkleZukunftDerErde->value,
+            'book_number' => 11,
+            'book_title' => 'Abgeschlossen',
+            'condition' => 'gut',
+            'completed' => true,
+        ]);
+
+        \App\Models\BookOffer::create([
+            'user_id' => $otherMember->id,
+            'series' => \App\Enums\BookType::MaddraxDieDunkleZukunftDerErde->value,
+            'book_number' => 12,
+            'book_title' => 'Fremdes Angebot',
+            'condition' => 'gut',
+            'completed' => false,
+        ]);
+
+        $this->actingAs($member);
+        Cache::flush();
+
+        $response = $this->get('/dashboard');
+
+        $response->assertOk();
+        $response->assertViewHas('romantauschOffers', 1);
     }
 
     public function test_dashboard_counts_only_challenges_assigned_to_current_user(): void


### PR DESCRIPTION
## Summary
- cache the number of active book offers created by the current member
- expose the cached offer count on the dashboard view via a new Bento card
- cover the new behaviour with feature tests ensuring only the member's open offers are counted

## Testing
- php artisan test --filter=DashboardControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68cebd534f58832eb9328a6644b685d9