### PR TITLE
Add Mission Mars author statistics

### DIFF
--- a/app/Http/Controllers/StatistikController.php
+++ b/app/Http/Controllers/StatistikController.php
@@ -71,6 +71,15 @@ class StatistikController extends Controller
             ->countBy()
             ->sortDesc();
 
+        // ── Card 31b – Mission Mars-Heftromane je Autor (inkl. Co-Autor:innen) ─────
+        $missionMarsAuthorCounts = $missionMarsNovels
+            ->pluck('text')
+            ->flatten()
+            ->map(fn ($a) => trim($a))
+            ->filter()
+            ->countBy()
+            ->sortDesc();
+
         // ── Card 3 – Top Teamplayer ─────────────────────────────────────────
         $teamplayerTable = $romane
             ->filter(fn ($r) => collect($r['text'])->filter()->count() > 1)
@@ -466,6 +475,7 @@ class StatistikController extends Controller
             'hardcoverValues' => $hardcoverValues,
             'missionMarsLabels' => $missionMarsLabels,
             'missionMarsValues' => $missionMarsValues,
+            'missionMarsAuthorCounts' => $missionMarsAuthorCounts,
             'hardcoverAuthorCounts' => $hardcoverAuthorCounts,
             'topFavoriteThemes' => $topFavoriteThemes,
             'totalReviews' => $totalReviews,

--- a/resources/js/statistik.js
+++ b/resources/js/statistik.js
@@ -86,6 +86,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const hcAuthorValues = window.hardcoverAuthorChartValues ?? [];
     drawAuthorChart('hardcoverAuthorChart', hcAuthorLabels, hcAuthorValues);
 
+    const missionMarsAuthorLabels = window.missionMarsAuthorChartLabels ?? [];
+    const missionMarsAuthorValues = window.missionMarsAuthorChartValues ?? [];
+    drawAuthorChart('missionMarsAuthorChart', missionMarsAuthorLabels, missionMarsAuthorValues);
+
     const cycles = ['euree', 'meeraka', 'expedition', 'kratersee', 'daaMuren', 'wandler', 'mars', 'ausala', 'afra', 'antarktis', 'schatten', 'ursprung', 'streiter', 'archivar', 'zeitsprung', 'fremdwelt', 'parallelwelt', 'weltenriss', 'amraka', 'weltrat', 'missionMars'];
     cycles.forEach((cycle) => {
         const cycleLabels = window[`${cycle}ChartLabels`] ?? [];

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -721,6 +721,25 @@
                     window.missionMarsChartValues = @json($missionMarsValues);
                 </script>
 
+            {{-- Card 31b – Mission Mars-Heftromane je Autor:in (≥ 43 Baxx) --}}
+                @php($min = 43)
+                <div data-min-points="{{ $min }}" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
+                    <h2 id="missionMarsAuthorChartTitle" class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
+                        Mission Mars-Heftromane je Autor:in
+                    </h2>
+                    <div data-chart-wrapper class="mt-4">
+                        <canvas id="missionMarsAuthorChart" height="140" role="img" aria-labelledby="missionMarsAuthorChartTitle"></canvas>
+                    </div>
+                    @if($userPoints < $min)
+                        @include('statistik.lock-message', ['min' => $min, 'userPoints' => $userPoints])
+                    @endif
+                </div>
+
+                <script>
+                    window.missionMarsAuthorChartLabels = @json($missionMarsAuthorCounts->keys());
+                    window.missionMarsAuthorChartValues = @json($missionMarsAuthorCounts->values());
+                </script>
+
             {{-- Card 32 – TOP10 Lieblingsthemen (≥ 50 Baxx) --}}
                 @php($min = 50)
                 <div data-min-points="{{ $min }}" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -97,11 +97,24 @@ class StatistikTest extends TestCase
     private function createMissionMarsFile(): void
     {
         $data = [];
+        $authors = [
+            'Mission Mars Autor 1',
+            'Mission Mars Autor 2',
+            'Mission Mars Autor 3',
+        ];
         for ($i = 1; $i <= 12; $i++) {
+            $authorIndex = ($i - 1) % count($authors);
+            $entryAuthors = [$authors[$authorIndex]];
+
+            if ($i % 5 === 0) {
+                $entryAuthors[] = 'Mission Mars Co-Autor';
+            }
+
             $data[] = [
                 'nummer' => $i,
                 'titel' => 'Mission Mars '.$i,
                 'bewertung' => 3.5 + ($i * 0.05),
+                'text' => $entryAuthors,
             ];
         }
 
@@ -766,6 +779,9 @@ class StatistikTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Bewertungen der Mission Mars-Heftromane');
+        $response->assertSee('Mission Mars-Heftromane je Autor:in');
+        $response->assertSee('Mission Mars Autor 1');
+        $response->assertSee('Mission Mars Co-Autor');
     }
 
     public function test_mission_mars_chart_locked_below_threshold(): void
@@ -779,6 +795,7 @@ class StatistikTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Bewertungen der Mission Mars-Heftromane');
+        $response->assertSee('Mission Mars-Heftromane je Autor:in');
         $response->assertSee('43 Baxx');
     }
 

--- a/tests/Jest/statistik.test.js
+++ b/tests/Jest/statistik.test.js
@@ -113,6 +113,24 @@ describe('statistik module', () => {
     expect(config.type).toBe('line');
   });
 
+  test('DOMContentLoaded draws Mission Mars author chart', async () => {
+    jest.resetModules();
+    const chartModule = await import('chart.js/auto');
+    mockChart = chartModule.default;
+    mockChart.mockClear();
+
+    document.body.innerHTML = '<canvas id="missionMarsAuthorChart"></canvas>';
+    window.missionMarsAuthorChartLabels = ['Autor'];
+    window.missionMarsAuthorChartValues = [3];
+
+    await import('../../resources/js/statistik.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    expect(mockChart).toHaveBeenCalled();
+    const config = mockChart.mock.calls[0][1];
+    expect(config.type).toBe('bar');
+  });
+
   test('DOMContentLoaded draws hardcover author chart', async () => {
     jest.resetModules();
     const chartModule = await import('chart.js/auto');


### PR DESCRIPTION
This pull request adds a new statistics card to display the number of "Mission Mars" novels per author, including co-authors, in the statistics dashboard. The implementation includes backend data aggregation, frontend chart rendering, and updates to both feature and unit tests to ensure correct behavior and visibility based on user points.

**Backend: Data Aggregation**
- Added aggregation of "Mission Mars" novels per author (including co-authors) in `StatistikController.php` and passed the results to the view. [[1]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR74-R82) [[2]](diffhunk://#diff-a03793889d74d1f53f701bcd94d817bc4c5d15a810f36dee5b6f0ec3a4d46e1cR478)

**Frontend: Chart Rendering**
- Added a new card and chart in `index.blade.php` to visualize "Mission Mars" novels per author, with visibility gated by a minimum user points threshold (43 Baxx).
- Updated `statistik.js` to render the new author chart for "Mission Mars" using the provided data.

**Testing: Feature and Unit Tests**
- Enhanced `StatistikTest.php` to generate test data with multiple authors and co-authors for "Mission Mars" and added assertions to verify the new chart and author names are displayed correctly based on user points. [[1]](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R100-R117) [[2]](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R782-R784) [[3]](diffhunk://#diff-c5847b425e9e9b33a9df6eda4a9f55744c3bc4487af792d1cead2a287ec1f0d0R798)
- Added a Jest unit test to verify that the "Mission Mars" author chart is drawn on DOMContentLoaded.