### PR TITLE
Split coverage workflows into PHP and JS

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -65,23 +65,11 @@ jobs:
         run: |
           mkdir -p database
           touch database/database.sqlite
-      - name: Setup Node.js and build assets
-        uses: ./.github/actions/build-assets
       - name: Execute tests with coverage
         env:
           DB_CONNECTION: sqlite
           DB_DATABASE: database/database.sqlite
         run: php -dxdebug.mode=coverage artisan test tests/Feature --coverage-clover=coverage.xml
-      - name: Run Jest tests with coverage
-        run: npm test -- --coverage --coverageReporters=json-summary --coverageDirectory=coverage
-      - name: Create JS coverage badge
-        if: github.ref == 'refs/heads/main'
-        run: |
-          mkdir -p output
-          if [ -f "coverage/coverage-summary.json" ]; then
-            npx --yes make-coverage-badge --report-path=coverage/coverage-summary.json --output-path=output/js-coverage.svg
-            sed -i 's/Coverage/JS Coverage/' output/js-coverage.svg
-          fi
       - name: Create PHP coverage badge
         if: github.ref == 'refs/heads/main'
         uses: timkrase/phpunit-coverage-badge@v1.2.1
@@ -95,8 +83,92 @@ jobs:
           if [ -f output/php-coverage.svg ]; then
             sed -i 's/Coverage/PHP Coverage/' output/php-coverage.svg
           fi
-      - name: Deploy coverage badges to image-data branch
+      - name: Upload PHP coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: php-coverage-report
+          path: coverage.xml
+      - name: Upload PHP coverage badge
         if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: php-coverage-badge
+          path: output/php-coverage.svg
+          if-no-files-found: ignore
+
+  js-coverage:
+    needs: tests
+    runs-on: ubuntu-latest
+    name: JS Coverage
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install Node dependencies
+        run: npm ci
+      - name: Run Jest tests with coverage
+        run: npm test -- --coverage --coverageReporters=json-summary --coverageDirectory=coverage
+      - name: Create JS coverage badge
+        if: github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p output
+          if [ -f "coverage/coverage-summary.json" ]; then
+            npx --yes make-coverage-badge --report-path=coverage/coverage-summary.json --output-path=output/js-coverage.svg
+            sed -i 's/Coverage/JS Coverage/' output/js-coverage.svg
+          fi
+      - name: Upload JS coverage summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-coverage-summary
+          path: coverage/coverage-summary.json
+      - name: Upload JS coverage badge
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-coverage-badge
+          path: output/js-coverage.svg
+          if-no-files-found: ignore
+
+  deploy-coverage:
+    needs:
+      - coverage
+      - js-coverage
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: '*-coverage-*'
+          path: artifacts
+          merge-multiple: true
+      - name: Download PHP coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: php-coverage-report
+          path: artifacts
+      - name: Prepare deployment directory
+        run: |
+          mkdir -p output
+          if [ -f artifacts/output/js-coverage.svg ]; then
+            cp artifacts/output/js-coverage.svg output/js-coverage.svg
+          fi
+          if [ -f artifacts/output/php-coverage.svg ]; then
+            cp artifacts/output/php-coverage.svg output/php-coverage.svg
+          fi
+          if [ -f artifacts/coverage/coverage-summary.json ]; then
+            mkdir -p output/coverage
+            cp artifacts/coverage/coverage-summary.json output/coverage/coverage-summary.json
+          fi
+          if [ -f artifacts/coverage.xml ]; then
+            cp artifacts/coverage.xml output/coverage.xml
+          fi
+      - name: Deploy coverage artifacts to image-data branch
         uses: peaceiris/actions-gh-pages@v4
         with:
           publish_dir: ./output


### PR DESCRIPTION
## Summary
- add a dedicated js-coverage job that handles Node setup, testing with coverage, and JS badge artifacts
- focus the coverage job on PHP setup, coverage generation, and artifact uploads
- introduce a deploy-coverage job to collect artifacts from both coverage runs and publish them via GitHub Pages

## Testing
- act workflow -j coverage *(fails: Docker daemon unavailable in environment)*
- act workflow -j js-coverage *(fails: Docker daemon unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6d273ea4832eb37def2a7cc690fc