### PR TITLE
Add comprehensive dashboard test coverage and accessibility support

### DIFF
--- a/database/seeders/DashboardSampleSeeder.php
+++ b/database/seeders/DashboardSampleSeeder.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\Role;
+use App\Enums\TodoStatus;
+use App\Models\Activity;
+use App\Models\BookOffer;
+use App\Models\BookRequest;
+use App\Models\BookSwap;
+use App\Models\Team;
+use App\Models\Todo;
+use App\Models\User;
+use App\Models\UserPoint;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Hash;
+
+class DashboardSampleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $team = Team::membersTeam();
+
+        if (! $team) {
+            return;
+        }
+
+        $admin = User::firstWhere('email', 'info@maddraxikon.com');
+
+        if (! $admin) {
+            $admin = User::withoutEvents(function () use ($team) {
+                $user = User::create([
+                    'name' => 'Holger Ehrmann',
+                    'email' => 'info@maddraxikon.com',
+                    'email_verified_at' => now(),
+                    'password' => Hash::make('password'),
+                    'vorname' => 'Holger',
+                    'nachname' => 'Ehrmann',
+                    'strasse' => 'Musterstraße',
+                    'hausnummer' => '123',
+                    'plz' => '12345',
+                    'stadt' => 'Musterstadt',
+                    'land' => 'Deutschland',
+                    'telefon' => '0123456789',
+                    'verein_gefunden' => 'Sonstiges',
+                    'mitgliedsbeitrag' => 36.00,
+                ]);
+
+                return $user;
+            });
+
+            $team->users()->attach($admin, ['role' => Role::Admin->value]);
+        }
+
+        if ($admin->current_team_id !== $team->id) {
+            $admin->forceFill(['current_team_id' => $team->id])->save();
+        }
+
+        $members = collect([
+            ['name' => 'Alex Beispiel', 'email' => 'alex.beispiel@example.com', 'points' => 180],
+            ['name' => 'Bianca Beispiel', 'email' => 'bianca.beispiel@example.com', 'points' => 140],
+            ['name' => 'Chris Beispiel', 'email' => 'chris.beispiel@example.com', 'points' => 95],
+        ])->map(function (array $attributes) use ($team) {
+            $user = User::firstOrCreate(
+                ['email' => $attributes['email']],
+                [
+                    'name' => $attributes['name'],
+                    'email_verified_at' => now(),
+                    'password' => Hash::make('password'),
+                    'vorname' => Arr::get(explode(' ', $attributes['name']), 0, 'Vorname'),
+                    'nachname' => Arr::get(explode(' ', $attributes['name']), 1, 'Nachname'),
+                    'strasse' => 'Musterstraße',
+                    'hausnummer' => '1',
+                    'plz' => '12345',
+                    'stadt' => 'Musterstadt',
+                    'land' => 'Deutschland',
+                    'telefon' => '0123456789',
+                    'verein_gefunden' => 'Sonstiges',
+                    'mitgliedsbeitrag' => 36.00,
+                ]
+            );
+
+            $user->forceFill(['current_team_id' => $team->id])->save();
+
+            $team->users()->syncWithoutDetaching([$user->id => ['role' => Role::Mitglied->value]]);
+
+            return [$user, $attributes['points']];
+        });
+
+        foreach ($members as [$member, $points]) {
+            UserPoint::updateOrCreate([
+                'user_id' => $member->id,
+                'team_id' => $team->id,
+            ], [
+                'points' => $points,
+            ]);
+        }
+
+        UserPoint::updateOrCreate([
+            'user_id' => $admin->id,
+            'team_id' => $team->id,
+        ], [
+            'points' => 120,
+        ]);
+
+        $team->users()->syncWithoutDetaching([$admin->id => ['role' => Role::Admin->value]]);
+
+        Todo::firstOrCreate([
+            'team_id' => $team->id,
+            'title' => 'Dashboard Sichtung',
+        ], [
+            'created_by' => $admin->id,
+            'assigned_to' => $admin->id,
+            'description' => 'Überprüfe die neuen Dashboard-Kennzahlen.',
+            'points' => 15,
+            'status' => TodoStatus::Assigned->value,
+        ]);
+
+        Todo::firstOrCreate([
+            'team_id' => $team->id,
+            'title' => 'Dashboard Verifizierung',
+        ], [
+            'created_by' => $admin->id,
+            'assigned_to' => $admin->id,
+            'description' => 'Diese Aufgabe wartet auf Verifizierung.',
+            'points' => 20,
+            'status' => TodoStatus::Completed->value,
+        ]);
+
+        $offer = BookOffer::firstOrCreate([
+            'user_id' => $admin->id,
+            'series' => 'Maddrax',
+            'book_number' => 1,
+        ], [
+            'book_title' => 'Maddrax Sammelband 1',
+            'condition' => 'neuwertig',
+            'completed' => false,
+        ]);
+
+        $requestUser = $members->first()[0] ?? $admin;
+
+        $request = BookRequest::firstOrCreate([
+            'user_id' => $requestUser->id,
+            'series' => 'Maddrax',
+            'book_number' => 1,
+        ], [
+            'book_title' => 'Maddrax Sammelband 1',
+            'condition' => 'gut',
+            'completed' => false,
+        ]);
+
+        BookSwap::firstOrCreate([
+            'offer_id' => $offer->id,
+            'request_id' => $request->id,
+        ]);
+
+        $applicant = User::firstOrCreate([
+            'email' => 'anwaerter-dashboard@example.com',
+        ], [
+            'name' => 'Playwright Anwärter',
+            'email_verified_at' => now(),
+            'password' => Hash::make('password'),
+            'vorname' => 'Playwright',
+            'nachname' => 'Anwärter',
+            'strasse' => 'Beispielweg',
+            'hausnummer' => '42',
+            'plz' => '54321',
+            'stadt' => 'Teststadt',
+            'land' => 'Deutschland',
+            'telefon' => '0987654321',
+            'verein_gefunden' => 'Sonstiges',
+            'mitgliedsbeitrag' => 36.00,
+        ]);
+
+        $team->users()->syncWithoutDetaching([
+            $applicant->id => ['role' => Role::Anwaerter->value],
+        ]);
+
+        Activity::firstOrCreate([
+            'user_id' => $admin->id,
+            'subject_type' => BookOffer::class,
+            'subject_id' => $offer->id,
+            'action' => 'created_offer',
+        ]);
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -83,3 +83,4 @@ window.L = L;
 import './chronik';
 import './char-editor';
 import './todos';
