### PR TITLE
Add comprehensive tests for /aufgaben challenges

### DIFF
--- a/app/Http/Controllers/TodoController.php
+++ b/app/Http/Controllers/TodoController.php
@@ -76,6 +76,7 @@ class TodoController extends Controller
             'memberTeam' => $memberTeam,
             'userRole' => $userRole,
             'filter' => $filter,
+            'activeFilter' => $filter === 'pending' ? 'pending' : 'all',
         ]);
     }
 

--- a/database/seeders/TodoPlaywrightSeeder.php
+++ b/database/seeders/TodoPlaywrightSeeder.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\TodoStatus;
+use App\Models\Team;
+use App\Models\Todo;
+use App\Models\TodoCategory;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Jetstream\Jetstream;
+
+class TodoPlaywrightSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $team = Team::membersTeam();
+
+        if (! $team) {
+            $admin = User::withoutEvents(function () {
+                return User::create([
+                    'name' => 'Holger Ehrmann',
+                    'email' => 'info@maddraxikon.com',
+                    'email_verified_at' => now(),
+                    'password' => Hash::make('password'),
+                    'vorname' => 'Holger',
+                    'nachname' => 'Ehrmann',
+                    'strasse' => 'Musterstraße',
+                    'hausnummer' => '123',
+                    'plz' => '12345',
+                    'stadt' => 'Musterstadt',
+                    'land' => 'Deutschland',
+                    'telefon' => '0123456789',
+                    'verein_gefunden' => 'Sonstiges',
+                    'mitgliedsbeitrag' => 36.00,
+                ]);
+            });
+
+            $team = Jetstream::newTeamModel()->forceFill([
+                'name' => 'Mitglieder',
+                'user_id' => $admin->id,
+                'personal_team' => false,
+            ]);
+
+            $team->save();
+            $team->users()->attach($admin, ['role' => 'Admin']);
+
+            $admin->forceFill([
+                'current_team_id' => $team->id,
+            ])->save();
+        } else {
+            $admin = User::firstWhere('email', 'info@maddraxikon.com');
+        }
+
+        if (! $admin) {
+            $admin = User::withoutEvents(function () use ($team) {
+                $user = User::create([
+                    'name' => 'Holger Ehrmann',
+                    'email' => 'info@maddraxikon.com',
+                    'email_verified_at' => now(),
+                    'password' => Hash::make('password'),
+                    'vorname' => 'Holger',
+                    'nachname' => 'Ehrmann',
+                    'strasse' => 'Musterstraße',
+                    'hausnummer' => '123',
+                    'plz' => '12345',
+                    'stadt' => 'Musterstadt',
+                    'land' => 'Deutschland',
+                    'telefon' => '0123456789',
+                    'verein_gefunden' => 'Sonstiges',
+                    'mitgliedsbeitrag' => 36.00,
+                ]);
+
+                return $user;
+            });
+
+            $team->users()->attach($admin, ['role' => 'Admin']);
+
+            $admin->forceFill([
+                'current_team_id' => $team->id,
+            ])->save();
+        }
+
+        $category = TodoCategory::firstOrCreate(
+            ['slug' => 'playwright-tests'],
+            ['name' => 'Playwright Tests']
+        );
+
+        $member = User::factory()->create([
+            'name' => 'Playwright Mitglied',
+            'email' => 'playwright-member@example.com',
+            'current_team_id' => $team->id,
+        ]);
+
+        $team->users()->attach($member, ['role' => 'Mitglied']);
+
+        Todo::create([
+            'team_id' => $team->id,
+            'created_by' => $admin->id,
+            'title' => 'Offene Playwright Challenge',
+            'description' => 'Diese Aufgabe bleibt offen, bis sie übernommen wird.',
+            'points' => 5,
+            'category_id' => $category->id,
+            'status' => TodoStatus::Open->value,
+        ]);
+
+        Todo::create([
+            'team_id' => $team->id,
+            'created_by' => $admin->id,
+            'title' => 'Übernommene Playwright Challenge',
+            'description' => 'Diese Aufgabe ist derzeit in Bearbeitung.',
+            'points' => 8,
+            'category_id' => $category->id,
+            'status' => TodoStatus::Assigned->value,
+            'assigned_to' => $member->id,
+        ]);
+
+        Todo::create([
+            'team_id' => $team->id,
+            'created_by' => $admin->id,
+            'title' => 'Abzuschließende Playwright Challenge',
+            'description' => 'Diese Aufgabe wartet auf Verifizierung.',
+            'points' => 10,
+            'category_id' => $category->id,
+            'status' => TodoStatus::Completed->value,
+            'assigned_to' => $member->id,
+            'completed_at' => now()->subHours(3),
+        ]);
+    }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,12 +1,27 @@
 import { defineConfig } from '@playwright/test';
