### PR TITLE
Add axe-core accessibility test for homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "leaflet.markercluster": "^1.5.3"
             },
             "devDependencies": {
+                "@axe-core/playwright": "^4.10.2",
                 "@playwright/test": "^1.47.2",
                 "@tailwindcss/forms": "^0.5.7",
                 "@tailwindcss/typography": "^0.5.10",
@@ -70,6 +71,19 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
             "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
             "license": "ISC"
+        },
+        "node_modules/@axe-core/playwright": {
+            "version": "4.10.2",
+            "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+            "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "axe-core": "~4.10.3"
+            },
+            "peerDependencies": {
+                "playwright-core": ">= 1.0.0"
+            }
         },
         "node_modules/@babel/code-frame": {
             "version": "7.27.1",
@@ -3022,6 +3036,16 @@
             },
             "peerDependencies": {
                 "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/axe-core": {
+            "version": "4.10.3",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+            "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/axios": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "test:vitest": "vitest run"
     },
     "devDependencies": {
+        "@axe-core/playwright": "^4.10.2",
         "@playwright/test": "^1.47.2",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.10",

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -129,8 +129,17 @@
 
             <!-- Hamburger (Mobile) -->
             <div class="-mr-2 flex items-center sm:hidden">
-                <button @click="open = !open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700">
-                    <svg class="h-6 w-6" stroke="currentColor" fill="none">
+                <button
+                    type="button"
+                    @click="open = !open"
+                    :aria-expanded="open"
+                    aria-label="Menü öffnen"
+                    x-bind:aria-label="open ? 'Menü schließen' : 'Menü öffnen'"
+                    aria-controls="mobile-navigation"
+                    class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                >
+                    <span class="sr-only" x-text="open ? 'Menü schließen' : 'Menü öffnen'">Menü öffnen</span>
+                    <svg class="h-6 w-6" stroke="currentColor" fill="none" aria-hidden="true">
                         <path :class="{'hidden': open, 'inline-flex': !open}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
                         <path :class="{'hidden': !open, 'inline-flex': open}" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
                     </svg>
@@ -140,7 +149,7 @@
     </div>
 
     <!-- Mobile-Menü -->
-    <div :class="{'block': open, 'hidden': !open}" class="hidden sm:hidden">
+    <div id="mobile-navigation" :class="{'block': open, 'hidden': !open}" class="hidden sm:hidden">
         @auth
             <x-responsive-nav-link href="{{ route('dashboard') }}">Dashboard</x-responsive-nav-link>
             <button id="verein-mobile-button" type="button" @click="openMenu = (openMenu === 'verein' ? null : 'verein')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'verein' }" :aria-expanded="openMenu === 'verein'" aria-controls="verein-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'verein' ? null : 'verein')" @keydown.space.prevent="openMenu = (openMenu === 'verein' ? null : 'verein')">

--- a/tests/e2e/accessibility-homepage.spec.js
+++ b/tests/e2e/accessibility-homepage.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test.describe('Accessibility checks', () => {
+  test('Homepage meets WCAG AA guidelines', async ({ page }) => {
+    await page.goto('/');
+
+    const accessibilityScanResults = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa'])
+      .analyze();
+
+    const formattedViolations = accessibilityScanResults.violations
+      .map((violation) => {
+        const targets = violation.nodes
+          .flatMap((node) => node.target)
+          .join(', ');
+        return `${violation.id}: ${violation.help} -> ${targets}`;
+      })
+      .join('\n');
+
+    expect(accessibilityScanResults.violations, formattedViolations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add an axe-core based Playwright spec to automatically scan the homepage for WCAG A/AA violations
- expose an accessible label for the mobile navigation toggle so the new audit passes
- install @axe-core/playwright as a dev dependency

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68cebee57820832e9671e47bd8219287