### PR TITLE
Verschiebe Admin-Statistikseite auf neue Route

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -75,11 +75,11 @@
                         @endif
                         @if(Auth::user()->hasRole(\App\Enums\Role::Admin))
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
-                            <button id="admin-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="admin-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
-                                Admin
+                            <button id="statistik-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="statistik-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                                Statistik
                             </button>
-                            <div id="admin-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="admin-button">
-                                <x-dropdown-link href="{{ route('admin.index') }}">Admin</x-dropdown-link>
+                            <div id="statistik-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="statistik-button">
+                                <x-dropdown-link href="{{ route('statistiken.index') }}">Statistik</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('admin.messages.index') }}">Kurznachrichten</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('rpg.char-editor') }}">Charakter-Editor</x-dropdown-link>
@@ -189,10 +189,10 @@
             </div>
             @endif
             @if(Auth::user()->hasRole(\App\Enums\Role::Admin))
-            <button id="admin-mobile-button" type="button" @click="openMenu = (openMenu === 'admin' ? null : 'admin')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'admin' }" :aria-expanded="openMenu === 'admin'" aria-controls="admin-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')" @keydown.space.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')">
-            Admin</button>
-            <div id="admin-mobile-menu" x-show="openMenu === 'admin'" x-cloak class="italic" aria-labelledby="admin-mobile-button">
-                <x-responsive-nav-link href="{{ route('admin.index') }}">Admin</x-responsive-nav-link>
+            <button id="statistik-mobile-button" type="button" @click="openMenu = (openMenu === 'statistik' ? null : 'statistik')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'statistik' }" :aria-expanded="openMenu === 'statistik'" aria-controls="statistik-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'statistik' ? null : 'statistik')" @keydown.space.prevent="openMenu = (openMenu === 'statistik' ? null : 'statistik')">
+            Statistik</button>
+            <div id="statistik-mobile-menu" x-show="openMenu === 'statistik'" x-cloak class="italic" aria-labelledby="statistik-mobile-button">
+                <x-responsive-nav-link href="{{ route('statistiken.index') }}">Statistik</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('admin.messages.index') }}">Kurznachrichten</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('rpg.char-editor') }}">Charakter-Editor</x-responsive-nav-link>

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,7 +55,7 @@ Route::get('/email/bestaetigen/{id}/{hash}', CustomEmailVerificationController::
 
 // Nur für eingeloggte und verifizierte Mitglieder, die NICHT Anwärter sind
 Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function () {
-    Route::get('/admin', [AdminController::class, 'index'])->name('admin.index')->middleware('admin');
+    Route::get('/statistiken', [AdminController::class, 'index'])->name('statistiken.index')->middleware('admin');
     Route::controller(DashboardController::class)->group(function () {
         Route::get('/dashboard', 'index')->name('dashboard');
         Route::post('/anwaerter/{user}/freigeben', 'approveAnwaerter')->name('anwaerter.approve');

--- a/tests/Feature/AdminPageTest.php
+++ b/tests/Feature/AdminPageTest.php
@@ -32,7 +32,7 @@ class AdminPageTest extends TestCase
         $member = $this->memberUser();
 
         $this->actingAs($member)
-            ->get('/admin')
+            ->get('/statistiken')
             ->assertStatus(403);
     }
 
@@ -47,6 +47,6 @@ class AdminPageTest extends TestCase
             'path' => '/dashboard',
         ]);
 
-        $this->actingAs($admin)->get('/admin')->assertOk();
+        $this->actingAs($admin)->get('/statistiken')->assertOk();
     }
 }

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -27,7 +27,7 @@ class NavigationMenuTest extends TestCase
         $response->assertSee(route('termine'));
     }
 
-    public function test_admin_users_see_admin_link_in_navigation_menu(): void
+    public function test_admin_users_see_statistik_link_in_navigation_menu(): void
     {
         $team = Team::membersTeam();
         $user = User::factory()->create(['current_team_id' => $team->id]);
@@ -35,10 +35,12 @@ class NavigationMenuTest extends TestCase
 
         $response = $this->actingAs($user)->get('/');
 
-        $response->assertSee(route('admin.index'));
+        $response->assertSee(route('statistiken.index'));
+        $response->assertSee('statistik-button');
+        $response->assertSee('statistik-mobile-button');
     }
 
-    public function test_non_admin_users_do_not_see_admin_link_in_navigation_menu(): void
+    public function test_non_admin_users_do_not_see_statistik_link_in_navigation_menu(): void
     {
         $team = Team::membersTeam();
         $user = User::factory()->create(['current_team_id' => $team->id]);
@@ -46,7 +48,9 @@ class NavigationMenuTest extends TestCase
 
         $response = $this->actingAs($user)->get('/');
 
-        $response->assertDontSee(route('admin.index'));
+        $response->assertDontSee(route('statistiken.index'));
+        $response->assertDontSee('statistik-button');
+        $response->assertDontSee('statistik-mobile-button');
     }
     public function test_admin_users_do_not_see_hoerbuch_create_link_in_navigation_menu(): void
     {


### PR DESCRIPTION
This pull request renames the "Admin" section in the navigation menu and related routes to "Statistik". All references to the admin dashboard are updated accordingly, including navigation buttons, route names and paths, and associated tests. The change is primarily a rebranding of the admin area to better reflect its purpose.

Navigation and UI updates:
* Renamed the "Admin" dropdown/button in the navigation menu to "Statistik", updated associated IDs and ARIA labels, and changed the linked route to `statistiken.index` in `navigation-menu.blade.php` [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL78-R82) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL192-R195).

Routing changes:
* Changed the `/admin` route and its name to `/statistiken` and `statistiken.index` in `web.php`, ensuring only admins can access it.

Test updates:
* Updated feature tests to check for the new "Statistik" menu/button and route, including renaming test methods and adjusting assertions to use the new route and button IDs in `AdminPageTest.php` and `NavigationMenuTest.php` [[1]](diffhunk://#diff-119b2ff3fba0e4ca4990e3f4366e30612dd5b288246d18e3fd6d198fa52e8d61L35-R35) [[2]](diffhunk://#diff-119b2ff3fba0e4ca4990e3f4366e30612dd5b288246d18e3fd6d198fa52e8d61L50-R50) [[3]](diffhunk://#diff-f07fc19527b4a5bab3d806bcfae04538554be984c2baf74012660dc78ac8672aL30-R53).