+import path from 'path';
+
+const databasePath = path.resolve('database/playwright.sqlite');
 
 export default defineConfig({
   testDir: 'tests/e2e',
+  globalSetup: './tests/e2e/global-setup.js',
   webServer: {
     command: 'php -S 127.0.0.1:8000 -t public public/index.php',
     port: 8000,
     reuseExistingServer: !process.env.CI,
     timeout: 180000,
+    env: {
+      APP_ENV: 'testing',
+      APP_DEBUG: 'false',
+      APP_KEY: process.env.APP_KEY ?? 'base64:oK0ZsJlI+o7C++h527lMcrrO4jzZrXqhouB/p0l+gFw=',
+      DB_CONNECTION: 'sqlite',
+      DB_DATABASE: databasePath,
+      SESSION_DRIVER: 'file',
+      CACHE_DRIVER: 'array',
+      QUEUE_CONNECTION: 'database',
+      MAIL_MAILER: 'array',
+    },
   },
   use: {
     baseURL: 'http://127.0.0.1:8000',

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -82,3 +82,4 @@ window.L = L;
 
 import './chronik';
 import './char-editor';
+import './todos';

--- a/resources/js/todos.js
+++ b/resources/js/todos.js
@@ -1,0 +1,5 @@
+import { initTodoFilters } from './utils/todoFilters';
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTodoFilters(document);
+});

--- a/resources/js/utils/todoFilters.js
+++ b/resources/js/utils/todoFilters.js
@@ -1,0 +1,131 @@
+const FILTER_MESSAGES = {
+    all: 'Zeigt alle verfügbaren Challenges.',
+    assigned: 'Zeigt deine übernommenen Challenges.',
+    open: 'Zeigt offene Challenges, die noch übernommen werden können.',
+    pending: 'Zeigt Challenges, die auf eine Verifizierung warten.',
+};
+
+const FILTER_SECTIONS = {
+    all: null,
+    assigned: new Set(['assigned']),
+    open: new Set(['open']),
+    pending: new Set(['pending']),
+};
+
+export function normaliseFilter(filter) {
+    if (typeof filter !== 'string') {
+        return 'all';
+    }
+
+    const trimmed = filter.trim().toLowerCase();
+
+    return Object.prototype.hasOwnProperty.call(FILTER_MESSAGES, trimmed) ? trimmed : 'all';
+}
+
+export function getFilterMessage(filter) {
+    const key = normaliseFilter(filter);
+
+    return FILTER_MESSAGES[key];
+}
+
+export function updateButtons(buttons, filter) {
+    const activeFilter = normaliseFilter(filter);
+
+    buttons.forEach((button) => {
+        if (!(button instanceof HTMLElement)) {
+            return;
+        }
+
+        const targetFilter = normaliseFilter(button.dataset.filter || 'all');
+        const isActive = targetFilter === activeFilter;
+
+        button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        button.dataset.active = isActive ? 'true' : 'false';
+    });
+}
+
+export function updateSections(sections, filter) {
+    const activeFilter = normaliseFilter(filter);
+    const allowed = FILTER_SECTIONS[activeFilter];
+
+    sections.forEach((section) => {
+        if (!(section instanceof HTMLElement)) {
+            return;
+        }
+
+        const sectionKey = normaliseFilter(section.dataset.todoSection || 'all');
+        const shouldShow = !allowed || allowed.has(sectionKey);
+
+        section.classList.toggle('hidden', !shouldShow);
+        section.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+    });
+}
+
+export function applyFilterState({
+    buttons,
+    sections,
+    statusElement,
+    filter,
+}) {
+    const activeFilter = normaliseFilter(filter);
+
+    updateButtons(buttons, activeFilter);
+
+    if (statusElement instanceof HTMLElement) {
+        statusElement.textContent = getFilterMessage(activeFilter);
+    }
+
+    updateSections(sections, activeFilter);
+
+    return activeFilter;
+}
+
+export function initTodoFilters(root = document) {
+    if (!root || typeof root.querySelector !== 'function') {
+        return;
+    }
+
+    const form = root.querySelector('[data-todo-filter-form]');
+
+    if (!form) {
+        return;
+    }
+
+    const buttons = Array.from(form.querySelectorAll('[data-todo-filter]'));
+
+    if (buttons.length === 0) {
+        return;
+    }
+
+    const sections = Array.from(root.querySelectorAll('[data-todo-section]'));
+    const statusElement = form.querySelector('[data-todo-filter-status]');
+    const initialFilter = normaliseFilter(form.dataset.currentFilter || 'all');
+
+    applyFilterState({
+        buttons,
+        sections,
+        statusElement,
+        filter: initialFilter,
+    });
+
+    form.addEventListener('click', (event) => {
+        const target = event.target instanceof HTMLElement
+            ? event.target.closest('[data-todo-filter]')
+            : null;
+
+        if (!target) {
+            return;
+        }
+
+        const nextFilter = normaliseFilter(target.dataset.filter || 'all');
+
+        applyFilterState({
+            buttons,
+            sections,
+            statusElement,
+            filter: nextFilter,
+        });
+
+        form.dataset.currentFilter = nextFilter;
+    });
+}

--- a/resources/views/todos/show.blade.php
+++ b/resources/views/todos/show.blade.php
@@ -2,14 +2,14 @@
     <x-member-page class="max-w-3xl">
 
             @if(session('status'))
-                <div
+                <div role="status" aria-live="polite"
                     class="mb-4 p-4 bg-green-100 dark:bg-green-900 border border-green-400 dark:border-green-600 text-green-800 dark:text-green-200 rounded">
                     {{ session('status') }}
                 </div>
             @endif
 
             @if(session('error'))
-                <div
+                <div role="alert"
                     class="mb-4 p-4 bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-800 dark:text-red-200 rounded">
                     {{ session('error') }}
                 </div>

--- a/tests/Jest/todoFilters.test.js
+++ b/tests/Jest/todoFilters.test.js
@@ -1,0 +1,177 @@
+import { describe, expect, test, beforeEach } from '@jest/globals';
+import {
+    applyFilterState,
+    getFilterMessage,
+    initTodoFilters,
+    normaliseFilter,
+    updateButtons,
+    updateSections,
+} from '../../resources/js/utils/todoFilters';
+
+describe('todoFilters utilities', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('normaliseFilter falls back to all for unknown values', () => {
+        expect(normaliseFilter('unknown')).toBe('all');
+        expect(normaliseFilter(' Pending ')).toBe('pending');
+        expect(normaliseFilter()).toBe('all');
+    });
+
+    test('getFilterMessage returns descriptive German text', () => {
+        expect(getFilterMessage('all')).toContain('alle verfügbaren');
+        expect(getFilterMessage('open')).toContain('offene Challenges');
+    });
+
+    test('updateButtons toggles aria-pressed and data-active', () => {
+        document.body.innerHTML = `
+            <form>
+                <button data-todo-filter data-filter="all"></button>
+                <button data-todo-filter data-filter="open"></button>
+            </form>
+        `;
+
+        const buttons = document.querySelectorAll('[data-todo-filter]');
+
+        updateButtons(buttons, 'open');
+
+        expect(buttons[0].getAttribute('aria-pressed')).toBe('false');
+        expect(buttons[0].dataset.active).toBe('false');
+        expect(buttons[1].getAttribute('aria-pressed')).toBe('true');
+        expect(buttons[1].dataset.active).toBe('true');
+    });
+
+    test('updateSections hides non matching sections', () => {
+        document.body.innerHTML = `
+            <section data-todo-section="assigned"></section>
+            <section data-todo-section="open"></section>
+            <section data-todo-section="pending"></section>
+        `;
+
+        const sections = document.querySelectorAll('[data-todo-section]');
+
+        updateSections(sections, 'open');
+
+        expect(sections[0].classList.contains('hidden')).toBe(true);
+        expect(sections[0].getAttribute('aria-hidden')).toBe('true');
+        expect(sections[1].classList.contains('hidden')).toBe(false);
+        expect(sections[1].getAttribute('aria-hidden')).toBe('false');
+        expect(sections[2].classList.contains('hidden')).toBe(true);
+    });
+
+    test('initTodoFilters wires listeners and updates status message', () => {
+        document.body.innerHTML = `
+            <div>
+                <form data-todo-filter-form data-current-filter="all">
+                    <div>
+                        <button type="button" data-todo-filter data-filter="assigned" data-active="false"></button>
+                        <button type="button" data-todo-filter data-filter="open" data-active="false"></button>
+                        <button type="submit" data-todo-filter data-filter="pending" data-active="false"></button>
+                    </div>
+                    <p data-todo-filter-status></p>
+                </form>
+                <section data-todo-section="assigned"></section>
+                <section data-todo-section="open"></section>
+                <section data-todo-section="pending"></section>
+            </div>
+        `;
+
+        const statusElement = document.querySelector('[data-todo-filter-status]');
+
+        initTodoFilters(document);
+
+        expect(statusElement.textContent).toContain('alle verfügbaren Challenges');
+
+        const assignedButton = document.querySelector('[data-filter="assigned"]');
+        assignedButton.dispatchEvent(new Event('click', { bubbles: true }));
+
+        expect(statusElement.textContent).toContain('übernommenen Challenges');
+
+        const hiddenAssigned = document.querySelector('[data-todo-section="open"]');
+        expect(hiddenAssigned.classList.contains('hidden')).toBe(true);
+
+        const pendingButton = document.querySelector('[data-filter="pending"]');
+        pendingButton.dispatchEvent(new Event('click', { bubbles: true }));
+        expect(statusElement.textContent).toContain('Verifizierung warten');
+    });
+
+    test('applyFilterState returns the active filter', () => {
+        document.body.innerHTML = `
+            <section data-todo-section="assigned"></section>
+            <section data-todo-section="open"></section>
+        `;
+
+        const buttons = [];
+        const sections = document.querySelectorAll('[data-todo-section]');
+        const statusElement = document.createElement('p');
+
+        const result = applyFilterState({
+            buttons,
+            sections,
+            statusElement,
+            filter: 'assigned',
+        });
+
+        expect(result).toBe('assigned');
+        expect(statusElement.textContent).toContain('übernommenen Challenges');
+        expect(sections[0].classList.contains('hidden')).toBe(false);
+        expect(sections[1].classList.contains('hidden')).toBe(true);
+    });
+
+    test('applyFilterState normalises invalid filters to all', () => {
+        document.body.innerHTML = `
+            <section data-todo-section="assigned"></section>
+        `;
+
+        const result = applyFilterState({
+            buttons: [],
+            sections: document.querySelectorAll('[data-todo-section]'),
+            statusElement: null,
+            filter: '  UNKNOWN  ',
+        });
+
+        expect(result).toBe('all');
+    });
+
+    test('updateButtons ignores non-HTMLElement entries gracefully', () => {
+        document.body.innerHTML = `
+            <button data-todo-filter data-filter="all"></button>
+        `;
+
+        const buttons = [
+            document.querySelector('[data-todo-filter]'),
+            null,
+            {},
+        ];
+
+        updateButtons(buttons, 'all');
+
+        expect(buttons[0].getAttribute('aria-pressed')).toBe('true');
+    });
+
+    test('initTodoFilters updates data attribute and leaves untouched when form missing', () => {
+        initTodoFilters({});
+
+        document.body.innerHTML = `
+            <div>
+                <form data-todo-filter-form data-current-filter="open">
+                    <button type="button" data-todo-filter data-filter="open" data-active="true"></button>
+                    <button type="button" data-todo-filter data-filter="assigned" data-active="false"></button>
+                    <p data-todo-filter-status></p>
+                </form>
+                <section data-todo-section="open"></section>
+                <section data-todo-section="assigned"></section>
+            </div>
+        `;
+
+        initTodoFilters(document);
+
+        const form = document.querySelector('[data-todo-filter-form]');
+        const assignedButton = document.querySelector('[data-filter="assigned"]');
+
+        assignedButton.dispatchEvent(new Event('click', { bubbles: true }));
+
+        expect(form.dataset.currentFilter).toBe('assigned');
+    });
+});