+import './dashboard';

--- a/resources/js/dashboard.js
+++ b/resources/js/dashboard.js
@@ -1,0 +1,5 @@
+import { setupDashboardAccessibility } from './dashboard/accessibility';
+
+document.addEventListener('DOMContentLoaded', () => {
+    setupDashboardAccessibility();
+});

--- a/resources/js/dashboard/accessibility.js
+++ b/resources/js/dashboard/accessibility.js
@@ -1,0 +1,80 @@
+const sanitizeTopUsers = (raw) => {
+    if (!raw) {
+        return [];
+    }
+
+    if (Array.isArray(raw)) {
+        return raw;
+    }
+
+    try {
+        const parsed = JSON.parse(raw);
+
+        return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+        return [];
+    }
+};
+
+export const buildTopUserSummary = (users) => {
+    const normalized = sanitizeTopUsers(users)
+        .filter((user) => user && typeof user.name === 'string')
+        .map((user, index) => ({
+            position: index + 1,
+            name: user.name.trim(),
+            points: Number.parseInt(user.points ?? 0, 10) || 0,
+        }));
+
+    if (normalized.length === 0) {
+        return '';
+    }
+
+    const header = `Top ${normalized.length} Baxx-Sammler: `;
+    const items = normalized
+        .map((user) => `${user.position}. ${user.name} (${user.points} Baxx)`)
+        .join(', ');
+
+    return `${header}${items}`;
+};
+
+export const enhanceTopUserList = (container, users = undefined) => {
+    if (!container) {
+        return '';
+    }
+
+    const summary = buildTopUserSummary(users ?? container.dataset.dashboardTopUsers ?? []);
+
+    if (!summary) {
+        container.removeAttribute('aria-label');
+        return '';
+    }
+
+    if (!container.hasAttribute('role')) {
+        container.setAttribute('role', 'list');
+    }
+
+    container.setAttribute('aria-label', summary);
+
+    const summaryTarget = container.querySelector('[data-dashboard-top-summary]');
+    if (summaryTarget) {
+        summaryTarget.textContent = summary;
+    }
+
+    container
+        .querySelectorAll('[data-dashboard-top-user-item]')
+        .forEach((item) => {
+            if (!item.hasAttribute('role')) {
+                item.setAttribute('role', 'listitem');
+            }
+        });
+
+    return summary;
+};
+
+export const setupDashboardAccessibility = (root = document) => {
+    const containers = Array.from(root.querySelectorAll('[data-dashboard-top-users]'));
+
+    containers.forEach((container) => {
+        enhanceTopUserList(container);
+    });
+};

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -186,11 +186,37 @@
             <!-- TOP 3 Mitglieder -->
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-8">
                 <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-6">TOP 3 Baxx-Sammler</h2>
