### PR TITLE
Add dashboard metrics and leaderboard to todo overview

### DIFF
--- a/app/Http/Controllers/TodoController.php
+++ b/app/Http/Controllers/TodoController.php
@@ -63,7 +63,7 @@ class TodoController extends Controller
             $todo->assigned_to !== $user->id
         );
 
-        $userPoints = $this->teamPointService->getUserPoints($user);
+        $dashboardMetrics = $this->teamPointService->getDashboardMetrics($user, $memberTeam);
 
         return view('todos.index', [
             'todos' => $todos,
@@ -72,11 +72,12 @@ class TodoController extends Controller
             'completedTodos' => $completedTodos,
             'canCreateTodos' => $canCreateTodos,
             'canVerifyTodos' => $canVerifyTodos,
-            'userPoints' => $userPoints,
+            'userPoints' => $dashboardMetrics['user_points'],
             'memberTeam' => $memberTeam,
             'userRole' => $userRole,
             'filter' => $filter,
             'activeFilter' => $filter === 'pending' ? 'pending' : 'all',
+            'dashboardMetrics' => $dashboardMetrics,
         ]);
     }
 

--- a/app/Services/TeamPointService.php
+++ b/app/Services/TeamPointService.php
@@ -262,7 +262,7 @@ class TeamPointService
 
             if ($userEntry) {
                 $foundIndex = $totals->search($userEntry);
-                $position = is_int($foundIndex) ? $foundIndex + 1 : null;
+                $position = $foundIndex !== false ? $foundIndex + 1 : null;
             }
 
             $leaderboard[] = [

--- a/app/Services/TeamPointService.php
+++ b/app/Services/TeamPointService.php
@@ -2,12 +2,18 @@
 
 namespace App\Services;
 
+use App\Models\Team;
 use App\Models\User;
+use App\Models\UserPoint;
+use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 
 class TeamPointService
 {
+    public const WEEKLY_GOAL_POINTS = 50;
+
     /**
      * Get the total points of a user in their current team.
      */
@@ -16,6 +22,114 @@ class TeamPointService
         $team = $user->currentTeam;
 
         return $team ? $user->totalPointsForTeam($team) : 0;
+    }
+
+    /**
+     * Build the metrics needed for the todo dashboard.
+     *
+     * @return array{
+     *     user_points:int,
+     *     trend:array<int, array{date:string,label:string,points:int}>,
+     *     trend_max:int,
+     *     weekly:array{total:int,target:int,progress:int},
+     *     team_average:float,
+     *     team_average_progress:int,
+     *     team_average_ratio:float|null,
+     *     leaderboard:array<int, array{rank:int|null,name:string,points:int,is_current_user:bool,is_additional?:bool}>,
+     *     user_rank:int|null,
+     *     points_to_next_rank:int|null,
+     *     next_rank_points:int|null
+     * }
+     */
+    public function getDashboardMetrics(User $user, Team $team): array
+    {
+        $userPoints = $this->getUserPoints($user);
+        $trend = $this->getUserPointTrend($user, $team);
+        $trendMax = collect($trend)->max(fn (array $entry) => $entry['points']) ?? 0;
+        $weeklyTotal = array_sum(array_column($trend, 'points'));
+
+        $leaderboardTotals = $this->getLeaderboardTotals($team);
+        $teamAverage = $this->calculateTeamAverage($team, $leaderboardTotals);
+        $rankData = $this->resolveUserRankData($user, $leaderboardTotals);
+        $leaderboard = $this->buildLeaderboard($leaderboardTotals, $user, $team);
+
+        $teamAverageRatio = $teamAverage > 0
+            ? round(($userPoints / $teamAverage) * 100, 1)
+            : null;
+
+        return [
+            'user_points' => $userPoints,
+            'trend' => $trend,
+            'trend_max' => $trendMax,
+            'weekly' => [
+                'total' => $weeklyTotal,
+                'target' => self::WEEKLY_GOAL_POINTS,
+                'progress' => $this->calculateProgress($weeklyTotal, self::WEEKLY_GOAL_POINTS),
+            ],
+            'team_average' => $teamAverage,
+            'team_average_progress' => $teamAverage > 0
+                ? $this->calculateProgress($userPoints, $teamAverage)
+                : 0,
+            'team_average_ratio' => $teamAverageRatio,
+            'leaderboard' => $leaderboard,
+            'user_rank' => $rankData['rank'],
+            'points_to_next_rank' => $rankData['points_to_next_rank'],
+            'next_rank_points' => $rankData['next_rank_points'],
+        ];
+    }
+
+    /**
+     * Retrieve the last X days of user points as an ordered trend.
+     *
+     * @return array<int, array{date:string,label:string,points:int}>
+     */
+    public function getUserPointTrend(User $user, Team $team, int $days = 7): array
+    {
+        $days = max($days, 1);
+        $endDate = Carbon::now()->endOfDay();
+        $startDate = Carbon::now()->subDays($days - 1)->startOfDay();
+
+        $dailyTotals = UserPoint::query()
+            ->where('team_id', $team->id)
+            ->where('user_id', $user->id)
+            ->whereBetween('created_at', [$startDate, $endDate])
+            ->selectRaw('DATE(created_at) as day, SUM(points) as total_points')
+            ->groupBy('day')
+            ->orderBy('day')
+            ->pluck('total_points', 'day');
+
+        $trend = [];
+
+        for ($date = $startDate->copy(); $date->lte($endDate); $date->addDay()) {
+            $dayKey = $date->toDateString();
+            $trend[] = [
+                'date' => $dayKey,
+                'label' => $date->format('d.m.'),
+                'points' => (int) ($dailyTotals[$dayKey] ?? 0),
+            ];
+        }
+
+        return $trend;
+    }
+
+    /**
+     * Create a leaderboard for the given team and highlight the current user.
+     *
+     * @return array<int, array{rank:int|null,name:string,points:int,is_current_user:bool,is_additional?:bool}>
+     */
+    public function getTeamLeaderboard(Team $team, User $user, int $limit = 5): array
+    {
+        return $this->buildLeaderboard($this->getLeaderboardTotals($team), $user, $team, $limit);
+    }
+
+    /**
+     * Determine the user rank for the given team.
+     */
+    public function getUserRank(User $user, Team $team): ?int
+    {
+        $rankData = $this->resolveUserRankData($user, $this->getLeaderboardTotals($team));
+
+        return $rankData['rank'];
     }
 
     /**
@@ -34,6 +148,133 @@ class TeamPointService
         if ($this->getUserPoints($user) < $required) {
             throw new AuthorizationException("Mindestens {$required} Baxx erforderlich.");
         }
+    }
+
+    /**
+     * @param  Collection<int, array{user_id:int,total:int}>  $totals
+     */
+    private function calculateTeamAverage(Team $team, Collection $totals): float
+    {
+        $memberIds = $team->activeUsers()->pluck('users.id');
+
+        if ($memberIds->isEmpty()) {
+            return 0.0;
+        }
+
+        $totalPoints = $memberIds
+            ->map(function (int $memberId) use ($totals) {
+                $entry = $totals->firstWhere('user_id', $memberId);
+
+                return $entry['total'] ?? 0;
+            })
+            ->sum();
+
+        return round($totalPoints / $memberIds->count(), 1);
+    }
+
+    private function calculateProgress(int|float $value, int|float $target): int
+    {
+        if ($target <= 0) {
+            return 0;
+        }
+
+        $percentage = ($value / $target) * 100;
+
+        return (int) max(0, min(100, round($percentage)));
+    }
+
+    /**
+     * @return Collection<int, array{user_id:int,total:int}>
+     */
+    private function getLeaderboardTotals(Team $team): Collection
+    {
+        return UserPoint::query()
+            ->where('team_id', $team->id)
+            ->selectRaw('user_id, SUM(points) as total_points')
+            ->groupBy('user_id')
+            ->orderByDesc('total_points')
+            ->get()
+            ->map(fn (UserPoint $row) => [
+                'user_id' => (int) $row->user_id,
+                'total' => (int) $row->total_points,
+            ]);
+    }
+
+    /**
+     * @param  Collection<int, array{user_id:int,total:int}>  $totals
+     * @return array{rank:int|null,points_to_next_rank:int|null,next_rank_points:int|null}
+     */
+    private function resolveUserRankData(User $user, Collection $totals): array
+    {
+        $rank = null;
+        $pointsToNext = null;
+        $nextRankPoints = null;
+
+        foreach ($totals as $index => $entry) {
+            if ($entry['user_id'] === $user->id) {
+                $rank = $index + 1;
+                if ($index > 0) {
+                    $nextEntry = $totals->get($index - 1);
+                    $nextRankPoints = $nextEntry['total'];
+                    $pointsToNext = max(0, $nextEntry['total'] - $entry['total']);
+                }
+                break;
+            }
+        }
+
+        return [
+            'rank' => $rank,
+            'points_to_next_rank' => $pointsToNext,
+            'next_rank_points' => $nextRankPoints,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, array{user_id:int,total:int}>  $totals
+     * @return array<int, array{rank:int|null,name:string,points:int,is_current_user:bool,is_additional?:bool}>
+     */
+    private function buildLeaderboard(Collection $totals, User $user, Team $team, int $limit = 5): array
+    {
+        $limit = max(1, $limit);
+        $topEntries = $totals->take($limit);
+        $userIds = $topEntries->pluck('user_id')->push($user->id)->unique()->values();
+
+        $userNames = $team->users()
+            ->whereIn('users.id', $userIds)
+            ->pluck('users.name', 'users.id');
+
+        $leaderboard = [];
+
+        foreach ($topEntries as $index => $entry) {
+            $leaderboard[] = [
+                'rank' => $index + 1,
+                'name' => $userNames[$entry['user_id']] ?? 'Unbekannt',
+                'points' => $entry['total'],
+                'is_current_user' => $entry['user_id'] === $user->id,
+            ];
+        }
+
+        $alreadyIncluded = collect($leaderboard)->contains(fn (array $row) => $row['is_current_user']);
+
+        if (! $alreadyIncluded) {
+            $userEntry = $totals->firstWhere('user_id', $user->id);
+            $position = null;
+
+            if ($userEntry) {
+                $foundIndex = $totals->search($userEntry);
+                $position = is_int($foundIndex) ? $foundIndex + 1 : null;
+            }
+
+            $leaderboard[] = [
+                'rank' => $position,
+                'name' => $userNames[$user->id] ?? $user->name,
+                'points' => $userEntry['total'] ?? 0,
+                'is_current_user' => true,
+                'is_additional' => true,
+            ];
+        }
+
+        return $leaderboard;
     }
 }
 

--- a/resources/js/todos.js
+++ b/resources/js/todos.js
@@ -1,5 +1,7 @@
 import { initTodoFilters } from './utils/todoFilters';
+import { initTodoDashboard } from './utils/dashboard';
 
 document.addEventListener('DOMContentLoaded', () => {
     initTodoFilters(document);
+    initTodoDashboard(document);
 });

--- a/resources/js/utils/dashboard.js
+++ b/resources/js/utils/dashboard.js
@@ -14,7 +14,7 @@ export function initTodoDashboard(root = document) {
         if (Number.isFinite(maxAttribute) && maxAttribute > 0) {
             normalizedMax = maxAttribute;
         } else {
-            const fallbackMax = Math.max(Math.abs(sanitizedValue), normalizedValue, 1);
+            const fallbackMax = Math.max(normalizedValue, 1);
             normalizedMax = fallbackMax;
         }
 

--- a/resources/js/utils/dashboard.js
+++ b/resources/js/utils/dashboard.js
@@ -31,7 +31,7 @@ export function initTodoDashboard(root = document) {
 
         const fill = bar.querySelector('[data-progress-fill]');
         if (fill) {
-            const percent = normalizedMax === 0 ? 0 : Math.round((clampedValue / normalizedMax) * 100);
+            const percent = normalizedMax > 0 ? Math.round((clampedValue / normalizedMax) * 100) : 0;
             fill.style.width = `${percent}%`;
             fill.style.setProperty('--progress-percent', String(percent));
         }

--- a/resources/js/utils/dashboard.js
+++ b/resources/js/utils/dashboard.js
@@ -1,0 +1,41 @@
+export function initTodoDashboard(root = document) {
+    const context = root || document;
+    const progressBars = context.querySelectorAll('[data-progress-bar]');
+
+    progressBars.forEach((bar) => {
+        const valueAttribute = Number(bar.getAttribute('data-progress-value'));
+        const maxAttribute = Number(bar.getAttribute('data-progress-max'));
+        const label = bar.getAttribute('data-progress-label');
+
+        const sanitizedValue = Number.isFinite(valueAttribute) ? valueAttribute : 0;
+        const normalizedValue = Math.max(0, sanitizedValue);
+
+        let normalizedMax;
+        if (Number.isFinite(maxAttribute) && maxAttribute > 0) {
+            normalizedMax = maxAttribute;
+        } else {
+            const fallbackMax = Math.max(Math.abs(sanitizedValue), normalizedValue, 1);
+            normalizedMax = fallbackMax;
+        }
+
+        const clampedValue = Math.min(normalizedValue, normalizedMax);
+
+        bar.setAttribute('role', 'progressbar');
+        bar.setAttribute('aria-valuemin', '0');
+        bar.setAttribute('aria-valuemax', normalizedMax.toString());
+        bar.setAttribute('aria-valuenow', clampedValue.toString());
+
+        if (label) {
+            bar.setAttribute('aria-label', label);
+        }
+
+        const fill = bar.querySelector('[data-progress-fill]');
+        if (fill) {
+            const percent = normalizedMax === 0 ? 0 : Math.round((clampedValue / normalizedMax) * 100);
+            fill.style.width = `${percent}%`;
+            fill.style.setProperty('--progress-percent', String(percent));
+        }
+    });
+}
+
+export default initTodoDashboard;

--- a/resources/js/utils/todoFilters.js
+++ b/resources/js/utils/todoFilters.js
@@ -80,6 +80,45 @@ export function applyFilterState({
     return activeFilter;
 }
 
+function focusFirstInput(panel) {
+    if (!(panel instanceof HTMLElement)) {
+        return;
+    }
+
+    const focusTarget = panel.querySelector(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+
+    if (focusTarget instanceof HTMLElement && typeof focusTarget.focus === 'function') {
+        focusTarget.focus({ preventScroll: true });
+    }
+}
+
+function togglePanelVisibility({ toggle, panel, expanded }) {
+    const isExpanded = Boolean(expanded);
+    const labelElement = toggle.querySelector('[data-todo-filter-toggle-text]');
+    const openLabel = toggle.dataset.labelOpen || 'Filter anzeigen';
+    const closeLabel = toggle.dataset.labelClose || 'Filter verbergen';
+
+    toggle.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+
+    if (isExpanded) {
+        panel.removeAttribute('hidden');
+        panel.setAttribute('aria-hidden', 'false');
+        panel.dataset.collapsed = 'false';
+    } else {
+        panel.setAttribute('hidden', '');
+        panel.setAttribute('aria-hidden', 'true');
+        panel.dataset.collapsed = 'true';
+    }
+
+    if (labelElement instanceof HTMLElement) {
+        labelElement.textContent = isExpanded ? closeLabel : openLabel;
+    } else {
+        toggle.textContent = isExpanded ? closeLabel : openLabel;
+    }
+}
+
 export function initTodoFilters(root = document) {
     if (!root || typeof root.querySelector !== 'function') {
         return;
@@ -98,7 +137,10 @@ export function initTodoFilters(root = document) {
     }
 
     const sections = Array.from(root.querySelectorAll('[data-todo-section]'));
-    const statusElement = form.querySelector('[data-todo-filter-status]');
+    const filterWrapper = form.closest('[data-todo-filter-wrapper]') || root;
+    const statusElement = filterWrapper.querySelector('[data-todo-filter-status]');
+    const toggle = filterWrapper.querySelector('[data-todo-filter-toggle]');
+    const panel = filterWrapper.querySelector('[data-todo-filter-panel]');
     const initialFilter = normaliseFilter(form.dataset.currentFilter || 'all');
 
     applyFilterState({
@@ -107,6 +149,28 @@ export function initTodoFilters(root = document) {
         statusElement,
         filter: initialFilter,
     });
+
+    if (toggle instanceof HTMLElement && panel instanceof HTMLElement) {
+        togglePanelVisibility({
+            toggle,
+            panel,
+            expanded: toggle.getAttribute('aria-expanded') === 'true',
+        });
+
+        toggle.addEventListener('click', () => {
+            const isCurrentlyExpanded = toggle.getAttribute('aria-expanded') === 'true';
+
+            togglePanelVisibility({
+                toggle,
+                panel,
+                expanded: !isCurrentlyExpanded,
+            });
+
+            if (!isCurrentlyExpanded) {
+                focusFirstInput(panel);
+            }
+        });
+    }
 
     form.addEventListener('click', (event) => {
         const target = event.target instanceof HTMLElement

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -15,14 +15,12 @@
             @php
                 $currentFilter = $activeFilter ?? 'all';
             @endphp
-            <!-- Kopfzeile mit Baxx und Aktionen -->
-            <div
-                class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+            <header class="mb-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                 <div>
-                    <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-1">Deine Baxx</h2>
-                    <div class="text-4xl font-bold text-gray-800 dark:text-gray-200">
-                        {{ $userPoints }}
-                    </div>
+                    <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Challenges &amp; Baxx</h1>
+                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                        Behalte deine Fortschritte und die Ziele des Vereins im Blick.
+                    </p>
                 </div>
                 @if($canCreateTodos)
                     <div>
@@ -37,7 +35,7 @@
                         </a>
                     </div>
                 @endif
-            </div>
+            </header>
             @php
                 $dashboard = $dashboardMetrics ?? [
                     'trend' => [],
@@ -76,7 +74,7 @@
                 </div>
                 <div class="mt-6 grid gap-6 xl:grid-cols-3" data-todo-dashboard>
                     <div class="space-y-6 xl:col-span-2">
-                        <div class="grid gap-6 md:grid-cols-2">
+                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
                             <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
                                 aria-labelledby="weekly-goal-heading">
                                 <div class="flex items-center justify-between gap-4">
@@ -149,6 +147,36 @@
                                         @endif
                                     </p>
                                 </div>
+                            </article>
+                            <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                                aria-labelledby="personal-points-heading">
+                                <div class="flex items-center justify-between gap-4">
+                                    <div>
+                                        <h3 id="personal-points-heading"
+                                            class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                                            Dein Punktestand
+                                        </h3>
+                                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                            Alle gesammelten Baxx deines Vereinskontos.
+                                        </p>
+                                    </div>
+                                    <div class="text-right">
+                                        <span class="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                                            {{ $userTotalPoints }}
+                                        </span>
+                                        <p class="text-xs text-gray-600 dark:text-gray-400">gesammelte Baxx</p>
+                                    </div>
+                                </div>
+                                @if($teamAverage > 0)
+                                    <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                                        Du liegst {{ $userTotalPoints >= $teamAverage ? 'über' : 'unter' }} dem Vereinsdurchschnitt
+                                        von {{ number_format($teamAverage, 1, ',', '.') }} Baxx.
+                                    </p>
+                                @else
+                                    <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                                        Sobald Baxx gesammelt wurden, erscheint hier dein Vergleich zum Verein.
+                                    </p>
+                                @endif
                             </article>
                         </div>
                         <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -72,196 +72,138 @@
                         </p>
                     </div>
                 </div>
-                <div class="mt-6 grid gap-6 xl:grid-cols-3" data-todo-dashboard>
-                    <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 xl:col-span-2">
-                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
-                                aria-labelledby="weekly-goal-heading">
-                                <div class="flex flex-wrap items-start justify-between gap-4">
-                                    <div>
-                                        <h3 id="weekly-goal-heading"
-                                            class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
-                                            Wochenziel
-                                        </h3>
-                                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                            Sammle kontinuierlich Baxx, um dein Wochenziel zu erreichen.
-                                        </p>
-                                    </div>
-                                    <div class="flex flex-col items-end text-right gap-1">
-                                        <span class="text-2xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl xl:text-4xl">
-                                            {{ number_format($weeklyTotal, 0, ',', '.') }}
-                                        </span>
-                                        <p class="text-xs text-gray-600 dark:text-gray-400">
-                                            von {{ number_format($weeklyTarget, 0, ',', '.') }} Baxx
-                                        </p>
-                                    </div>
-                                </div>
-                                <div class="mt-4" data-progress-bar data-progress-value="{{ $weeklyTotal }}"
-                                    data-progress-max="{{ max($weeklyTarget, 1) }}"
-                                    data-progress-label="Fortschritt Richtung Wochenziel">
-                                    <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
-                                        aria-hidden="true">
-                                        <div data-progress-fill
-                                            class="h-full bg-[#8B0116] dark:bg-[#FF6B81]"
-                                            style="width: {{ $weeklyProgress }}%"></div>
-                                    </div>
-                                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                        {{ number_format($weeklyTotal, 0, ',', '.') }} von {{ number_format($weeklyTarget, 0, ',', '.') }} Baxx gesammelt.
-                                    </p>
-                                </div>
-                            </article>
-                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
-                                aria-labelledby="team-average-heading">
-                                <div class="flex flex-wrap items-start justify-between gap-4">
-                                    <div>
-                                        <h3 id="team-average-heading"
-                                            class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
-                                            Vereinsdurchschnitt
-                                        </h3>
-                                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                            Vergleiche deine Punkte mit dem Durchschnitt des Vereins.
-                                        </p>
-                                    </div>
-                                    <div class="flex flex-col items-end text-right gap-1">
-                                        <span class="text-2xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl xl:text-4xl">
-                                            {{ number_format($teamAverage, 1, ',', '.') }}
-                                        </span>
-                                        <p class="text-xs text-gray-600 dark:text-gray-400">Ø Vereins-Baxx</p>
-                                    </div>
-                                </div>
-                                <div class="mt-4" data-progress-bar data-progress-value="{{ $userTotalPoints }}"
-                                    data-progress-max="{{ max($teamAverage, 1) }}"
-                                    data-progress-label="Vergleich zum Vereinsdurchschnitt">
-                                    <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
-                                        aria-hidden="true">
-                                        <div data-progress-fill
-                                            class="h-full bg-[#006D77] dark:bg-[#33BBC5]"
-                                            style="width: {{ $teamAverageProgress }}%"></div>
-                                    </div>
-                                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                        @if(! is_null($teamAverageRatio))
-                                            Du liegst bei {{ number_format($teamAverageRatio, 1, ',', '.') }} % des
-                                            Vereinsdurchschnitts.
-                                        @else
-                                            Sobald Vereinsmitglieder Punkte gesammelt haben, erscheint hier der Vergleich.
-                                        @endif
-                                    </p>
-                                </div>
-                            </article>
-                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
-                                aria-labelledby="personal-points-heading">
-                                <div class="flex flex-wrap items-start justify-between gap-4">
-                                    <div>
-                                        <h3 id="personal-points-heading"
-                                            class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
-                                            Dein Punktestand
-                                        </h3>
-                                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                            Alle gesammelten Baxx deines Vereinskontos.
-                                        </p>
-                                    </div>
-                                    <div class="flex flex-col items-end text-right gap-1">
-                                        <span class="text-2xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl xl:text-4xl">
-                                            {{ number_format($userTotalPoints, 0, ',', '.') }}
-                                        </span>
-                                        <p class="text-xs text-gray-600 dark:text-gray-400">gesammelte Baxx</p>
-                                    </div>
-                                </div>
-                                @if($teamAverage > 0)
-                                    <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
-                                        Du liegst {{ $userTotalPoints >= $teamAverage ? 'über' : 'unter' }} dem Vereinsdurchschnitt
-                                        von {{ number_format($teamAverage, 1, ',', '.') }} Baxx.
-                                    </p>
-                                @else
-                                    <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
-                                        Sobald Baxx gesammelt wurden, erscheint hier dein Vergleich zum Verein.
-                                    </p>
-                                @endif
-                            </article>
-                        </div>
-                    </div>
-                    <div class="space-y-6">
-                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
-                            aria-labelledby="leaderboard-heading">
-                            <h3 id="leaderboard-heading"
-                                class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
-                                Rangliste
-                            </h3>
-                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                So steht dein Verein aktuell da.
-                            </p>
-                            <ol class="mt-4 space-y-3" role="list">
-                                @forelse($dashboard['leaderboard'] as $entry)
-                                    <li
-                                        class="flex items-center justify-between gap-3 rounded-md px-3 py-2 @if($entry['is_current_user']) bg-[#8B0116] text-white dark:bg-[#FF6B81] dark:text-gray-900 @else bg-white text-gray-800 dark:bg-gray-800 dark:text-gray-100 @endif border border-gray-200 dark:border-gray-700">
-                                        <div class="flex items-center gap-3">
-                                            <span class="text-sm font-semibold @if($entry['is_current_user']) text-white dark:text-gray-900 @else text-gray-600 dark:text-gray-400 @endif">
-                                                {{ $entry['rank'] ? '#' . $entry['rank'] : '–' }}
-                                            </span>
-                                            <span class="text-sm font-semibold">{{ $entry['name'] }}</span>
-                                        </div>
-                                        <span class="text-sm font-semibold">{{ number_format($entry['points'], 0, ',', '.') }} Baxx</span>
-                                    </li>
-                                @empty
-                                    <li class="text-sm text-gray-600 dark:text-gray-400">
-                                        Sobald Punkte gesammelt wurden, erscheint hier die Rangliste.
-                                    </li>
-                                @endforelse
-                            </ol>
-                        </article>
-                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
-                            aria-labelledby="goal-heading">
-                            <h3 id="goal-heading"
-                                class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
-                                Dein nächstes Ziel
-                            </h3>
-                            <div class="mt-2 text-sm text-gray-600 dark:text-gray-400 space-y-3">
-                                @if(is_null($userRank))
-                                    <p>Du hast noch keine Baxx gesammelt. Starte jetzt eine Challenge und sichere dir einen Platz
-                                        in der Rangliste.</p>
-                                @else
-                                    <p>Aktuelle Platzierung: <span class="font-semibold text-gray-900 dark:text-gray-100">#{{ $userRank }}</span>
-                                    </p>
-                                    @if(! is_null($pointsToNext) && $userRank > 1)
-                                        <p>Es fehlen dir
-                                            <span class="font-semibold text-gray-900 dark:text-gray-100">{{ number_format($pointsToNext, 0, ',', '.') }} Baxx</span>
-                                            zu Platz #{{ $userRank - 1 }}.</p>
-                                        @php
-                                            $targetForNextRank = max($userTotalPoints + $pointsToNext, 1);
-                                        @endphp
-                                        <div class="pt-1" data-progress-bar
-                                            data-progress-value="{{ $userTotalPoints }}"
-                                            data-progress-max="{{ $targetForNextRank }}"
-                                            data-progress-label="Fortschritt zum nächsten Rang">
-                                            <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
-                                                aria-hidden="true">
-                                                <div data-progress-fill
-                                                    class="h-full bg-[#F4A261] dark:bg-[#FFB86C]"
-                                                    style="width: {{ $targetForNextRank > 0 ? min(100, round(($userTotalPoints / $targetForNextRank) * 100)) : 0 }}%"></div>
-                                            </div>
-                                            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                                Ziel: {{ number_format($targetForNextRank, 0, ',', '.') }} Baxx (Platz #{{ $userRank - 1 }})
-                                            </p>
-                                        </div>
-                                    @else
-                                        <p>Starke Leistung! Du führst die Rangliste aktuell an.</p>
-                                        <div class="pt-1" data-progress-bar data-progress-value="{{ $userTotalPoints }}"
-                                            data-progress-max="{{ max($weeklyTarget, 1) }}"
-                                            data-progress-label="Stabilisiere deine Führung">
-                                            <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
-                                                aria-hidden="true">
-                                                <div data-progress-fill
-                                                    class="h-full bg-[#2A9D8F] dark:bg-[#2DD4BF]"
-                                                    style="width: {{ $weeklyProgress }}%"></div>
-                                            </div>
-                                            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                                Halte dein Wochenziel von {{ number_format($weeklyTarget, 0, ',', '.') }} Baxx, um vorne zu bleiben.
-                                            </p>
-                                        </div>
-                                    @endif
-                                @endif
+                <div class="mt-6 grid gap-6 md:grid-cols-2 xl:grid-cols-4" data-todo-dashboard>
+                    <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900 md:col-span-2 xl:col-span-1"
+                        aria-labelledby="weekly-goal-heading">
+                        <div class="flex flex-wrap items-start justify-between gap-4">
+                            <div>
+                                <h3 id="weekly-goal-heading"
+                                    class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                                    Wochenziel
+                                </h3>
+                                <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                    Sammle kontinuierlich Baxx, um dein Wochenziel zu erreichen.
+                                </p>
                             </div>
-                        </article>
-                    </div>
+                            <div class="flex flex-col items-end text-right gap-1">
+                                <span class="text-2xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl xl:text-4xl">
+                                    {{ number_format($weeklyTotal, 0, ',', '.') }}
+                                </span>
+                                <p class="text-xs text-gray-600 dark:text-gray-400">
+                                    von {{ number_format($weeklyTarget, 0, ',', '.') }} Baxx
+                                </p>
+                            </div>
+                        </div>
+                        <div class="mt-4" data-progress-bar data-progress-value="{{ $weeklyTotal }}"
+                            data-progress-max="{{ max($weeklyTarget, 1) }}"
+                            data-progress-label="Fortschritt Richtung Wochenziel">
+                            <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
+                                aria-hidden="true">
+                                <div data-progress-fill
+                                    class="h-full bg-[#8B0116] dark:bg-[#FF6B81]"
+                                    style="width: {{ $weeklyProgress }}%"></div>
+                            </div>
+                            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                {{ number_format($weeklyTotal, 0, ',', '.') }} von {{ number_format($weeklyTarget, 0, ',', '.') }} Baxx gesammelt.
+                            </p>
+                        </div>
+                    </article>
+                    <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                        aria-labelledby="team-average-heading">
+                        <div class="flex flex-wrap items-start justify-between gap-4">
+                            <div>
+                                <h3 id="team-average-heading"
+                                    class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                                    Vereinsdurchschnitt
+                                </h3>
+                                <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                    Vergleiche deine Punkte mit dem Durchschnitt des Vereins.
+                                </p>
+                            </div>
+                            <div class="flex flex-col items-end text-right gap-1">
+                                <span class="text-2xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl xl:text-4xl">
+                                    {{ number_format($teamAverage, 1, ',', '.') }}
+                                </span>
+                                <p class="text-xs text-gray-600 dark:text-gray-400">Ø Vereins-Baxx</p>
+                            </div>
+                        </div>
+                        <div class="mt-4" data-progress-bar data-progress-value="{{ $userTotalPoints }}"
+                            data-progress-max="{{ max($teamAverage, 1) }}"
+                            data-progress-label="Vergleich zum Vereinsdurchschnitt">
+                            <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
+                                aria-hidden="true">
+                                <div data-progress-fill
+                                    class="h-full bg-[#006D77] dark:bg-[#33BBC5]"
+                                    style="width: {{ $teamAverageProgress }}%"></div>
+                            </div>
+                            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                @if(! is_null($teamAverageRatio))
+                                    Du liegst bei {{ number_format($teamAverageRatio, 1, ',', '.') }} % des
+                                    Vereinsdurchschnitts.
+                                @else
+                                    Sobald Vereinsmitglieder Punkte gesammelt haben, erscheint hier der Vergleich.
+                                @endif
+                            </p>
+                        </div>
+                    </article>
+                    <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                        aria-labelledby="personal-points-heading">
+                        <div class="flex flex-wrap items-start justify-between gap-4">
+                            <div>
+                                <h3 id="personal-points-heading"
+                                    class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                                    Dein Punktestand
+                                </h3>
+                                <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                    Alle gesammelten Baxx deines Vereinskontos.
+                                </p>
+                            </div>
+                            <div class="flex flex-col items-end text-right gap-1">
+                                <span class="text-2xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl xl:text-4xl">
+                                    {{ number_format($userTotalPoints, 0, ',', '.') }}
+                                </span>
+                                <p class="text-xs text-gray-600 dark:text-gray-400">gesammelte Baxx</p>
+                            </div>
+                        </div>
+                        @if($teamAverage > 0)
+                            <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                                Du liegst {{ $userTotalPoints >= $teamAverage ? 'über' : 'unter' }} dem Vereinsdurchschnitt
+                                von {{ number_format($teamAverage, 1, ',', '.') }} Baxx.
+                            </p>
+                        @else
+                            <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                                Sobald Baxx gesammelt wurden, erscheint hier dein Vergleich zum Verein.
+                            </p>
+                        @endif
+                    </article>
+                    <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900 md:col-span-2 xl:col-span-1"
+                        aria-labelledby="leaderboard-heading">
+                        <h3 id="leaderboard-heading"
+                            class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                            Rangliste
+                        </h3>
+                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                            So steht dein Verein aktuell da.
+                        </p>
+                        <ol class="mt-4 space-y-3" role="list">
+                            @forelse($dashboard['leaderboard'] as $entry)
+                                <li
+                                    class="flex items-center justify-between gap-3 rounded-md px-3 py-2 @if($entry['is_current_user']) bg-[#8B0116] text-white dark:bg-[#FF6B81] dark:text-gray-900 @else bg-white text-gray-800 dark:bg-gray-800 dark:text-gray-100 @endif border border-gray-200 dark:border-gray-700">
+                                    <div class="flex items-center gap-3">
+                                        <span class="text-sm font-semibold @if($entry['is_current_user']) text-white dark:text-gray-900 @else text-gray-600 dark:text-gray-400 @endif">
+                                            {{ $entry['rank'] ? '#' . $entry['rank'] : '–' }}
+                                        </span>
+                                        <span class="text-sm font-semibold">{{ $entry['name'] }}</span>
+                                    </div>
+                                    <span class="text-sm font-semibold">{{ number_format($entry['points'], 0, ',', '.') }} Baxx</span>
+                                </li>
+                            @empty
+                                <li class="text-sm text-gray-600 dark:text-gray-400">
+                                    Sobald Punkte gesammelt wurden, erscheint hier die Rangliste.
+                                </li>
+                            @endforelse
+                        </ol>
+                    </article>
                 </div>
             </section>
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6" data-todo-filter-wrapper>

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -38,6 +38,236 @@
                     </div>
                 @endif
             </div>
+            @php
+                $dashboard = $dashboardMetrics ?? [
+                    'trend' => [],
+                    'trend_max' => 0,
+                    'weekly' => ['progress' => 0, 'target' => 0, 'total' => 0],
+                    'team_average' => 0,
+                    'team_average_progress' => 0,
+                    'team_average_ratio' => null,
+                    'leaderboard' => [],
+                    'user_rank' => null,
+                    'points_to_next_rank' => null,
+                    'next_rank_points' => null,
+                    'user_points' => $userPoints,
+                ];
+                $weeklyProgress = $dashboard['weekly']['progress'] ?? 0;
+                $weeklyTarget = $dashboard['weekly']['target'] ?? 0;
+                $weeklyTotal = $dashboard['weekly']['total'] ?? 0;
+                $teamAverage = $dashboard['team_average'] ?? 0;
+                $teamAverageProgress = $dashboard['team_average_progress'] ?? 0;
+                $teamAverageRatio = $dashboard['team_average_ratio'] ?? null;
+                $trendMax = max($dashboard['trend_max'] ?? 0, 1);
+                $userRank = $dashboard['user_rank'] ?? null;
+                $pointsToNext = $dashboard['points_to_next_rank'] ?? null;
+                $userTotalPoints = $dashboard['user_points'] ?? $userPoints;
+            @endphp
+            <section aria-labelledby="todo-dashboard-heading"
+                class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h2 id="todo-dashboard-heading"
+                            class="text-xl font-semibold text-gray-900 dark:text-gray-100">Team-Dashboard</h2>
+                        <p class="text-sm text-gray-600 dark:text-gray-400">
+                            Fortschritt, Vergleich und Ziele deines Teams auf einen Blick.
+                        </p>
+                    </div>
+                </div>
+                <div class="mt-6 grid gap-6 xl:grid-cols-3" data-todo-dashboard>
+                    <div class="space-y-6 xl:col-span-2">
+                        <div class="grid gap-6 md:grid-cols-2">
+                            <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                                aria-labelledby="weekly-goal-heading">
+                                <div class="flex items-center justify-between gap-4">
+                                    <div>
+                                        <h3 id="weekly-goal-heading"
+                                            class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                                            Wochenziel
+                                        </h3>
+                                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                            Sammle kontinuierlich Baxx, um dein Wochenziel zu erreichen.
+                                        </p>
+                                    </div>
+                                    <div class="text-right">
+                                        <span class="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                                            {{ $weeklyTotal }}
+                                        </span>
+                                        <p class="text-xs text-gray-600 dark:text-gray-400">
+                                            von {{ $weeklyTarget }} Baxx
+                                        </p>
+                                    </div>
+                                </div>
+                                <div class="mt-4" data-progress-bar data-progress-value="{{ $weeklyTotal }}"
+                                    data-progress-max="{{ max($weeklyTarget, 1) }}"
+                                    data-progress-label="Fortschritt Richtung Wochenziel">
+                                    <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
+                                        aria-hidden="true">
+                                        <div data-progress-fill
+                                            class="h-full bg-[#8B0116] dark:bg-[#FF6B81]"
+                                            style="width: {{ $weeklyProgress }}%"></div>
+                                    </div>
+                                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                        {{ $weeklyTotal }} von {{ $weeklyTarget }} Baxx gesammelt.
+                                    </p>
+                                </div>
+                            </article>
+                            <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                                aria-labelledby="team-average-heading">
+                                <div class="flex items-center justify-between gap-4">
+                                    <div>
+                                        <h3 id="team-average-heading"
+                                            class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                                            Teamdurchschnitt
+                                        </h3>
+                                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                            Vergleiche deine Punkte mit dem Durchschnitt deines Teams.
+                                        </p>
+                                    </div>
+                                    <div class="text-right">
+                                        <span class="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                                            {{ number_format($teamAverage, 1, ',', '.') }}
+                                        </span>
+                                        <p class="text-xs text-gray-600 dark:text-gray-400">Ø Team-Baxx</p>
+                                    </div>
+                                </div>
+                                <div class="mt-4" data-progress-bar data-progress-value="{{ $userTotalPoints }}"
+                                    data-progress-max="{{ max($teamAverage, 1) }}"
+                                    data-progress-label="Vergleich zum Teamdurchschnitt">
+                                    <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
+                                        aria-hidden="true">
+                                        <div data-progress-fill
+                                            class="h-full bg-[#006D77] dark:bg-[#33BBC5]"
+                                            style="width: {{ $teamAverageProgress }}%"></div>
+                                    </div>
+                                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                        @if(! is_null($teamAverageRatio))
+                                            Du liegst bei {{ number_format($teamAverageRatio, 1, ',', '.') }} % des
+                                            Teamdurchschnitts.
+                                        @else
+                                            Sobald das Team Punkte gesammelt hat, erscheint hier der Vergleich.
+                                        @endif
+                                    </p>
+                                </div>
+                            </article>
+                        </div>
+                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                            aria-labelledby="trend-heading">
+                            <h3 id="trend-heading"
+                                class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                                Aktivität der letzten 7 Tage
+                            </h3>
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                Die Balken zeigen, an welchen Tagen du Baxx gesammelt hast.
+                            </p>
+                            <ul class="mt-6 grid gap-4 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7" role="list">
+                                @foreach($dashboard['trend'] as $day)
+                                    @php
+                                        $barHeight = $trendMax > 0 ? round(($day['points'] / $trendMax) * 100) : 0;
+                                    @endphp
+                                    <li class="flex flex-col" role="listitem">
+                                        <div class="flex items-center justify-between text-sm font-medium text-gray-700 dark:text-gray-200">
+                                            <span aria-hidden="true">{{ $day['label'] }}</span>
+                                            <span>{{ $day['points'] }} Baxx</span>
+                                        </div>
+                                        <div class="mt-3 h-24 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden"
+                                            aria-hidden="true">
+                                            <div class="flex items-end h-full">
+                                                <div class="w-full bg-[#8B0116] dark:bg-[#FF6B81] transition-all duration-500"
+                                                    style="height: {{ $barHeight }}%"></div>
+                                            </div>
+                                        </div>
+                                        <span class="sr-only">{{ $day['label'] }}: {{ $day['points'] }} Baxx</span>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </article>
+                    </div>
+                    <div class="space-y-6">
+                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                            aria-labelledby="leaderboard-heading">
+                            <h3 id="leaderboard-heading"
+                                class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                                Rangliste
+                            </h3>
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                                So steht dein Team aktuell da.
+                            </p>
+                            <ol class="mt-4 space-y-3" role="list">
+                                @forelse($dashboard['leaderboard'] as $entry)
+                                    <li
+                                        class="flex items-center justify-between gap-3 rounded-md px-3 py-2 @if($entry['is_current_user']) bg-[#8B0116] text-white dark:bg-[#FF6B81] dark:text-gray-900 @else bg-white text-gray-800 dark:bg-gray-800 dark:text-gray-100 @endif border border-gray-200 dark:border-gray-700">
+                                        <div class="flex items-center gap-3">
+                                            <span class="text-sm font-semibold @if($entry['is_current_user']) text-white dark:text-gray-900 @else text-gray-600 dark:text-gray-400 @endif">
+                                                {{ $entry['rank'] ? '#' . $entry['rank'] : '–' }}
+                                            </span>
+                                            <span class="text-sm font-semibold">{{ $entry['name'] }}</span>
+                                        </div>
+                                        <span class="text-sm font-semibold">{{ $entry['points'] }} Baxx</span>
+                                    </li>
+                                @empty
+                                    <li class="text-sm text-gray-600 dark:text-gray-400">
+                                        Sobald Punkte gesammelt wurden, erscheint hier die Rangliste.
+                                    </li>
+                                @endforelse
+                            </ol>
+                        </article>
+                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                            aria-labelledby="goal-heading">
+                            <h3 id="goal-heading"
+                                class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                                Dein nächstes Ziel
+                            </h3>
+                            <div class="mt-2 text-sm text-gray-600 dark:text-gray-400 space-y-3">
+                                @if(is_null($userRank))
+                                    <p>Du hast noch keine Baxx gesammelt. Starte jetzt eine Challenge und sichere dir einen Platz
+                                        in der Rangliste.</p>
+                                @else
+                                    <p>Aktuelle Platzierung: <span class="font-semibold text-gray-900 dark:text-gray-100">#{{ $userRank }}</span>
+                                    </p>
+                                    @if(! is_null($pointsToNext) && $userRank > 1)
+                                        <p>Es fehlen dir
+                                            <span class="font-semibold text-gray-900 dark:text-gray-100">{{ $pointsToNext }} Baxx</span>
+                                            zu Platz #{{ $userRank - 1 }}.</p>
+                                        @php
+                                            $targetForNextRank = max($userTotalPoints + $pointsToNext, 1);
+                                        @endphp
+                                        <div class="pt-1" data-progress-bar
+                                            data-progress-value="{{ $userTotalPoints }}"
+                                            data-progress-max="{{ $targetForNextRank }}"
+                                            data-progress-label="Fortschritt zum nächsten Rang">
+                                            <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
+                                                aria-hidden="true">
+                                                <div data-progress-fill
+                                                    class="h-full bg-[#F4A261] dark:bg-[#FFB86C]"
+                                                    style="width: {{ $targetForNextRank > 0 ? min(100, round(($userTotalPoints / $targetForNextRank) * 100)) : 0 }}%"></div>
+                                            </div>
+                                            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                                Ziel: {{ $targetForNextRank }} Baxx (Platz #{{ $userRank - 1 }})
+                                            </p>
+                                        </div>
+                                    @else
+                                        <p>Starke Leistung! Du führst die Rangliste aktuell an.</p>
+                                        <div class="pt-1" data-progress-bar data-progress-value="{{ $userTotalPoints }}"
+                                            data-progress-max="{{ max($weeklyTarget, 1) }}"
+                                            data-progress-label="Stabilisiere deine Führung">
+                                            <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
+                                                aria-hidden="true">
+                                                <div data-progress-fill
+                                                    class="h-full bg-[#2A9D8F] dark:bg-[#2DD4BF]"
+                                                    style="width: {{ $weeklyProgress }}%"></div>
+                                            </div>
+                                            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                                                Halte dein Wochenziel von {{ $weeklyTarget }} Baxx, um vorne zu bleiben.
+                                            </p>
+                                        </div>
+                                    @endif
+                                @endif
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </section>
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6" data-todo-filter-wrapper>
                 <form method="GET" action="{{ route('todos.index') }}" data-todo-filter-form
                     data-current-filter="{{ $currentFilter }}">

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -68,9 +68,9 @@
                 <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <div>
                         <h2 id="todo-dashboard-heading"
-                            class="text-xl font-semibold text-gray-900 dark:text-gray-100">Team-Dashboard</h2>
+                            class="text-xl font-semibold text-gray-900 dark:text-gray-100">Vereins-Dashboard</h2>
                         <p class="text-sm text-gray-600 dark:text-gray-400">
-                            Fortschritt, Vergleich und Ziele deines Teams auf einen Blick.
+                            Fortschritt, Vergleich und Ziele deines Vereins auf einen Blick.
                         </p>
                     </div>
                 </div>
@@ -118,22 +118,22 @@
                                     <div>
                                         <h3 id="team-average-heading"
                                             class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
-                                            Teamdurchschnitt
+                                            Vereinsdurchschnitt
                                         </h3>
                                         <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                            Vergleiche deine Punkte mit dem Durchschnitt deines Teams.
+                                            Vergleiche deine Punkte mit dem Durchschnitt des Vereins.
                                         </p>
                                     </div>
                                     <div class="text-right">
                                         <span class="text-3xl font-bold text-gray-900 dark:text-gray-100">
                                             {{ number_format($teamAverage, 1, ',', '.') }}
                                         </span>
-                                        <p class="text-xs text-gray-600 dark:text-gray-400">Ø Team-Baxx</p>
+                                        <p class="text-xs text-gray-600 dark:text-gray-400">Ø Vereins-Baxx</p>
                                     </div>
                                 </div>
                                 <div class="mt-4" data-progress-bar data-progress-value="{{ $userTotalPoints }}"
                                     data-progress-max="{{ max($teamAverage, 1) }}"
-                                    data-progress-label="Vergleich zum Teamdurchschnitt">
+                                    data-progress-label="Vergleich zum Vereinsdurchschnitt">
                                     <div class="h-2 w-full bg-white dark:bg-gray-800 rounded-full overflow-hidden"
                                         aria-hidden="true">
                                         <div data-progress-fill
@@ -143,9 +143,9 @@
                                     <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
                                         @if(! is_null($teamAverageRatio))
                                             Du liegst bei {{ number_format($teamAverageRatio, 1, ',', '.') }} % des
-                                            Teamdurchschnitts.
+                                            Vereinsdurchschnitts.
                                         @else
-                                            Sobald das Team Punkte gesammelt hat, erscheint hier der Vergleich.
+                                            Sobald Vereinsmitglieder Punkte gesammelt haben, erscheint hier der Vergleich.
                                         @endif
                                     </p>
                                 </div>
@@ -191,7 +191,7 @@
                                 Rangliste
                             </h3>
                             <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                So steht dein Team aktuell da.
+                                So steht dein Verein aktuell da.
                             </p>
                             <ol class="mt-4 space-y-3" role="list">
                                 @forelse($dashboard['leaderboard'] as $entry)

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -73,11 +73,10 @@
                     </div>
                 </div>
                 <div class="mt-6 grid gap-6 xl:grid-cols-3" data-todo-dashboard>
-                    <div class="space-y-6 xl:col-span-2">
-                        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-                            <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                    <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3 xl:col-span-2">
+                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
                                 aria-labelledby="weekly-goal-heading">
-                                <div class="flex items-center justify-between gap-4">
+                                <div class="flex flex-wrap items-start justify-between gap-4">
                                     <div>
                                         <h3 id="weekly-goal-heading"
                                             class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
@@ -87,12 +86,12 @@
                                             Sammle kontinuierlich Baxx, um dein Wochenziel zu erreichen.
                                         </p>
                                     </div>
-                                    <div class="text-right">
-                                        <span class="text-3xl font-bold text-gray-900 dark:text-gray-100">
-                                            {{ $weeklyTotal }}
+                                    <div class="flex flex-col items-end text-right gap-1">
+                                        <span class="text-2xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl xl:text-4xl">
+                                            {{ number_format($weeklyTotal, 0, ',', '.') }}
                                         </span>
                                         <p class="text-xs text-gray-600 dark:text-gray-400">
-                                            von {{ $weeklyTarget }} Baxx
+                                            von {{ number_format($weeklyTarget, 0, ',', '.') }} Baxx
                                         </p>
                                     </div>
                                 </div>
@@ -106,13 +105,13 @@
                                             style="width: {{ $weeklyProgress }}%"></div>
                                     </div>
                                     <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                        {{ $weeklyTotal }} von {{ $weeklyTarget }} Baxx gesammelt.
+                                        {{ number_format($weeklyTotal, 0, ',', '.') }} von {{ number_format($weeklyTarget, 0, ',', '.') }} Baxx gesammelt.
                                     </p>
                                 </div>
                             </article>
-                            <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
                                 aria-labelledby="team-average-heading">
-                                <div class="flex items-center justify-between gap-4">
+                                <div class="flex flex-wrap items-start justify-between gap-4">
                                     <div>
                                         <h3 id="team-average-heading"
                                             class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
@@ -122,8 +121,8 @@
                                             Vergleiche deine Punkte mit dem Durchschnitt des Vereins.
                                         </p>
                                     </div>
-                                    <div class="text-right">
-                                        <span class="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                                    <div class="flex flex-col items-end text-right gap-1">
+                                        <span class="text-2xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl xl:text-4xl">
                                             {{ number_format($teamAverage, 1, ',', '.') }}
                                         </span>
                                         <p class="text-xs text-gray-600 dark:text-gray-400">Ø Vereins-Baxx</p>
@@ -148,9 +147,9 @@
                                     </p>
                                 </div>
                             </article>
-                            <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
+                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
                                 aria-labelledby="personal-points-heading">
-                                <div class="flex items-center justify-between gap-4">
+                                <div class="flex flex-wrap items-start justify-between gap-4">
                                     <div>
                                         <h3 id="personal-points-heading"
                                             class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
@@ -160,9 +159,9 @@
                                             Alle gesammelten Baxx deines Vereinskontos.
                                         </p>
                                     </div>
-                                    <div class="text-right">
-                                        <span class="text-3xl font-bold text-gray-900 dark:text-gray-100">
-                                            {{ $userTotalPoints }}
+                                    <div class="flex flex-col items-end text-right gap-1">
+                                        <span class="text-2xl font-bold leading-none tracking-tight text-gray-900 dark:text-gray-100 sm:text-3xl xl:text-4xl">
+                                            {{ number_format($userTotalPoints, 0, ',', '.') }}
                                         </span>
                                         <p class="text-xs text-gray-600 dark:text-gray-400">gesammelte Baxx</p>
                                     </div>
@@ -179,37 +178,6 @@
                                 @endif
                             </article>
                         </div>
-                        <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
-                            aria-labelledby="trend-heading">
-                            <h3 id="trend-heading"
-                                class="text-lg font-semibold text-[#8B0116] dark:text-[#FF6B81]">
-                                Aktivität der letzten 7 Tage
-                            </h3>
-                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                                Die Balken zeigen, an welchen Tagen du Baxx gesammelt hast.
-                            </p>
-                            <ul class="mt-6 grid gap-4 sm:grid-cols-3 lg:grid-cols-5 xl:grid-cols-7" role="list">
-                                @foreach($dashboard['trend'] as $day)
-                                    @php
-                                        $barHeight = $trendMax > 0 ? round(($day['points'] / $trendMax) * 100) : 0;
-                                    @endphp
-                                    <li class="flex flex-col" role="listitem">
-                                        <div class="flex items-center justify-between text-sm font-medium text-gray-700 dark:text-gray-200">
-                                            <span aria-hidden="true">{{ $day['label'] }}</span>
-                                            <span>{{ $day['points'] }} Baxx</span>
-                                        </div>
-                                        <div class="mt-3 h-24 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md overflow-hidden"
-                                            aria-hidden="true">
-                                            <div class="flex items-end h-full">
-                                                <div class="w-full bg-[#8B0116] dark:bg-[#FF6B81] transition-all duration-500"
-                                                    style="height: {{ $barHeight }}%"></div>
-                                            </div>
-                                        </div>
-                                        <span class="sr-only">{{ $day['label'] }}: {{ $day['points'] }} Baxx</span>
-                                    </li>
-                                @endforeach
-                            </ul>
-                        </article>
                     </div>
                     <div class="space-y-6">
                         <article class="rounded-lg border border-gray-200 dark:border-gray-700 p-5 bg-gray-50 dark:bg-gray-900"
@@ -231,7 +199,7 @@
                                             </span>
                                             <span class="text-sm font-semibold">{{ $entry['name'] }}</span>
                                         </div>
-                                        <span class="text-sm font-semibold">{{ $entry['points'] }} Baxx</span>
+                                        <span class="text-sm font-semibold">{{ number_format($entry['points'], 0, ',', '.') }} Baxx</span>
                                     </li>
                                 @empty
                                     <li class="text-sm text-gray-600 dark:text-gray-400">
@@ -255,7 +223,7 @@
                                     </p>
                                     @if(! is_null($pointsToNext) && $userRank > 1)
                                         <p>Es fehlen dir
-                                            <span class="font-semibold text-gray-900 dark:text-gray-100">{{ $pointsToNext }} Baxx</span>
+                                            <span class="font-semibold text-gray-900 dark:text-gray-100">{{ number_format($pointsToNext, 0, ',', '.') }} Baxx</span>
                                             zu Platz #{{ $userRank - 1 }}.</p>
                                         @php
                                             $targetForNextRank = max($userTotalPoints + $pointsToNext, 1);
@@ -271,7 +239,7 @@
                                                     style="width: {{ $targetForNextRank > 0 ? min(100, round(($userTotalPoints / $targetForNextRank) * 100)) : 0 }}%"></div>
                                             </div>
                                             <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                                Ziel: {{ $targetForNextRank }} Baxx (Platz #{{ $userRank - 1 }})
+                                                Ziel: {{ number_format($targetForNextRank, 0, ',', '.') }} Baxx (Platz #{{ $userRank - 1 }})
                                             </p>
                                         </div>
                                     @else
@@ -286,7 +254,7 @@
                                                     style="width: {{ $weeklyProgress }}%"></div>
                                             </div>
                                             <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                                                Halte dein Wochenziel von {{ $weeklyTarget }} Baxx, um vorne zu bleiben.
+                                                Halte dein Wochenziel von {{ number_format($weeklyTarget, 0, ',', '.') }} Baxx, um vorne zu bleiben.
                                             </p>
                                         </div>
                                     @endif

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -206,47 +206,63 @@
                     </article>
                 </div>
             </section>
-            <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6" data-todo-filter-wrapper>
-                <form method="GET" action="{{ route('todos.index') }}" data-todo-filter-form
-                    data-current-filter="{{ $currentFilter }}">
-                    <fieldset>
-                        <legend class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-                            Challenges filtern
-                        </legend>
-                        <div class="flex flex-wrap gap-2" role="group" aria-label="Challenges filtern">
-                            <button type="submit" name="filter" value="" data-todo-filter data-filter="all"
-                                data-active="{{ $currentFilter === 'all' ? 'true' : 'false' }}"
-                                class="px-4 py-2 rounded-md border border-[#8B0116] text-[#8B0116] dark:text-[#FF6B81] dark:border-[#FF6B81] font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8B0116] dark:focus-visible:outline-[#FF6B81] data-[active=true]:bg-[#8B0116] data-[active=true]:text-white dark:data-[active=true]:bg-[#FF6B81] dark:data-[active=true]:text-gray-900">
-                                Alle
-                            </button>
-                            <button type="button" data-todo-filter data-filter="assigned" data-active="false"
-                                class="px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8B0116] dark:focus-visible:outline-[#FF6B81] data-[active=true]:bg-[#8B0116] data-[active=true]:text-white dark:data-[active=true]:bg-[#FF6B81] dark:data-[active=true]:text-gray-900">
-                                Eigene Challenges
-                            </button>
-                            <button type="button" data-todo-filter data-filter="open" data-active="false"
-                                class="px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8B0116] dark:focus-visible:outline-[#FF6B81] data-[active=true]:bg-[#8B0116] data-[active=true]:text-white dark:data-[active=true]:bg-[#FF6B81] dark:data-[active=true]:text-gray-900">
-                                Offene Challenges
-                            </button>
-                            @if($canVerifyTodos)
-                                <button type="submit" name="filter" value="pending" data-todo-filter data-filter="pending"
-                                    data-active="{{ $currentFilter === 'pending' ? 'true' : 'false' }}"
-                                    class="px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8B0116] dark:focus-visible:outline-[#FF6B81] data-[active=true]:bg-[#8B0116] data-[active=true]:text-white dark:data-[active=true]:bg-[#FF6B81] dark:data-[active=true]:text-gray-900">
-                                    Zu verifizieren
-                                </button>
-                            @endif
-                        </div>
+            <section class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6" data-todo-filter-wrapper>
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div class="space-y-1">
+                        <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">Challenges filtern</h2>
                         <p id="todo-filter-status" data-todo-filter-status role="status" aria-live="polite"
-                            class="mt-3 text-sm text-gray-600 dark:text-gray-400">
+                            class="text-sm text-gray-600 dark:text-gray-400">
                             {{ $currentFilter === 'pending' ? 'Zeigt Challenges, die auf eine Verifizierung warten.' : 'Zeigt alle verfügbaren Challenges.' }}
                         </p>
-                        <noscript>
-                            <p class="mt-3 text-xs text-gray-500 dark:text-gray-400">
-                                Für weitere Filteroptionen aktiviere JavaScript in deinem Browser.
-                            </p>
-                        </noscript>
-                    </fieldset>
-                </form>
-            </div>
+                    </div>
+                    <button type="button" data-todo-filter-toggle aria-expanded="false" aria-controls="todo-filter-panel"
+                        data-label-open="Filter anzeigen" data-label-close="Filter verbergen"
+                        class="inline-flex items-center gap-2 self-start rounded-md border border-[#8B0116] bg-white px-4 py-2 text-sm font-semibold text-[#8B0116] shadow-sm transition hover:bg-[#8B0116] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8B0116] dark:border-[#FF6B81] dark:bg-gray-900 dark:text-[#FF6B81] dark:hover:bg-[#FF6B81] dark:hover:text-gray-900 dark:focus-visible:outline-[#FF6B81]">
+                        <svg class="h-4 w-4" aria-hidden="true" fill="none" stroke="currentColor" stroke-linecap="round"
+                            stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24">
+                            <path d="M4 6h16M6 12h12M10 18h4" />
+                        </svg>
+                        <span data-todo-filter-toggle-text>Filter anzeigen</span>
+                    </button>
+                </div>
+                <div id="todo-filter-panel" data-todo-filter-panel
+                    class="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700">
+                    <form method="GET" action="{{ route('todos.index') }}" data-todo-filter-form
+                        data-current-filter="{{ $currentFilter }}">
+                        <fieldset class="space-y-4">
+                            <legend class="sr-only">Challenges filtern</legend>
+                            <div class="flex flex-wrap gap-2" role="group" aria-label="Challenges filtern">
+                                <button type="submit" name="filter" value="" data-todo-filter data-filter="all"
+                                    data-active="{{ $currentFilter === 'all' ? 'true' : 'false' }}"
+                                    class="px-4 py-2 rounded-md border border-[#8B0116] text-[#8B0116] dark:text-[#FF6B81] dark:border-[#FF6B81] font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8B0116] dark:focus-visible:outline-[#FF6B81] data-[active=true]:bg-[#8B0116] data-[active=true]:text-white dark:data-[active=true]:bg-[#FF6B81] dark:data-[active=true]:text-gray-900">
+                                    Alle
+                                </button>
+                                <button type="button" data-todo-filter data-filter="assigned" data-active="false"
+                                    class="px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8B0116] dark:focus-visible:outline-[#FF6B81] data-[active=true]:bg-[#8B0116] data-[active=true]:text-white dark:data-[active=true]:bg-[#FF6B81] dark:data-[active=true]:text-gray-900">
+                                    Eigene Challenges
+                                </button>
+                                <button type="button" data-todo-filter data-filter="open" data-active="false"
+                                    class="px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8B0116] dark:focus-visible:outline-[#FF6B81] data-[active=true]:bg-[#8B0116] data-[active=true]:text-white dark:data-[active=true]:bg-[#FF6B81] dark:data-[active=true]:text-gray-900">
+                                    Offene Challenges
+                                </button>
+                                @if($canVerifyTodos)
+                                    <button type="submit" name="filter" value="pending" data-todo-filter
+                                        data-filter="pending"
+                                        data-active="{{ $currentFilter === 'pending' ? 'true' : 'false' }}"
+                                        class="px-4 py-2 rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#8B0116] dark:focus-visible:outline-[#FF6B81] data-[active=true]:bg-[#8B0116] data-[active=true]:text-white dark:data-[active=true]:bg-[#FF6B81] dark:data-[active=true]:text-gray-900">
+                                        Zu verifizieren
+                                    </button>
+                                @endif
+                            </div>
+                            <noscript>
+                                <p class="text-xs text-gray-500 dark:text-gray-400">
+                                    Für weitere Filteroptionen aktiviere JavaScript in deinem Browser.
+                                </p>
+                            </noscript>
+                        </fieldset>
+                    </form>
+                </div>
+            </section>
             <!-- Deine Challenges -->
             <section data-todo-section="assigned" aria-labelledby="todo-assigned-heading"
                 class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -144,7 +144,9 @@ class TodoControllerTest extends TestCase
         $response->assertSeeText('Vereins-Dashboard');
         $response->assertSeeText('Vereinsdurchschnitt');
         $response->assertSeeText('So steht dein Verein aktuell da.');
+        $response->assertSeeText('Dein Punktestand');
         $response->assertDontSeeText('Teamdurchschnitt');
+        $response->assertDontSeeText('Deine Baxx');
     }
 
     public function test_assigned_user_can_release_todo(): void

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -133,6 +133,20 @@ class TodoControllerTest extends TestCase
         $this->assertNull($todo->verified_by);
     }
 
+    public function test_dashboard_copy_uses_club_language(): void
+    {
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $response = $this->get('/aufgaben');
+
+        $response->assertOk();
+        $response->assertSeeText('Vereins-Dashboard');
+        $response->assertSeeText('Vereinsdurchschnitt');
+        $response->assertSeeText('So steht dein Verein aktuell da.');
+        $response->assertDontSeeText('Teamdurchschnitt');
+    }
+
     public function test_assigned_user_can_release_todo(): void
     {
         $user = $this->actingMember();

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -163,6 +163,20 @@ class TodoControllerTest extends TestCase
         $response->assertDontSeeText('Aktivität der letzten 7 Tage');
     }
 
+    public function test_dashboard_displays_leaderboard_without_goal_card(): void
+    {
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $response = $this->get('/aufgaben');
+
+        $response->assertOk();
+        $response->assertDontSeeText('Dein nächstes Ziel');
+        $response->assertSeeInOrder(['Dein Punktestand', 'Rangliste']);
+        $response->assertSee('data-todo-dashboard', false);
+        $response->assertSee('xl:grid-cols-4', false);
+    }
+
     public function test_assigned_user_can_release_todo(): void
     {
         $user = $this->actingMember();

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -149,6 +149,20 @@ class TodoControllerTest extends TestCase
         $response->assertDontSeeText('Deine Baxx');
     }
 
+    public function test_dashboard_formats_large_numbers_and_hides_trend_card(): void
+    {
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $user->incrementTeamPoints(12345);
+
+        $response = $this->get('/aufgaben');
+
+        $response->assertOk();
+        $response->assertSeeText('12.345');
+        $response->assertDontSeeText('Aktivität der letzten 7 Tage');
+    }
+
     public function test_assigned_user_can_release_todo(): void
     {
         $user = $this->actingMember();

--- a/tests/Jest/todoDashboard.test.js
+++ b/tests/Jest/todoDashboard.test.js
@@ -41,4 +41,26 @@ describe('todo dashboard utilities', () => {
         expect(bar?.getAttribute('aria-valuenow')).toBe('0');
         expect(fill?.style.width).toBe('0%');
     });
+
+    test('guards against invalid numeric attributes when calculating progress', () => {
+        const originalIsFinite = Number.isFinite;
+        Number.isFinite = () => true;
+
+        document.body.innerHTML = `
+            <div data-progress-bar data-progress-value="foo" data-progress-max="bar">
+                <div data-progress-fill></div>
+            </div>
+        `;
+
+        try {
+            initTodoDashboard(document);
+        } finally {
+            Number.isFinite = originalIsFinite;
+        }
+
+        const fill = document.querySelector('[data-progress-fill]');
+
+        expect(fill?.style.width).toBe('0%');
+        expect(fill?.style.getPropertyValue('--progress-percent')).toBe('0');
+    });
 });

--- a/tests/Jest/todoDashboard.test.js
+++ b/tests/Jest/todoDashboard.test.js
@@ -37,7 +37,7 @@ describe('todo dashboard utilities', () => {
         const bar = document.querySelector('[data-progress-bar]');
         const fill = document.querySelector('[data-progress-fill]');
 
-        expect(bar?.getAttribute('aria-valuemax')).toBe('10');
+        expect(bar?.getAttribute('aria-valuemax')).toBe('1');
         expect(bar?.getAttribute('aria-valuenow')).toBe('0');
         expect(fill?.style.width).toBe('0%');
     });

--- a/tests/Jest/todoDashboard.test.js
+++ b/tests/Jest/todoDashboard.test.js
@@ -1,0 +1,44 @@
+import { initTodoDashboard } from '../../resources/js/utils/dashboard';
+
+describe('todo dashboard utilities', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    test('initialises progress bars with accessible attributes', () => {
+        document.body.innerHTML = `
+            <div data-progress-bar data-progress-value="25" data-progress-max="50" data-progress-label="Wochenziel">
+                <div data-progress-fill style="width: 0"></div>
+            </div>
+        `;
+
+        initTodoDashboard(document);
+
+        const bar = document.querySelector('[data-progress-bar]');
+        const fill = document.querySelector('[data-progress-fill]');
+
+        expect(bar?.getAttribute('role')).toBe('progressbar');
+        expect(bar?.getAttribute('aria-valuemin')).toBe('0');
+        expect(bar?.getAttribute('aria-valuemax')).toBe('50');
+        expect(bar?.getAttribute('aria-valuenow')).toBe('25');
+        expect(bar?.getAttribute('aria-label')).toBe('Wochenziel');
+        expect(fill?.style.width).toBe('50%');
+    });
+
+    test('falls back to sane defaults when values are missing', () => {
+        document.body.innerHTML = `
+            <div data-progress-bar data-progress-value="-10">
+                <div data-progress-fill></div>
+            </div>
+        `;
+
+        initTodoDashboard(document);
+
+        const bar = document.querySelector('[data-progress-bar]');
+        const fill = document.querySelector('[data-progress-fill]');
+
+        expect(bar?.getAttribute('aria-valuemax')).toBe('10');
+        expect(bar?.getAttribute('aria-valuenow')).toBe('0');
+        expect(fill?.style.width).toBe('0%');
+    });
+});

--- a/tests/Jest/todoFilters.test.js
+++ b/tests/Jest/todoFilters.test.js
@@ -62,19 +62,28 @@ describe('todoFilters utilities', () => {
 
     test('initTodoFilters wires listeners and updates status message', () => {
         document.body.innerHTML = `
-            <div>
-                <form data-todo-filter-form data-current-filter="all">
-                    <div>
-                        <button type="button" data-todo-filter data-filter="assigned" data-active="false"></button>
-                        <button type="button" data-todo-filter data-filter="open" data-active="false"></button>
-                        <button type="submit" data-todo-filter data-filter="pending" data-active="false"></button>
-                    </div>
+            <section data-todo-filter-wrapper>
+                <div>
                     <p data-todo-filter-status></p>
-                </form>
-                <section data-todo-section="assigned"></section>
-                <section data-todo-section="open"></section>
-                <section data-todo-section="pending"></section>
-            </div>
+                    <button type="button" data-todo-filter-toggle aria-expanded="false"
+                        aria-controls="todo-panel" data-label-open="Filter anzeigen"
+                        data-label-close="Filter verbergen">
+                        <span data-todo-filter-toggle-text>Filter anzeigen</span>
+                    </button>
+                </div>
+                <div id="todo-panel" data-todo-filter-panel>
+                    <form data-todo-filter-form data-current-filter="all">
+                        <div>
+                            <button type="button" data-todo-filter data-filter="assigned" data-active="false"></button>
+                            <button type="button" data-todo-filter data-filter="open" data-active="false"></button>
+                            <button type="submit" data-todo-filter data-filter="pending" data-active="false"></button>
+                        </div>
+                    </form>
+                </div>
+                <div data-todo-section="assigned"></div>
+                <div data-todo-section="open"></div>
+                <div data-todo-section="pending"></div>
+            </section>
         `;
 
         const statusElement = document.querySelector('[data-todo-filter-status]');
@@ -94,6 +103,50 @@ describe('todoFilters utilities', () => {
         const pendingButton = document.querySelector('[data-filter="pending"]');
         pendingButton.dispatchEvent(new Event('click', { bubbles: true }));
         expect(statusElement.textContent).toContain('Verifizierung warten');
+    });
+
+    test('initTodoFilters toggles the disclosure panel and focuses the first control', () => {
+        document.body.innerHTML = `
+            <section data-todo-filter-wrapper>
+                <button type="button" data-todo-filter-toggle aria-expanded="false" aria-controls="filters"
+                    data-label-open="Filter anzeigen" data-label-close="Filter verbergen">
+                    <span data-todo-filter-toggle-text>Filter anzeigen</span>
+                </button>
+                <div id="filters" data-todo-filter-panel>
+                    <form data-todo-filter-form data-current-filter="all">
+                        <div>
+                            <button type="button" data-todo-filter data-filter="all" data-active="true"></button>
+                            <button type="button" data-todo-filter data-filter="open" data-active="false"></button>
+                        </div>
+                    </form>
+                </div>
+            </section>
+        `;
+
+        const toggle = document.querySelector('[data-todo-filter-toggle]');
+        const panel = document.querySelector('[data-todo-filter-panel]');
+        const firstButton = panel.querySelector('[data-filter="all"]');
+
+        initTodoFilters(document);
+
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(panel.hasAttribute('hidden')).toBe(true);
+        expect(panel.getAttribute('aria-hidden')).toBe('true');
+        expect(toggle.textContent).toContain('Filter anzeigen');
+
+        toggle.dispatchEvent(new Event('click'));
+
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+        expect(panel.hasAttribute('hidden')).toBe(false);
+        expect(panel.getAttribute('aria-hidden')).toBe('false');
+        expect(toggle.textContent).toContain('Filter verbergen');
+        expect(document.activeElement).toBe(firstButton);
+
+        toggle.dispatchEvent(new Event('click'));
+
+        expect(toggle.getAttribute('aria-expanded')).toBe('false');
+        expect(panel.hasAttribute('hidden')).toBe(true);
+        expect(toggle.textContent).toContain('Filter anzeigen');
     });
 
     test('applyFilterState returns the active filter', () => {
@@ -154,15 +207,17 @@ describe('todoFilters utilities', () => {
         initTodoFilters({});
 
         document.body.innerHTML = `
-            <div>
-                <form data-todo-filter-form data-current-filter="open">
-                    <button type="button" data-todo-filter data-filter="open" data-active="true"></button>
-                    <button type="button" data-todo-filter data-filter="assigned" data-active="false"></button>
-                    <p data-todo-filter-status></p>
-                </form>
-                <section data-todo-section="open"></section>
-                <section data-todo-section="assigned"></section>
-            </div>
+            <section data-todo-filter-wrapper>
+                <p data-todo-filter-status></p>
+                <div data-todo-filter-panel>
+                    <form data-todo-filter-form data-current-filter="open">
+                        <button type="button" data-todo-filter data-filter="open" data-active="true"></button>
+                        <button type="button" data-todo-filter data-filter="assigned" data-active="false"></button>
+                    </form>
+                </div>
+                <div data-todo-section="open"></div>
+                <div data-todo-section="assigned"></div>
+            </section>
         `;
 
         initTodoFilters(document);

--- a/tests/Unit/TeamPointServiceTest.php
+++ b/tests/Unit/TeamPointServiceTest.php
@@ -137,6 +137,7 @@ class TeamPointServiceTest extends TestCase
         $this->assertSame($user->name, $highlight['name']);
         $this->assertTrue($highlight['is_additional'] ?? false);
         $this->assertSame(5, $highlight['points']);
+        $this->assertSame(4, $highlight['rank']);
     }
 }
 

--- a/tests/Unit/TeamPointServiceTest.php
+++ b/tests/Unit/TeamPointServiceTest.php
@@ -5,7 +5,9 @@ namespace Tests\Unit;
 use App\Enums\Role;
 use App\Models\Team;
 use App\Models\User;
+use App\Models\UserPoint;
 use App\Services\TeamPointService;
+use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -15,22 +17,40 @@ class TeamPointServiceTest extends TestCase
     use RefreshDatabase;
 
     private TeamPointService $service;
+    private Team $team;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->service = new TeamPointService();
+        $this->team = Team::membersTeam();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
     }
 
     private function memberWithPoints(int $points = 0): User
     {
-        $team = Team::membersTeam();
-        $user = User::factory()->create(['current_team_id' => $team->id]);
-        $team->users()->attach($user, ['role' => Role::Mitglied->value]);
+        $user = User::factory()->create(['current_team_id' => $this->team->id]);
+        $this->team->users()->attach($user, ['role' => Role::Mitglied->value]);
         if ($points > 0) {
-            $user->incrementTeamPoints($points);
+            $this->addPoints($user, $points, Carbon::now());
         }
         return $user;
+    }
+
+    private function addPoints(User $user, int $points, Carbon $createdAt): void
+    {
+        UserPoint::create([
+            'user_id' => $user->id,
+            'team_id' => $this->team->id,
+            'points' => $points,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ]);
     }
 
     public function test_get_user_points_returns_team_points(): void
@@ -53,6 +73,70 @@ class TeamPointServiceTest extends TestCase
         $this->actingAs($user);
         $this->expectException(AuthorizationException::class);
         $this->service->assertMinPoints(5);
+    }
+
+    public function test_get_user_point_trend_returns_last_seven_days(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 1, 10, 12));
+        $user = $this->memberWithPoints();
+
+        $this->addPoints($user, 5, Carbon::now()->subDays(1));
+        $this->addPoints($user, 3, Carbon::now()->subDays(3));
+
+        $trend = $this->service->getUserPointTrend($user, $this->team);
+
+        $this->assertCount(7, $trend);
+        $trendByDate = collect($trend)->keyBy('date');
+        $this->assertSame(5, $trendByDate[Carbon::now()->subDays(1)->toDateString()]['points']);
+        $this->assertSame(3, $trendByDate[Carbon::now()->subDays(3)->toDateString()]['points']);
+        $this->assertSame(0, $trendByDate[Carbon::now()->subDays(2)->toDateString()]['points']);
+    }
+
+    public function test_dashboard_metrics_calculates_team_average_and_progress(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 1, 10, 12));
+
+        $user = $this->memberWithPoints();
+        $otherOne = $this->memberWithPoints();
+        $otherTwo = $this->memberWithPoints();
+
+        $this->addPoints($user, 12, Carbon::now());
+        $this->addPoints($otherOne, 18, Carbon::now());
+        // $otherTwo intentionally keeps zero points to check averaging with non-contributors.
+
+        $metrics = $this->service->getDashboardMetrics($user, $this->team);
+
+        $this->assertSame(10.0, $metrics['team_average']);
+        $this->assertSame(100, $metrics['team_average_progress']);
+        $this->assertSame(12, $metrics['weekly']['total']);
+        $this->assertSame(24, $metrics['weekly']['progress']);
+    }
+
+    public function test_dashboard_metrics_exposes_leaderboard_and_rank_gap(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 1, 10, 12));
+
+        $user = $this->memberWithPoints();
+        $leader = $this->memberWithPoints();
+        $second = $this->memberWithPoints();
+        $third = $this->memberWithPoints();
+
+        $this->addPoints($leader, 60, Carbon::now());
+        $this->addPoints($second, 40, Carbon::now());
+        $this->addPoints($third, 20, Carbon::now());
+        $this->addPoints($user, 5, Carbon::now());
+
+        $metrics = $this->service->getDashboardMetrics($user, $this->team);
+
+        $this->assertSame(4, $metrics['user_rank']);
+        $this->assertSame(15, $metrics['points_to_next_rank']);
+        $this->assertSame(20, $metrics['next_rank_points']);
+
+        $highlight = collect($metrics['leaderboard'])->firstWhere('is_current_user');
+        $this->assertNotNull($highlight);
+        $this->assertSame($user->name, $highlight['name']);
+        $this->assertTrue($highlight['is_additional'] ?? false);
+        $this->assertSame(5, $highlight['points']);
     }
 }
 


### PR DESCRIPTION
This pull request introduces a significant upgrade to the team points dashboard for todos, both on the backend and frontend. The main focus is on centralizing and expanding the calculation of user and team metrics, providing richer data for the dashboard, and improving the user interface for progress visualization and filter controls.

**Backend: Enhanced Dashboard Metrics and Leaderboard Calculations**

* Added a comprehensive `getDashboardMetrics` method in `TeamPointService` to aggregate user points, trends, weekly progress, team averages, and leaderboard data for the dashboard.
* Refactored the `TodoController@index` to use the new `getDashboardMetrics` method, passing richer metrics to the view and updating variable usage accordingly. [[1]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L66-R66) [[2]](diffhunk://#diff-c38e575280103245323a4245abc9ee00de86ac5c21706df5c2607293271876d5L75-R80)
* Introduced helper methods in `TeamPointService` for calculating trends, weekly targets, team averages, progress percentages, leaderboard data, and user rank resolution.
* Improved imports and type annotations in `TeamPointService` to support new functionality.

**Frontend: Dashboard Interactivity and Filter Panel Improvements**

* Added a new `initTodoDashboard` utility (`resources/js/utils/dashboard.js`) to handle progress bar rendering and accessibility for dashboard metrics. [[1]](diffhunk://#diff-2daa6a857eaf30ff12b18f0b4accd9378395d5dade0da4f20786095b5a107c8aR1-R41) [[2]](diffhunk://#diff-5f38504959903bc576364978d6298892df7261edb1c301e9ed6554225655b8c8R2-R6)
* Enhanced the todo filter panel with toggle functionality, improved accessibility, and better focus management when opening the panel (`resources/js/utils/todoFilters.js`). [[1]](diffhunk://#diff-d75d11a6d70437360c5b5b7b38915cdf017f5752361a3d8c1cab2f19d9b560eeR83-R121) [[2]](diffhunk://#diff-d75d11a6d70437360c5b5b7b38915cdf017f5752361a3d8c1cab2f19d9b560eeL101-R143) [[3]](diffhunk://#diff-d75d11a6d70437360c5b5b7b38915cdf017f5752361a3d8c1cab2f19d9b560eeR153-R174)

**UI/UX: Dashboard Header Update**

* Updated the dashboard header in `todos/index.blade.php` to introduce a clearer title, subtitle, and improved layout for presenting user points and challenges.