--- a/tests/e2e/aufgaben.spec.js
+++ b/tests/e2e/aufgaben.spec.js
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+
+test('admin can filter and accept challenges', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', 'info@maddraxikon.com');
+    await page.fill('input[name="password"]', 'password');
+
+    await Promise.all([
+        page.waitForNavigation(),
+        page.click('button[type="submit"]'),
+    ]);
+
+    await page.goto('/aufgaben');
+
+    await expect(page.getByRole('heading', { name: 'Deine Challenges' })).toBeVisible();
+    await expect(page.locator('[data-todo-filter-status]')).toHaveText(/alle verfügbaren Challenges/i);
+
+    const verifyButton = page.getByRole('button', { name: 'Zu verifizieren', exact: true });
+    await expect(verifyButton).toBeVisible();
+
+    await Promise.all([
+        page.waitForNavigation(),
+        verifyButton.click(),
+    ]);
+
+    await expect(page).toHaveURL(/filter=pending/);
+    await expect(page.locator('[data-todo-filter-status]')).toHaveText(/Verifizierung warten/i);
+    await expect(page.getByRole('heading', { name: 'Zu verifizierende Challenges' })).toBeVisible();
+
+    const allButton = page.getByRole('button', { name: 'Alle', exact: true });
+    await Promise.all([
+        page.waitForNavigation(),
+        allButton.click(),
+    ]);
+
+    await expect(page).not.toHaveURL(/filter=pending/);
+
+    const assignButton = page.getByRole('button', { name: 'Übernehmen', exact: true }).first();
+    await expect(assignButton).toBeVisible();
+
+    await Promise.all([
+        page.waitForNavigation(),
+        assignButton.click(),
+    ]);
+
+    await expect(page.getByRole('status')).toContainText('erfolgreich übernommen');
+});
+
+test('member can focus on own challenges and release one', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', 'playwright-member@example.com');
+    await page.fill('input[name="password"]', 'password');
+
+    await Promise.all([
+        page.waitForNavigation(),
+        page.click('button[type="submit"]'),
+    ]);
+
+    await page.goto('/aufgaben');
+
+    const ownButton = page.getByRole('button', { name: 'Eigene Challenges', exact: true });
+    await ownButton.click();
+
+    const releaseButton = page.getByRole('button', { name: 'Freigeben', exact: true }).first();
+
+    await Promise.all([
+        page.waitForNavigation(),
+        releaseButton.click(),
+    ]);
+
+    await expect(page.locator('div[role="status"]').first()).toContainText('erfolgreich freigegeben');
+    await expect(page.locator('[data-todo-section="assigned"]')).not.toContainText('Übernommene Playwright Challenge');
+    await expect(page.locator('[data-todo-section="open"]')).toContainText('Übernommene Playwright Challenge');
+});

