### PR TITLE
Rename admin navigation menu label

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -75,10 +75,10 @@
                         @endif
                         @if(Auth::user()->hasRole(\App\Enums\Role::Admin))
                         <div class="relative flex items-center ml-4 group" x-data="{ open: false }" @click="open = !open" @click.away="open = false" @keydown.escape="open = false">
-                            <button id="statistik-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="statistik-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
-                                Statistik
+                            <button id="admin-button" type="button" class="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition" :aria-expanded="open" aria-controls="admin-menu" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+                                Admin
                             </button>
-                            <div id="statistik-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="statistik-button">
+                            <div id="admin-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="admin-button">
                                 <x-dropdown-link href="{{ route('statistiken.index') }}">Statistik</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('admin.messages.index') }}">Kurznachrichten</x-dropdown-link>
@@ -189,9 +189,9 @@
             </div>
             @endif
             @if(Auth::user()->hasRole(\App\Enums\Role::Admin))
-            <button id="statistik-mobile-button" type="button" @click="openMenu = (openMenu === 'statistik' ? null : 'statistik')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'statistik' }" :aria-expanded="openMenu === 'statistik'" aria-controls="statistik-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'statistik' ? null : 'statistik')" @keydown.space.prevent="openMenu = (openMenu === 'statistik' ? null : 'statistik')">
-            Statistik</button>
-            <div id="statistik-mobile-menu" x-show="openMenu === 'statistik'" x-cloak class="italic" aria-labelledby="statistik-mobile-button">
+            <button id="admin-mobile-button" type="button" @click="openMenu = (openMenu === 'admin' ? null : 'admin')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'admin' }" :aria-expanded="openMenu === 'admin'" aria-controls="admin-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')" @keydown.space.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')">
+            Admin</button>
+            <div id="admin-mobile-menu" x-show="openMenu === 'admin'" x-cloak class="italic" aria-labelledby="admin-mobile-button">
                 <x-responsive-nav-link href="{{ route('statistiken.index') }}">Statistik</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('admin.messages.index') }}">Kurznachrichten</x-responsive-nav-link>

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -27,7 +27,7 @@ class NavigationMenuTest extends TestCase
         $response->assertSee(route('termine'));
     }
 
-    public function test_admin_users_see_statistik_link_in_navigation_menu(): void
+    public function test_admin_users_see_admin_menu_with_statistik_link(): void
     {
         $team = Team::membersTeam();
         $user = User::factory()->create(['current_team_id' => $team->id]);
@@ -36,11 +36,12 @@ class NavigationMenuTest extends TestCase
         $response = $this->actingAs($user)->get('/');
 
         $response->assertSee(route('statistiken.index'));
-        $response->assertSee('statistik-button');
-        $response->assertSee('statistik-mobile-button');
+        $response->assertSee('Admin');
+        $response->assertSee('admin-button');
+        $response->assertSee('admin-mobile-button');
     }
 
-    public function test_non_admin_users_do_not_see_statistik_link_in_navigation_menu(): void
+    public function test_non_admin_users_do_not_see_admin_menu(): void
     {
         $team = Team::membersTeam();
         $user = User::factory()->create(['current_team_id' => $team->id]);
@@ -49,8 +50,8 @@ class NavigationMenuTest extends TestCase
         $response = $this->actingAs($user)->get('/');
 
         $response->assertDontSee(route('statistiken.index'));
-        $response->assertDontSee('statistik-button');
-        $response->assertDontSee('statistik-mobile-button');
+        $response->assertDontSee('admin-button');
+        $response->assertDontSee('admin-mobile-button');
     }
     public function test_admin_users_do_not_see_hoerbuch_create_link_in_navigation_menu(): void
     {


### PR DESCRIPTION
## Summary
- rename the admin dropdown label in the authenticated navigation to "Admin" and align related identifiers and accessibility attributes
- ensure the mobile navigation reflects the new label while keeping the Statistik submenu entry intact
- update navigation menu feature tests to cover the new label and verify access restrictions

## Testing
- php artisan test --filter=NavigationMenuTest

------
https://chatgpt.com/codex/tasks/task_e_68cec2bc2360832e8c55d60adf883cba