### PR TITLE
Add reward for Mission Mars author statistic

### DIFF
--- a/config/rewards.php
+++ b/config/rewards.php
@@ -182,6 +182,11 @@ return [
         'points' => 43,
     ],
     [
+        'title' => 'Statistik - Mission Mars-Heftromane je Autor:in',
+        'description' => 'Balkendiagramm mit der Anzahl der Mission Mars-Heftromane je Autor:in.',
+        'points' => 44,
+    ],
+    [
         'title' => 'Statistik - TOP10 Lieblingsthemen',
         'description' => 'Zeigt die beliebtesten Lieblingsthemen der Mitglieder.',
         'points' => 50,

--- a/resources/views/statistik/index.blade.php
+++ b/resources/views/statistik/index.blade.php
@@ -721,8 +721,8 @@
                     window.missionMarsChartValues = @json($missionMarsValues);
                 </script>
 
-            {{-- Card 31b – Mission Mars-Heftromane je Autor:in (≥ 43 Baxx) --}}
-                @php($min = 43)
+            {{-- Card 31b – Mission Mars-Heftromane je Autor:in (≥ 44 Baxx) --}}
+                @php($min = 44)
                 <div data-min-points="{{ $min }}" class="relative bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                     <h2 id="missionMarsAuthorChartTitle" class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-4 text-center">
                         Mission Mars-Heftromane je Autor:in

--- a/tests/Feature/RewardControllerTest.php
+++ b/tests/Feature/RewardControllerTest.php
@@ -161,4 +161,29 @@ class RewardControllerTest extends TestCase
         $this->assertNotNull($reward);
         $this->assertEquals(0, $reward['percentage']);
     }
+
+    public function test_mission_mars_author_reward_visible(): void
+    {
+        $user = $this->actingMember(44);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $response->assertSee('Statistik - Mission Mars-Heftromane je Autor:in');
+    }
+
+    public function test_mission_mars_author_reward_hidden_when_points_insufficient(): void
+    {
+        $user = $this->actingMember(43);
+        $this->actingAs($user);
+
+        $response = $this->get('/belohnungen');
+
+        $response->assertOk();
+        $rewards = $response->viewData('rewards');
+        $reward = collect($rewards)->firstWhere('title', 'Statistik - Mission Mars-Heftromane je Autor:in');
+        $this->assertNotNull($reward);
+        $this->assertEquals(0, $reward['percentage']);
+    }
 }

--- a/tests/Feature/StatistikTest.php
+++ b/tests/Feature/StatistikTest.php
@@ -772,7 +772,7 @@ class StatistikTest extends TestCase
     {
         $this->createDataFile();
         $this->createMissionMarsFile();
-        $user = $this->actingMemberWithPoints(43);
+        $user = $this->actingMemberWithPoints(44);
         $this->actingAs($user);
 
         $response = $this->get('/statistiken');
@@ -788,7 +788,7 @@ class StatistikTest extends TestCase
     {
         $this->createDataFile();
         $this->createMissionMarsFile();
-        $user = $this->actingMemberWithPoints(42);
+        $user = $this->actingMemberWithPoints(43);
         $this->actingAs($user);
 
         $response = $this->get('/statistiken');
@@ -796,7 +796,7 @@ class StatistikTest extends TestCase
         $response->assertOk();
         $response->assertSee('Bewertungen der Mission Mars-Heftromane');
         $response->assertSee('Mission Mars-Heftromane je Autor:in');
-        $response->assertSee('43 Baxx');
+        $response->assertSee('44 Baxx');
     }
 
     public function test_top_themes_require_minimum_book_count(): void


### PR DESCRIPTION
## Summary
- add the Mission Mars author statistic to the rewards configuration and expose it at 44 Baxx
- update the statistics view so the Mission Mars author chart unlocks at the same threshold
- extend feature tests for rewards and statistics to cover the new unlock level

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d015c7bfe8832e95de7737cfc2047d