--- a/tests/e2e/aufgaben.spec.js
+++ b/tests/e2e/aufgaben.spec.js
@@ -5,10 +5,8 @@ test('admin can filter and accept challenges', async ({ page }) => {
     await page.fill('input[name="email"]', 'info@maddraxikon.com');
     await page.fill('input[name="password"]', 'password');
 
-    await Promise.all([
-        page.waitForNavigation(),
-        page.click('button[type="submit"]'),
-    ]);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(url => !url.pathname.endsWith('/login'));
 
     await page.goto('/aufgaben');
 
@@ -18,31 +16,19 @@ test('admin can filter and accept challenges', async ({ page }) => {
     const verifyButton = page.getByRole('button', { name: 'Zu verifizieren', exact: true });
     await expect(verifyButton).toBeVisible();
 
-    await Promise.all([
-        page.waitForNavigation(),
-        verifyButton.click(),
-    ]);
-
+    await verifyButton.click();
     await expect(page).toHaveURL(/filter=pending/);
     await expect(page.locator('[data-todo-filter-status]')).toHaveText(/Verifizierung warten/i);
     await expect(page.getByRole('heading', { name: 'Zu verifizierende Challenges' })).toBeVisible();
 
     const allButton = page.getByRole('button', { name: 'Alle', exact: true });
-    await Promise.all([
-        page.waitForNavigation(),
-        allButton.click(),
-    ]);
-
+    await allButton.click();
     await expect(page).not.toHaveURL(/filter=pending/);
 
     const assignButton = page.getByRole('button', { name: 'Übernehmen', exact: true }).first();
     await expect(assignButton).toBeVisible();
 
-    await Promise.all([
-        page.waitForNavigation(),
-        assignButton.click(),
-    ]);
-
+    await assignButton.click();
     await expect(page.getByRole('status')).toContainText('erfolgreich übernommen');
 });
 
@@ -51,10 +37,8 @@ test('member can focus on own challenges and release one', async ({ page }) => {
     await page.fill('input[name="email"]', 'playwright-member@example.com');
     await page.fill('input[name="password"]', 'password');
 
-    await Promise.all([
-        page.waitForNavigation(),
-        page.click('button[type="submit"]'),
-    ]);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(url => !url.pathname.endsWith('/login'));
 
     await page.goto('/aufgaben');
 
@@ -63,11 +47,7 @@ test('member can focus on own challenges and release one', async ({ page }) => {
 
     const releaseButton = page.getByRole('button', { name: 'Freigeben', exact: true }).first();
 
-    await Promise.all([
-        page.waitForNavigation(),
-        releaseButton.click(),
-    ]);
-
+    await releaseButton.click();
     await expect(page.locator('div[role="status"]').first()).toContainText('erfolgreich freigegeben');
     await expect(page.locator('[data-todo-section="assigned"]')).not.toContainText('Übernommene Playwright Challenge');
     await expect(page.locator('[data-todo-section="open"]')).toContainText('Übernommene Playwright Challenge');

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { runArtisan } from './utils/artisan.js';
+
+export default async function globalSetup() {
+    const databasePath = path.resolve('database/playwright.sqlite');
+
+    process.env.APP_ENV = 'testing';
+    process.env.APP_DEBUG = 'false';
+    process.env.APP_KEY = process.env.APP_KEY ?? 'base64:oK0ZsJlI+o7C++h527lMcrrO4jzZrXqhouB/p0l+gFw=';
+    process.env.DB_CONNECTION = 'sqlite';
+    process.env.DB_DATABASE = databasePath;
+    process.env.SESSION_DRIVER = 'file';
+    process.env.CACHE_DRIVER = 'array';
+    process.env.QUEUE_CONNECTION = 'database';
+    process.env.MAIL_MAILER = 'array';
+
+    if (fs.existsSync(databasePath)) {
+        fs.rmSync(databasePath);
+    }
+
+    const databaseDirectory = path.dirname(databasePath);
+    if (!fs.existsSync(databaseDirectory)) {
+        fs.mkdirSync(databaseDirectory, { recursive: true });
+    }
+
+    fs.closeSync(fs.openSync(databasePath, 'w'));
+
+    await runArtisan('migrate:fresh');
+    await runArtisan('db:seed --class="Database\\\\Seeders\\\\TodoCategorySeeder"');
+    await runArtisan('db:seed --class="Database\\\\Seeders\\\\TodoPlaywrightSeeder"');
+}

--- a/tests/e2e/utils/artisan.js
+++ b/tests/e2e/utils/artisan.js
@@ -1,0 +1,30 @@
+import { exec as execCallback } from 'child_process';
+import { promisify } from 'util';
+
+const exec = promisify(execCallback);
+
+export async function runArtisan(command, options = {}) {
+    const env = {
+        ...process.env,
+        APP_ENV: process.env.APP_ENV ?? 'testing',
+    };
+
+    try {
+        const result = await exec(`php artisan ${command}`, {
+            env,
+            ...options,
+        });
+
+        return result.stdout.trim();
+    } catch (error) {
+        if (error.stdout) {
+            console.error(error.stdout);
+        }
+
+        if (error.stderr) {
+            console.error(error.stderr);
+        }
+
+        throw error;
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive client-side filtering system for the "Challenges" (Todos) page, improves accessibility, and adds supporting utilities and tests. The main focus is to enable users to filter challenges by different statuses (all, assigned, open, pending) using interactive buttons, with filter state managed dynamically via JavaScript. Additionally, the PR enhances accessibility for status and error messages and adds a database seeder for Playwright end-to-end testing.

**Client-side Filtering and UI Enhancements:**

* Added a filter bar with buttons to the `todos/index.blade.php` view, allowing users to filter challenges by status (all, assigned, open, pending), and restructured challenge sections with semantic HTML and ARIA attributes for accessibility. [[1]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162R41-R86) [[2]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L151-R202) [[3]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L237-R291) [[4]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L324-R385) [[5]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L398-R450)
* Implemented `resources/js/utils/todoFilters.js` to manage filter logic, button state, section visibility, and filter status messages, and initialized this logic in `resources/js/todos.js` [[1]](diffhunk://#diff-d75d11a6d70437360c5b5b7b38915cdf017f5752361a3d8c1cab2f19d9b560eeR1-R131) [[2]](diffhunk://#diff-5f38504959903bc576364978d6298892df7261edb1c301e9ed6554225655b8c8R1-R5) [[3]](diffhunk://#diff-583a1f586bc298813341bce6fec77a1f6338f2559471fe600f15a18316fe82bdR85)
* Updated the controller (`TodoController.php`) and Blade view to provide and use the current active filter in the UI [[1]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5R79) [[2]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L4-R17)

**Accessibility Improvements:**

* Added `role` and `aria-live` attributes to status and error message containers in `todos/index.blade.php` and `todos/show.blade.php` to improve accessibility for screen readers. [[1]](diffhunk://#diff-fc345167b2a93d8585706aa48006764f8133ffee108ec55a1bd822556ea99162L4-R17) [[2]](diffhunk://#diff-b8a567b21d24c339f30a38551740cb99aee9ba87c59070afc97afdbbf07aa255L5-R12)

**Testing and Development Support:**

* Added a dedicated `TodoPlaywrightSeeder.php` for Playwright E2E tests, which seeds the database with a team, users, categories, and todos in various states for reliable testing.
* Updated `playwright.config.js` to use a separate SQLite database and set up the environment for Playwright tests, including a global setup script.

**Backend Test Improvements:**

* Enhanced feature tests to assert that activity records are created when todos are assigned or completed, ensuring correct activity tracking. [[1]](diffhunk://#diff-669cfc3d38315de73b5673ec24d0cd9fd372b85892c838739f395885b034fef7R67-R71) [[2]](diffhunk://#diff-669cfc3d38315de73b5673ec24d0cd9fd372b85892c838739f395885b034fef7R110-R114)