-                
-                @if(count($topUsers) > 0)
-                    <div class="flex flex-col md:flex-row items-center md:items-start justify-center gap-6 md:gap-10">
-                        @foreach($topUsers as $index => $topUser)
-                            <a href="{{ route('profile.view', $topUser['id']) }}" class="flex flex-col items-center group">
+
+                @php
+                    $topUsersCollection = collect($topUsers)->values();
+                    $topUsersSummary = $topUsersCollection->isNotEmpty()
+                        ? 'Top ' . $topUsersCollection->count() . ' Baxx-Sammler: '
+                            . $topUsersCollection->map(function ($user, $index) {
+                                $position = $index + 1;
+                                $points = number_format((int) $user['points'], 0, ',', '.');
+
+                                return $position . '. ' . $user['name'] . ' (' . $points . ' Baxx)';
+                            })->implode(', ')
+                        : null;
+                    $topUsersPayload = $topUsersCollection->map(function ($user) {
+                        return [
+                            'id' => $user['id'],
+                            'name' => $user['name'],
+                            'points' => (int) $user['points'],
+                        ];
+                    })->toArray();
+                @endphp
+
+                @if($topUsersCollection->isNotEmpty())
+                    <div
+                        class="flex flex-col md:flex-row items-center md:items-start justify-center gap-6 md:gap-10"
+                        data-dashboard-top-users='{{ json_encode($topUsersPayload, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE) }}'
+                        role="list"
+                        aria-label="{{ $topUsersSummary }}"
+                    >
+                        <p class="sr-only" data-dashboard-top-summary aria-live="polite">{{ $topUsersSummary }}</p>
+                        @foreach($topUsersCollection as $index => $topUser)
+                            <a href="{{ route('profile.view', $topUser['id']) }}" class="flex flex-col items-center group" data-dashboard-top-user-item role="listitem">
                                 @if($index === 0)
                                     <!-- Gold Medaille für Platz 1 -->
                                     <div class="relative mb-2">

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -3,15 +3,44 @@
 namespace Tests\Feature;
 
 use App\Enums\Role;
+use App\Enums\TodoStatus;
 use App\Models\Team;
+use App\Models\Todo;
 use App\Models\User;
+use App\Models\UserPoint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\DomCrawler\Crawler;
 use Tests\TestCase;
 
 class DashboardTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    private function createUserWithRole(Role $role): User
+    {
+        $team = Team::membersTeam();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => $role->value]);
+
+        return $user;
+    }
+
+    public static function privilegedRoleProvider(): array
+    {
+        return [
+            'admin' => [Role::Admin],
+            'vorstand' => [Role::Vorstand],
+            'kassenwart' => [Role::Kassenwart],
+        ];
+    }
 
     public function test_dashboard_renders_cards_with_screenreader_texts(): void
     {
@@ -49,5 +78,114 @@ class DashboardTest extends TestCase
             $this->assertEquals($headingId, $card->attr('aria-labelledby'));
             $this->assertGreaterThan(0, $card->filter('.sr-only')->count());
         }
