### PR TITLE
Add composer caches to phpunit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -27,6 +27,24 @@ jobs:
           php-version: ${{ matrix.php-version }}
       - name: Copy .env
         run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php-version }}-composer-
+            ${{ runner.os }}-php-${{ matrix.php-version }}-
+            ${{ runner.os }}-
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-composer-cache-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php-version }}-composer-cache-
+            ${{ runner.os }}-php-${{ matrix.php-version }}-
+            ${{ runner.os }}-
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
       - name: Directory Permissions
@@ -57,6 +75,24 @@ jobs:
           php-version: '8.4'
       - name: Copy .env
         run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-composer-
+            ${{ runner.os }}-php-8.4-
+            ${{ runner.os }}-
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-php-8.4-composer-cache-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-composer-cache-
+            ${{ runner.os }}-php-8.4-
+            ${{ runner.os }}-
       - name: Install Dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
       - name: Directory Permissions


### PR DESCRIPTION
## Summary
- cache Composer dependencies in the phpunit workflow for test and coverage jobs
- add optional cache for Composer downloads to speed up dependency installs

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cf8ab9ddb4832e8bd38c1085411ddd