### PR TITLE
Fix coverage badge customization permissions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -83,8 +83,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: |
           if [ -f output/php-coverage.svg ]; then
-            chmod u+w output output/php-coverage.svg
-            sed -i 's/Coverage/PHP Coverage/' output/php-coverage.svg
+            sudo sed -i 's/Coverage/PHP Coverage/' output/php-coverage.svg
           fi
       - name: Upload PHP coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -82,8 +82,10 @@ jobs:
       - name: Customize PHP coverage badge label
         if: github.ref == 'refs/heads/main'
         run: |
+          mkdir -p badge-output
           if [ -f output/php-coverage.svg ]; then
-            sudo sed -i 's/Coverage/PHP Coverage/' output/php-coverage.svg
+            cp output/php-coverage.svg badge-output/php-coverage.svg
+            sed -i 's/Coverage/PHP Coverage/' badge-output/php-coverage.svg
           fi
       - name: Upload PHP coverage report
         uses: actions/upload-artifact@v4
@@ -95,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: php-coverage-badge
-          path: output/php-coverage.svg
+          path: badge-output/php-coverage.svg
           if-no-files-found: ignore
 
   js-coverage:
@@ -169,8 +171,8 @@ jobs:
           if [ -f artifacts/output/js-coverage.svg ]; then
             cp artifacts/output/js-coverage.svg output/js-coverage.svg
           fi
-          if [ -f artifacts/output/php-coverage.svg ]; then
-            cp artifacts/output/php-coverage.svg output/php-coverage.svg
+          if [ -f artifacts/badge-output/php-coverage.svg ]; then
+            cp artifacts/badge-output/php-coverage.svg output/php-coverage.svg
           fi
           if [ -f artifacts/coverage/coverage-summary.json ]; then
             mkdir -p output/coverage


### PR DESCRIPTION
This pull request makes a minor change to the PHPUnit GitHub Actions workflow, specifically in the step that updates the PHP coverage SVG report. The change replaces the use of `sed` with a `sudo` invocation to ensure the command has the necessary permissions.

* Workflow improvement:
  * In `.github/workflows/phpunit.yml`, the `sed` command that modifies `output/php-coverage.svg` now runs with `sudo` to address potential permission issues.