### PR TITLE
Convert review dashboard cards to Bento layout

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -123,19 +123,19 @@
             <!-- Weitere Dashboard Cards -->
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
                 <!-- Meine Rezensionen Card -->
-                <a href="{{ route('reviews.index') }}" class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col hover:bg-gray-50 dark:hover:bg-gray-700 transition duration-200">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Meine Rezensionen</h2>
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
+                <x-bento-card href="{{ route('reviews.index') }}" title="Meine Rezensionen" sr-text="Meine Rezensionen: {{ $myReviews }}">
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Überblick deiner veröffentlichten Rezensionen</p>
+                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200" aria-live="polite">
                         {{ $myReviews }}
                     </div>
-                </a>
+                </x-bento-card>
                 <!-- Meine Kommentare Card -->
-                <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 flex flex-col">
-                    <h2 class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-2">Meine Kommentare</h2>
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto">
+                <x-bento-card title="Meine Kommentare" sr-text="Meine Kommentare: {{ $myReviewComments }}">
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Kommentare, die du zu Rezensionen verfasst hast</p>
+                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200" aria-live="polite">
                         {{ $myReviewComments }}
                     </div>
-                </div>
+                </x-bento-card>
             </div>
             <!-- Aktivitäten Card -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-8">

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -26,14 +26,19 @@ class DashboardTest extends TestCase
         $expectedTitles = [
             'Offene Challenges',
             'Meine Baxx',
+            'Matches in Tauschbörse',
+            'Angebote in der Tauschbörse',
+            'Meine Rezensionen',
+            'Meine Kommentare',
         ];
 
         $crawler = new Crawler($response->getContent());
-        $grid = $crawler->filter('div.grid')->first();
-        $this->assertGreaterThan(0, $grid->count());
-        $this->assertStringContainsString('md:grid-cols-2', $grid->attr('class'));
+        $grids = $crawler->filter('div.grid');
+        $this->assertGreaterThan(0, $grids->count());
+        $this->assertStringContainsString('md:grid-cols-2', $grids->first()->attr('class'));
+        $cards = $crawler->filter('[role="region"]');
         foreach ($expectedTitles as $title) {
-            $card = $crawler->filter('[role="region"]')->reduce(function (Crawler $node) use ($title) {
+            $card = $cards->reduce(function (Crawler $node) use ($title) {
                 return $node->filter('h2')->count() && trim($node->filter('h2')->text()) === $title;
             });
             $this->assertCount(1, $card, "Card {$title} missing");


### PR DESCRIPTION
## Summary
- convert the “Meine Rezensionen” and “Meine Kommentare” dashboard cards to the shared Bento card component with descriptive copy and screen reader text
- ensure the dashboard accessibility test covers all six Bento cards, including the review and comment counts

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cebff3be9c832e80f80298c22cb9b4