### PR TITLE
Add Playwright E2E Tests badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![JS Coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/js-coverage.svg)
 ![PHP Coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/php-coverage.svg)
 [![License](https://img.shields.io/badge/license-GPLv3-green)](https://github.com/mcnamara84/omxfc-vereinswebseite/blob/main/LICENSE)
+[![Playwright E2E Tests](https://github.com/McNamara84/omxfc-vereinswebseite/actions/workflows/playwright.yml/badge.svg)](https://github.com/McNamara84/omxfc-vereinswebseite/actions/workflows/playwright.yml)
 
 Eine Laravel 12 Anwendung für die Vereinswebseite des OMFXC.
 


### PR DESCRIPTION
This pull request adds a new status badge to the `README.md` file to display the results of Playwright end-to-end (E2E) tests, providing better visibility into the health of the E2E test suite.

Documentation update:

* Added a Playwright E2E test status badge to the top of the `README.md` to show the current state of E2E tests in the GitHub Actions workflow.