### PR TITLE
Fix coverage badge customization permissions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -83,6 +83,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           if [ -f output/php-coverage.svg ]; then
+            chmod u+w output output/php-coverage.svg
             sed -i 's/Coverage/PHP Coverage/' output/php-coverage.svg
           fi
       - name: Upload PHP coverage report


### PR DESCRIPTION
## Summary
- ensure the workflow sets write permissions on the coverage badge output directory before editing it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf7b4bf71c832eb7252684842b558c