### PR TITLE
Change Playwright E2E Tests badge label

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![JS Coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/js-coverage.svg)
 ![PHP Coverage](https://raw.githubusercontent.com/McNamara84/omxfc-vereinswebseite/image-data/php-coverage.svg)
 [![License](https://img.shields.io/badge/license-GPLv3-green)](https://github.com/mcnamara84/omxfc-vereinswebseite/blob/main/LICENSE)
-[![Playwright E2E Tests](https://github.com/McNamara84/omxfc-vereinswebseite/actions/workflows/playwright.yml/badge.svg)](https://github.com/McNamara84/omxfc-vereinswebseite/actions/workflows/playwright.yml)
+[![E2E Tests](https://github.com/McNamara84/omxfc-vereinswebseite/actions/workflows/playwright.yml/badge.svg)](https://github.com/McNamara84/omxfc-vereinswebseite/actions/workflows/playwright.yml)
 
 Eine Laravel 12 Anwendung für die Vereinswebseite des OMFXC.
 


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file, renaming the badge label for end-to-end tests from "Playwright E2E Tests" to "E2E Tests" for improved clarity.