+    }
+
+    #[DataProvider('privilegedRoleProvider')]
+    public function test_dashboard_shows_applicants_for_privileged_roles(Role $role): void
+    {
+        $team = Team::membersTeam();
+        $user = $this->createUserWithRole($role);
+        $applicant = User::factory()->create();
+        $team->users()->attach($applicant, ['role' => Role::Anwaerter->value]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertOk();
+        $response->assertSeeText('Mitgliedsanträge');
+        $response->assertSeeText($applicant->name);
+
+        $crawler = new Crawler($response->getContent());
+        $table = $crawler->filter('table');
+        $this->assertGreaterThan(0, $table->count());
+        $this->assertSame('Name', trim($table->first()->filter('th')->eq(0)->text()));
+        $this->assertSame('Genehmigen', trim($table->first()->filter('button')->eq(0)->text()));
+    }
+
+    public function test_dashboard_hides_applicants_for_regular_members(): void
+    {
+        $team = Team::membersTeam();
+        $user = $this->createUserWithRole(Role::Mitglied);
+        $applicant = User::factory()->create();
+        $team->users()->attach($applicant, ['role' => Role::Anwaerter->value]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertOk();
+        $response->assertDontSee('Mitgliedsanträge');
+        $response->assertDontSee($applicant->name);
+    }
+
+    #[DataProvider('privilegedRoleProvider')]
+    public function test_dashboard_shows_pending_verification_card(Role $role): void
+    {
+        $user = $this->createUserWithRole($role);
+        $team = Team::membersTeam();
+
+        Todo::create([
+            'team_id' => $team->id,
+            'created_by' => $user->id,
+            'assigned_to' => $user->id,
+            'title' => 'Abschließen',
+            'description' => 'Wartet auf Verifizierung',
+            'points' => 5,
+            'status' => TodoStatus::Completed,
+        ]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertOk();
+        $response->assertSeeText('Auf Verifizierung wartende Challenges');
+        $response->assertSeeText('Challenge(s)');
+    }
+
+    public function test_dashboard_hides_pending_verification_card_for_members(): void
+    {
+        $user = $this->createUserWithRole(Role::Mitglied);
+        $team = Team::membersTeam();
+
+        Todo::create([
+            'team_id' => $team->id,
+            'created_by' => $user->id,
+            'assigned_to' => $user->id,
+            'title' => 'Verifizierung wartet',
+            'description' => 'Soll nicht sichtbar sein',
+            'points' => 5,
+            'status' => TodoStatus::Completed,
+        ]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertOk();
+        $response->assertDontSee('Auf Verifizierung wartende Challenges');
+    }
+
+    public function test_dashboard_displays_top_user_summary(): void
+    {
+        $user = $this->createUserWithRole(Role::Admin);
+        $team = Team::membersTeam();
+
+        $topUsers = User::factory()->count(3)->create(['current_team_id' => $team->id]);
+
+        foreach ($topUsers as $index => $topUser) {
+            $team->users()->attach($topUser, ['role' => Role::Mitglied->value]);
+            UserPoint::create([
+                'user_id' => $topUser->id,
+                'team_id' => $team->id,
+                'points' => 100 - ($index * 10),
+            ]);
+        }
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertOk();
+
+        $crawler = new Crawler($response->getContent());
+        $topList = $crawler->filter('[data-dashboard-top-users]');
+        $this->assertSame(1, $topList->count());
+        $this->assertStringContainsString('Top 3 Baxx-Sammler', $topList->attr('aria-label'));
+        $this->assertSame(3, $topList->filter('[data-dashboard-top-user-item]')->count());
+        $srSummary = $topList->filter('[data-dashboard-top-summary]');
+        $this->assertSame(1, $srSummary->count());
+        $this->assertStringContainsString('Top 3 Baxx-Sammler', trim($srSummary->text()));
     }
 }

--- a/tests/Vitest/dashboard-accessibility.test.js
+++ b/tests/Vitest/dashboard-accessibility.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { buildTopUserSummary, enhanceTopUserList, setupDashboardAccessibility } from '@/js/dashboard/accessibility';
+
+describe('dashboard accessibility utilities', () => {
+  const sampleUsers = [
+    { name: 'Alex Beispiel', points: 180 },
+    { name: 'Bianca Beispiel', points: 140 },
+    { name: 'Chris Beispiel', points: 95 },
+  ];
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('builds a readable summary for top users', () => {
+    const summary = buildTopUserSummary(sampleUsers);
+
+    expect(summary).toBe('Top 3 Baxx-Sammler: 1. Alex Beispiel (180 Baxx), 2. Bianca Beispiel (140 Baxx), 3. Chris Beispiel (95 Baxx)');
+  });
+
+  it('enhances the top user list with aria attributes and summary text', () => {
+    const container = document.createElement('div');
+    container.dataset.dashboardTopUsers = JSON.stringify(sampleUsers);
+    container.innerHTML = `
+      <span data-dashboard-top-summary></span>
+      <a data-dashboard-top-user-item></a>
+      <a data-dashboard-top-user-item></a>
+      <a data-dashboard-top-user-item></a>
+    `;
+
+    const summary = enhanceTopUserList(container);
+
+    expect(summary).toContain('Top 3 Baxx-Sammler');
+    expect(container.getAttribute('role')).toBe('list');
+    expect(container.getAttribute('aria-label')).toBe(summary);
+    container.querySelectorAll('[data-dashboard-top-user-item]').forEach((item) => {
+      expect(item.getAttribute('role')).toBe('listitem');
+    });
+    expect(container.querySelector('[data-dashboard-top-summary]').textContent).toBe(summary);
+  });
+
+  it('ignores containers with invalid data without throwing', () => {
+    const container = document.createElement('div');
+    container.dataset.dashboardTopUsers = 'not-json';
+    document.body.appendChild(container);
+
+    expect(() => setupDashboardAccessibility(document)).not.toThrow();
+    expect(container.hasAttribute('aria-label')).toBe(false);
+  });
+});

--- a/tests/e2e/dashboard.spec.js
+++ b/tests/e2e/dashboard.spec.js
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+const login = async (page, email, password = 'password') => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', email);
+    await page.fill('input[name="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((url) => !url.pathname.endsWith('/login'));
+};
+
+test.describe('Dashboard overview', () => {
+    test('admin sees dashboard insights, applicants and verification card', async ({ page }) => {
+        await login(page, 'info@maddraxikon.com');
+
+        await page.goto('/dashboard');
+
+        await expect(page).toHaveURL(/\/dashboard$/);
+        const cards = page.locator('div[aria-label="Überblick wichtiger Community-Kennzahlen"] [role="region"]');
+        await expect(cards).toHaveCount(6);
+
+        await expect(page.getByRole('heading', { name: 'Mitgliedsanträge' })).toBeVisible();
+        await expect(page.getByRole('row', { name: /Playwright Anwärter/i })).toBeVisible();
+        await expect(page.getByRole('link', { name: /Auf Verifizierung wartende Challenges/i })).toBeVisible();
+
+        const topUsers = page.locator('[data-dashboard-top-users]');
+        await expect(topUsers).toBeVisible();
+        await expect(topUsers).toHaveAttribute('aria-label', /Top 3 Baxx-Sammler/i);
+        await expect(topUsers.locator('[data-dashboard-top-summary]')).toContainText(/Top 3 Baxx-Sammler/i);
+    });
+
+    test('member sees dashboard without applicant management', async ({ page }) => {
+        await login(page, 'playwright-member@example.com');
+
+        await page.goto('/dashboard');
+
+        await expect(page.getByRole('heading', { name: 'Mitgliedsanträge' })).toHaveCount(0);
+        await expect(page.getByRole('link', { name: /Auf Verifizierung wartende Challenges/i })).toHaveCount(0);
+
+        const cards = page.locator('div[aria-label="Überblick wichtiger Community-Kennzahlen"] [role="region"]');
+        await expect(cards).toHaveCount(6);
+        await expect(page.locator('[data-dashboard-top-summary]')).toContainText(/Top 3 Baxx-Sammler/i);
+    });
+});

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -29,4 +29,5 @@ export default async function globalSetup() {
     await runArtisan('migrate:fresh');
     await runArtisan('db:seed --class="Database\\\\Seeders\\\\TodoCategorySeeder"');
     await runArtisan('db:seed --class="Database\\\\Seeders\\\\TodoPlaywrightSeeder"');
+    await runArtisan('db:seed --class="Database\\\\Seeders\\\\DashboardSampleSeeder"');
 }


### PR DESCRIPTION
## Summary
- enrich the dashboard top user section with an accessible summary and screen reader context
- introduce dashboard accessibility utilities with Vitest coverage and Playwright scenarios for admin and member flows
- add Laravel feature coverage for applicant tables, verification cards, and top user summaries plus a Playwright seeder for consistent data

## Testing
- php artisan test
- npm run test:vitest
- npm run test:e2e *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf898a4908832eb408e77cbaae3615