### PR TITLE
Update project metadata in composer.json and fix dev server timeout

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,16 @@
 {
     "$schema": "https://getcomposer.org/schema.json",
-    "name": "laravel/laravel",
+    "name": "omxfc/omxfc",
     "type": "project",
-    "description": "The skeleton application for the Laravel framework.",
+    "description": "The official website of Offizieller MADDRAX Fanclub.",
     "keywords": [
+        "website",
         "laravel",
-        "framework"
+        "maddrax",
+        "fanclub",
+        "omxfc"
     ],
-    "license": "MIT",
+    "license": "GPL-3.0-or-later",
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
@@ -71,7 +74,8 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
-        }
+        },
+        "process-timeout": 0
     },
     "minimum-stability": "stable",
     "prefer-stable": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77cd8094e317f81817867f95c0715c87",
+    "content-hash": "3ce16b9a0ce0b136b372519b0261ec33",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
This pull request updates the project's `composer.json` to reflect a rebranding and to better describe the project's purpose and metadata. The most important changes are:

Project identity and metadata updates:

* Changed the `name` field from `laravel/laravel` to `omxfc/omxfc` to reflect the new project identity.
* Updated the `description` to specify that this is the official website of Offizieller MADDRAX Fanclub.
* Changed the `license` from `MIT` to `GPL-3.0-or-later` to reflect the new licensing.
* Expanded the `keywords` array to include terms relevant to the new project, such as `website`, `maddrax`, `fanclub`, and `omxfc`.

Composer configuration:

* Added `"process-timeout": 0` to the `config` section to allow Composer processes to run without a timeout.