### PR TITLE
Add Mission Mars ratings statistics

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -42,6 +42,12 @@ class StatistikController extends Controller
             $hardcovers = collect(json_decode(file_get_contents($hardcoverPath), true));
         }
 
+        $missionMarsPath = storage_path('app/private/missionmars.json');
+        $missionMarsNovels = collect();
+        if (is_readable($missionMarsPath)) {
+            $missionMarsNovels = collect(json_decode(file_get_contents($missionMarsPath), true));
+        }
+
         // ── Card 1 – Grundstatistiken ──────────────────────────────────────────────
         $averageRating = round($romane->avg('bewertung'), 2);
         $totalVotes = $romane->sum('stimmen');
@@ -325,6 +331,11 @@ class StatistikController extends Controller
         $hardcoverLabels = $hardcoverCycle->pluck('nummer');
         $hardcoverValues = $hardcoverCycle->pluck('bewertung');
 
+        // ── Card 31 – Bewertungen der Mission Mars-Heftromane ──────────────
+        $missionMarsCycle = $missionMarsNovels->sortBy('nummer')->take(12);
+        $missionMarsLabels = $missionMarsCycle->pluck('nummer');
+        $missionMarsValues = $missionMarsCycle->pluck('bewertung');
+
         // ── Card 7 – Rezensionen unserer Mitglieder ───────────────────────────
         $totalReviews = 0;
         $averageReviewsPerBook = 0;
@@ -453,6 +464,8 @@ class StatistikController extends Controller
             'weltratValues' => $weltratValues,
             'hardcoverLabels' => $hardcoverLabels,
             'hardcoverValues' => $hardcoverValues,
+            'missionMarsLabels' => $missionMarsLabels,
+            'missionMarsValues' => $missionMarsValues,
             'hardcoverAuthorCounts' => $hardcoverAuthorCounts,
             'topFavoriteThemes' => $topFavoriteThemes,
             'totalReviews' => $totalReviews,

--- a/config/rewards.php
+++ b/config/rewards.php
@@ -177,6 +177,11 @@ return [
         'points' => 42,
     ],
     [
+        'title' => 'Statistik - Bewertungen der Mission Mars-Heftromane',
+        'description' => 'Zeigt Bewertungen der Mission Mars-Heftromane aus dem Maddraxikon in einem Liniendiagramm.',
+        'points' => 43,
+    ],
+    [
         'title' => 'Statistik - TOP10 Lieblingsthemen',
         'description' => 'Zeigt die beliebtesten Lieblingsthemen der Mitglieder.',
         'points' => 50,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -86,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const hcAuthorValues = window.hardcoverAuthorChartValues ?? [];
     drawAuthorChart('hardcoverAuthorChart', hcAuthorLabels, hcAuthorValues);
 
-    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka', 'weltrat'];
+    const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka', 'weltrat', 'missionMars'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];
         const cycleValues = window[`${cycle}ChartValues`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -702,7 +702,26 @@
                 @endif
             </div>
 
-            {{-- Card 31 – TOP10 Lieblingsthemen (≥ 50 Baxx) --}}
+            {{-- Card 31 – Bewertungen der Mission Mars-Heftromane (≥ 43 Baxx) --}}
+                @php($min = 43)
+                <div data-min-points="{{ $min }}" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 id="missionMarsChartTitle" class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Bewertungen der Mission Mars-Heftromane
+                    </h2>
+                    <div data-chart-wrapper class="mt-4">
+                        <canvas id="missionMarsChart" height="140" role="img" aria-labelledby="missionMarsChartTitle"></canvas>
+                    </div>
+                    @if($userPoints < $min)
+                        @include('statistik.lock-message', ['min' => $min, 'userPoints' => $userPoints])
+                    @endif
+                </div>
+
+                <script>
+                    window.missionMarsChartLabels = @json($missionMarsLabels);
+                    window.missionMarsChartValues = @json($missionMarsValues);
+                </script>
+
+            {{-- Card 32 – TOP10 Lieblingsthemen (≥ 50 Baxx) --}}
                 @php($min = 50)
                 <div data-min-points="{{ $min }}" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">

--- a/tests/Feature/RewardControllerTest.php
+++ b/tests/Feature/RewardControllerTest.php
@@ -136,4 +136,29 @@ class RewardControllerTest extends TestCase
         $this->assertNotNull($reward);
         $this->assertEquals(0, $reward['percentage']);
     }
+
+    public function test_mission_mars_reward_visible(): void
+    {
+        $user = $this->actingMember(43);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $response->assertSee('Statistik - Bewertungen der Mission Mars-Heftromane');
+    }
+
+    public function test_mission_mars_reward_hidden_when_points_insufficient(): void
+    {
+        $user = $this->actingMember(42);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $rewards = $response->viewData('rewards');
+        $reward = collect($rewards)->firstWhere('title', 'Statistik - Bewertungen der Mission Mars-Heftromane');
+        $this->assertNotNull($reward);
+        $this->assertEquals(0, $reward['percentage']);
+    }
 }

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -95,6 +95,24 @@ describe('statistik module', () => {
     expect(config.type).toBe('line');
   });
 
+  test('DOMContentLoaded draws Mission Mars chart when data available', async () => {
+    jest.resetModules();
+    const chartModule = await import('chart.js/auto');
+    mockChart = chartModule.default;
+    mockChart.mockClear();
+
+    document.body.innerHTML = '<canvas id="missionMarsChart"></canvas>';
+    window.missionMarsChartLabels = ['1'];
+    window.missionMarsChartValues = [4.2];
+
+    await import('../../resources/js/statistik.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(mockChart).toHaveBeenCalled();
+    const config = mockChart.mock.calls[0][1];
+    expect(config.type).toBe('line');
+  });
+
   test('DOMContentLoaded draws hardcover author chart', async () => {
     jest.resetModules();
     const chartModule = await import('chart.js/auto');


### PR DESCRIPTION
This pull request adds a new "Mission Mars" statistics card to the statistics dashboard, displaying the ratings of Mission Mars pulp novels in a line chart. It includes backend, frontend, and test updates to support this feature, as well as a new unlockable reward for users with at least 43 points. The changes ensure the data is loaded, displayed, and gated correctly, and are covered by both feature and JavaScript tests.

**Mission Mars statistics feature:**

* Loads Mission Mars ratings data from `missionmars.json` and prepares it for the view in `StatistikController.php`, including labels and values for charting. [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR45-R50) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR334-R338) [[3]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR467-R468)
* Adds a new statistics card to `statistik/index.blade.php` that displays the Mission Mars ratings chart, visible only to users with at least 43 points, and exposes the data to JavaScript.

**Rewards system:**

* Adds a new reward entry for the Mission Mars ratings statistics, requiring 43 points, in `config/rewards.php`.
* Updates reward tests to check visibility and gating for the new Mission Mars reward.

**Frontend JavaScript:**

* Updates `statistik.js` to include the Mission Mars cycle in the list of charted cycles, so its chart is drawn if data is present.
* Adds a Jest test to verify the Mission Mars chart is drawn when data is available.

**Backend and integration tests:**

* Adds helper to create mock Mission Mars data in `StatistikTest.php` and tests to verify the chart is shown or locked based on user points. [[1]](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R97-R115) [[2]](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R758-R784)