### PR TITLE
Fix dashboard bento grid alignment

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,7 +7,7 @@
                 </div>
             @endif
             <!-- Dashboard Cards Grid -->
-            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-8">
+            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-8 grid-flow-row-dense" aria-label="Überblick wichtiger Community-Kennzahlen">
                 <!-- Persönliche offene Challenges Card -->
                 <x-bento-card href="{{ route('todos.index') }}" title="Offene Challenges" sr-text="Meine offenen Challenges: {{ $openTodos }}">
                     <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Angenommene, noch nicht abgeschlossene Challenges</p>
@@ -34,6 +34,20 @@
                     <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Aktive Angebote, die du für die Community bereitgestellt hast</p>
                     <div class="text-4xl font-bold text-gray-800 dark:text-gray-200 mt-auto" aria-live="polite">
                         {{ $romantauschOffers }}
+                    </div>
+                </x-bento-card>
+                <!-- Meine Rezensionen Card -->
+                <x-bento-card href="{{ route('reviews.index') }}" title="Meine Rezensionen" sr-text="Meine Rezensionen: {{ $myReviews }}">
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Überblick deiner veröffentlichten Rezensionen</p>
+                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200" aria-live="polite">
+                        {{ $myReviews }}
+                    </div>
+                </x-bento-card>
+                <!-- Meine Kommentare Card -->
+                <x-bento-card title="Meine Kommentare" sr-text="Meine Kommentare: {{ $myReviewComments }}">
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Kommentare, die du zu Rezensionen verfasst hast</p>
+                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200" aria-live="polite">
+                        {{ $myReviewComments }}
                     </div>
                 </x-bento-card>
             </div>
@@ -120,23 +134,6 @@
                     </div>
                 </div>
             @endif
-            <!-- Weitere Dashboard Cards -->
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-                <!-- Meine Rezensionen Card -->
-                <x-bento-card href="{{ route('reviews.index') }}" title="Meine Rezensionen" sr-text="Meine Rezensionen: {{ $myReviews }}">
-                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Überblick deiner veröffentlichten Rezensionen</p>
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200" aria-live="polite">
-                        {{ $myReviews }}
-                    </div>
-                </x-bento-card>
-                <!-- Meine Kommentare Card -->
-                <x-bento-card title="Meine Kommentare" sr-text="Meine Kommentare: {{ $myReviewComments }}">
-                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Kommentare, die du zu Rezensionen verfasst hast</p>
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200" aria-live="polite">
-                        {{ $myReviewComments }}
-                    </div>
-                </x-bento-card>
-            </div>
             <!-- Aktivitäten Card -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-8">
                 <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-4">Aktivitäten</h2>

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -33,10 +33,12 @@ class DashboardTest extends TestCase
         ];
 
         $crawler = new Crawler($response->getContent());
-        $grids = $crawler->filter('div.grid');
-        $this->assertGreaterThan(0, $grids->count());
-        $this->assertStringContainsString('md:grid-cols-2', $grids->first()->attr('class'));
-        $cards = $crawler->filter('[role="region"]');
+        $cardsContainer = $crawler->filter('div[aria-label="Überblick wichtiger Community-Kennzahlen"]');
+        $this->assertCount(1, $cardsContainer, 'Dashboard card container missing');
+        $this->assertStringContainsString('md:grid-cols-2', $cardsContainer->attr('class'));
+        $this->assertStringContainsString('grid-flow-row-dense', $cardsContainer->attr('class'));
+        $cards = $cardsContainer->filter('[role="region"]');
+        $this->assertCount(count($expectedTitles), $cards, 'Unexpected number of dashboard cards rendered');
         foreach ($expectedTitles as $title) {
             $card = $cards->reduce(function (Crawler $node) use ($title) {
                 return $node->filter('h2')->count() && trim($node->filter('h2')->text()) === $title;


### PR DESCRIPTION
This pull request updates the dashboard layout to improve accessibility and card organization, and updates the corresponding feature test to match the new structure. The most important changes include moving the "Meine Rezensionen" and "Meine Kommentare" cards into the main dashboard grid, adding accessibility attributes, and updating the test to check for the new layout and attributes.

**Dashboard layout and accessibility improvements:**

* Moved the "Meine Rezensionen" and "Meine Kommentare" cards from a separate grid into the main dashboard card grid, consolidating all key cards into a single, denser grid for better organization. [[1]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324R39-R52) [[2]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324L123-L139)
* Added the `aria-label="Überblick wichtiger Community-Kennzahlen"` attribute to the main dashboard grid container and included the `grid-flow-row-dense` class to improve accessibility and layout density.

**Test updates:**

* Updated `DashboardTest` to locate the dashboard cards container using the new `aria-label`, check for the `grid-flow-row-dense` class, and verify the correct number of cards are rendered within the main grid.