### PR TITLE
Add weekday activity chart to admin statistics

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -113,12 +113,25 @@ class AdminController extends Controller
             $activityData['all'][$hour] = $sum / 7;
         }
 
+        $activityTimeline = collect(range(0, 6))
+            ->flatMap(function (int $day) use ($activityData) {
+                return collect(range(0, 23))->map(function (int $hour) use ($activityData, $day) {
+                    return [
+                        'weekday' => $day,
+                        'hour' => $hour,
+                        'total' => $activityData[$day][$hour] ?? 0,
+                    ];
+                });
+            })
+            ->values();
+
         $browserUsage = $this->browserStatsService->browserUsage();
 
         return view('admin.index', [
             'visitData' => $visitData,
             'userVisitData' => $userVisitData,
             'activityData' => $activityData,
+            'activityTimeline' => $activityTimeline,
             'homepageVisits' => $homepageVisits,
             'browserUsageByBrowser' => $browserUsage['browserCounts'],
             'browserUsageByFamily' => $browserUsage['familyCounts'],

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -212,6 +212,29 @@
                 ></canvas>
             </div>
         </section>
+
+        <section
+            class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6 mt-8"
+            aria-labelledby="active-users-weekday-heading"
+            aria-describedby="active-users-weekday-description"
+        >
+            <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-2 mb-4">
+                <h2 id="active-users-weekday-heading" class="font-semibold text-lg text-[#8B0116] dark:text-[#FCA5A5]">
+                    Aktive Mitglieder nach Wochentag
+                </h2>
+                <p id="active-users-weekday-description" class="text-sm text-gray-600 dark:text-gray-400">
+                    Zeigt den Verlauf aktiver Mitglieder je Stunde, gruppiert nach Wochentag.
+                </p>
+            </div>
+            <div data-chart-wrapper class="mt-6">
+                <canvas
+                    id="activeUsersWeekdayChart"
+                    class="h-80 w-full"
+                    role="img"
+                    aria-label="Liniendiagramm der aktiven Mitglieder nach Wochentag und Uhrzeit"
+                ></canvas>
+            </div>
+        </section>
     </x-member-page>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -219,6 +242,7 @@
         const visitData = @json($visitData);
         const userVisitData = @json($userVisitData);
         const activityData = @json($activityData);
+        const activityTimeline = @json($activityTimeline);
         const browserUsageByBrowser = @json($browserUsageByBrowser);
         const browserUsageByFamily = @json($browserUsageByFamily);
 
@@ -496,6 +520,61 @@
 
             updateActiveChart('all');
             weekdaySelect?.addEventListener('change', (event) => updateActiveChart(event.target.value));
+        }
+
+        const activeUsersWeekdayElement = document.getElementById('activeUsersWeekdayChart');
+        const ctx4 = activeUsersWeekdayElement?.getContext?.('2d');
+        if (ctx4) {
+            const weekdayLabels = [];
+            const weekdayValues = [];
+
+            activityTimeline.forEach((entry) => {
+                const dayLabel = dayNames[entry.weekday] ?? '';
+                const hourLabel = hours[entry.hour] ?? '';
+                weekdayLabels.push(`${dayLabel}\n${hourLabel}`);
+                weekdayValues.push(entry.total ?? 0);
+            });
+
+            new Chart(ctx4, {
+                type: 'line',
+                data: {
+                    labels: weekdayLabels,
+                    datasets: [
+                        {
+                            label: 'Aktive Mitglieder',
+                            data: weekdayValues,
+                            ...lineDatasetStyles,
+                        },
+                    ],
+                },
+                options: getCommonOptions({
+                    additionalOptions: {
+                        scales: {
+                            x: {
+                                ticks: {
+                                    color: axisColor,
+                                    autoSkip: true,
+                                    maxRotation: 0,
+                                    callback(value) {
+                                        const label = this.getLabelForValue(value);
+                                        return typeof label === 'string' ? label.split('\n') : label;
+                                    },
+                                },
+                                grid: {
+                                    color: gridColor,
+                                    drawOnChartArea: false,
+                                },
+                            },
+                        },
+                        plugins: {
+                            legend: {
+                                display: true,
+                                labels: { color: axisColor },
+                            },
+                        },
+                    },
+                }),
+            });
         }
     </script>
 </x-app-layout>

--- a/tests/Feature/AdminPageTest.php
+++ b/tests/Feature/AdminPageTest.php
@@ -114,8 +114,24 @@ class AdminPageTest extends TestCase
             return true;
         });
 
+        $response->assertViewHas('activityTimeline', function ($data) {
+            $collection = collect($data);
+
+            $this->assertCount(7 * 24, $collection);
+
+            $firstEntry = $collection->first();
+            $this->assertIsArray($firstEntry);
+            $this->assertArrayHasKey('weekday', $firstEntry);
+            $this->assertArrayHasKey('hour', $firstEntry);
+            $this->assertArrayHasKey('total', $firstEntry);
+
+            return true;
+        });
+
         $response->assertSee("allOption.selected = true;", false);
         $response->assertSee("updateActiveChart('all');", false);
+        $response->assertSee('id="activeUsersWeekdayChart"', false);
+        $response->assertSee('aria-describedby="active-users-weekday-description"', false);
     }
 
     public function test_browser_usage_statistics_visible_for_admins(): void


### PR DESCRIPTION
This pull request introduces a new visualization to the admin dashboard that displays active members by weekday and hour. The main changes include preparing timeline data in the controller, rendering a new chart in the Blade template, updating the JavaScript to plot this data using Chart.js, and extending feature tests to cover the new functionality.

**New Active Members by Weekday Feature:**

- **Backend Data Preparation:**
  * In `AdminController.php`, a new `activityTimeline` collection is generated, flattening the weekly activity data into a structure suitable for charting and passed to the view.

- **Frontend Chart Rendering:**
  * In `index.blade.php`, a new dashboard section and canvas for the "Aktive Mitglieder nach Wochentag" chart are added, including relevant ARIA labels for accessibility.
  * JavaScript is updated to process `activityTimeline` and render a line chart using Chart.js, formatting labels by weekday and hour.

**Testing Enhancements:**

- **Feature Test Coverage:**
  * The feature test is extended to assert that `activityTimeline` is present, correctly structured, and that the new chart elements appear in the rendered HTML.