### PR TITLE
Align tests with team point service logic

### DIFF
--- a/resources/js/utils/dashboard.js
+++ b/resources/js/utils/dashboard.js
@@ -31,7 +31,7 @@ export function initTodoDashboard(root = document) {
 
         const fill = bar.querySelector('[data-progress-fill]');
         if (fill) {
-            const percent = normalizedMax === 0 ? 0 : Math.round((clampedValue / normalizedMax) * 100);
+            const percent = normalizedMax > 0 ? Math.round((clampedValue / normalizedMax) * 100) : 0;
             fill.style.width = `${percent}%`;
             fill.style.setProperty('--progress-percent', String(percent));
         }

--- a/tests/Jest/todoDashboard.test.js
+++ b/tests/Jest/todoDashboard.test.js
@@ -41,4 +41,26 @@ describe('todo dashboard utilities', () => {
         expect(bar?.getAttribute('aria-valuenow')).toBe('0');
         expect(fill?.style.width).toBe('0%');
     });
+
+    test('guards against invalid numeric attributes when calculating progress', () => {
+        const originalIsFinite = Number.isFinite;
+        Number.isFinite = () => true;
+
+        document.body.innerHTML = `
+            <div data-progress-bar data-progress-value="foo" data-progress-max="bar">
+                <div data-progress-fill></div>
+            </div>
+        `;
+
+        try {
+            initTodoDashboard(document);
+        } finally {
+            Number.isFinite = originalIsFinite;
+        }
+
+        const fill = document.querySelector('[data-progress-fill]');
+
+        expect(fill?.style.width).toBe('0%');
+        expect(fill?.style.getPropertyValue('--progress-percent')).toBe('0');
+    });
 });


### PR DESCRIPTION
This pull request improves the reliability and accuracy of the todo dashboard progress calculation and enhances the test coverage and correctness of the `TeamPointService`. The main changes include fixing progress bar calculation logic, adding tests for edge cases, and updating the team points test setup and assertions.

**Todo Dashboard Progress Calculation:**

* Fixed the calculation of progress bar percentage to correctly handle cases where `normalizedMax` is zero or invalid, preventing possible division by zero or NaN issues.
* Added a test to ensure the progress bar gracefully handles invalid numeric attributes, always displaying `0%` when values are not finite.

**TeamPointService Unit Tests:**

* Updated the test setup in `TeamPointServiceTest` to detach all users from the team and refresh the team model before each test, ensuring a clean state.
* Refactored the `addPoints` helper to use the `incrementTeamPoints` method with proper test time control, aligning tests with the actual application logic.
* Corrected leaderboard assertion logic and added a new test to verify that a user outside the leaderboard limit is appended with the correct flags and ranking.