### PR TITLE
Enhance Protokolle accordion accessibility and coverage

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -86,3 +86,4 @@ import './todos';
 import './dashboard';
 import './mitglieder/accessibility';
 import './mitglieder/map-utils';
+import './protokolle/accordion';

--- a/resources/js/protokolle/accordion.js
+++ b/resources/js/protokolle/accordion.js
@@ -1,0 +1,73 @@
+const HIDDEN_CLASS = 'hidden';
+
+if (typeof window !== 'undefined' && typeof window.__omxfcProtokolleAccordionInitialised === 'undefined') {
+    window.__omxfcProtokolleAccordionInitialised = false;
+}
+
+export function applyAccordionState(button, panel, icon, expand, container) {
+    const parentDetails = container ?? button.closest('details');
+    const shouldExpand = typeof expand === 'boolean' ? expand : Boolean(parentDetails?.open);
+
+    if (parentDetails && parentDetails.open !== shouldExpand) {
+        parentDetails.open = shouldExpand;
+    }
+
+    button.setAttribute('aria-expanded', shouldExpand ? 'true' : 'false');
+    panel.classList.toggle(HIDDEN_CLASS, !shouldExpand);
+
+    if (shouldExpand) {
+        panel.removeAttribute('hidden');
+    } else {
+        panel.setAttribute('hidden', '');
+    }
+
+    panel.setAttribute('aria-hidden', shouldExpand ? 'false' : 'true');
+
+    if (icon) {
+        icon.textContent = shouldExpand ? '−' : '+';
+    }
+
+    return shouldExpand;
+}
+
+export function setupProtokolleAccordion(root = document) {
+    const buttons = Array.from(root.querySelectorAll('[data-protokolle-accordion-button]'));
+
+    buttons.forEach((button) => {
+        const container = button.closest('details');
+        const targetId = button.getAttribute('aria-controls');
+        const panel = targetId ? root.getElementById(targetId) : null;
+
+        if (!container || !panel) {
+            return;
+        }
+
+        const icon = button.querySelector('[data-protokolle-accordion-icon]');
+        const isExpanded = Boolean(container.open);
+        applyAccordionState(button, panel, icon, isExpanded, container);
+
+        container.addEventListener('toggle', () => {
+            applyAccordionState(button, panel, icon, container.open, container);
+        });
+    });
+
+    if (typeof window !== 'undefined' && buttons.length > 0) {
+        window.__omxfcProtokolleAccordionInitialised = true;
+    }
+
+    return buttons;
+}
+
+if (typeof document !== 'undefined') {
+    const bootstrapAccordion = () => {
+        setupProtokolleAccordion();
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', bootstrapAccordion, { once: true });
+    } else {
+        bootstrapAccordion();
+    }
+}
+
+export default setupProtokolleAccordion;

--- a/resources/views/pages/protokolle.blade.php
+++ b/resources/views/pages/protokolle.blade.php
@@ -4,42 +4,55 @@
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6">
                 <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#ff4b63] mb-6">Protokolle</h1>
 
-                <div id="accordion">
+                <div id="accordion" data-protokolle-accordion>
                     @foreach($protokolle as $jahr => $dokumente)
-                        <div class="mb-4 border border-gray-200 dark:border-gray-700 rounded-lg">
-                            <h2>
-                                <button type="button"
-                                    class="w-full flex justify-between items-center bg-gray-100 dark:bg-gray-700 px-4 py-3 rounded-t-lg font-semibold"
-                                    onclick="toggleAccordion({{ $jahr }})">
-                                    Protokolle {{ $jahr }}
-                                    <span id="icon-{{ $jahr }}">+</span>
-                                </button>
-                            </h2>
+                        <details class="mb-4 border border-gray-200 dark:border-gray-700 rounded-lg" data-protokolle-accordion-item>
+                            <summary
+                                id="accordion-trigger-{{ $jahr }}"
+                                class="list-none w-full flex justify-between items-center gap-4 bg-gray-100 dark:bg-gray-700 px-4 py-3 rounded-t-lg font-semibold text-left cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                                data-protokolle-accordion-button
+                                aria-controls="content-{{ $jahr }}"
+                                aria-expanded="false"
+                                role="button"
+                            >
+                                <span class="flex flex-col sm:flex-row sm:items-center sm:gap-2">
+                                    <span>Protokolle {{ $jahr }}</span>
+                                    <span class="text-sm font-normal text-gray-600 dark:text-gray-300 sm:mt-0 mt-1">
+                                        {{ count($dokumente) }} {{ count($dokumente) === 1 ? 'Dokument' : 'Dokumente' }}
+                                    </span>
+                                </span>
+                                <span class="flex items-center gap-2 text-xl" aria-hidden="true">
+                                    <span data-protokolle-accordion-icon class="select-none">+</span>
+                                </span>
+                                <span class="sr-only" data-protokolle-accordion-label>Abschnitt Protokolle {{ $jahr }} umschalten</span>
+                            </summary>
 
-                            <div id="content-{{ $jahr }}" class="hidden bg-white dark:bg-gray-900 px-4 py-2 rounded-b-lg">
+                            <div
+                                id="content-{{ $jahr }}"
+                                class="bg-white dark:bg-gray-900 px-4 py-2 rounded-b-lg"
+                                role="region"
+                                aria-labelledby="accordion-trigger-{{ $jahr }}"
+                                aria-hidden="true"
+                                data-protokolle-accordion-panel
+                            >
                                 <ul class="space-y-2">
                                     @foreach($dokumente as $protokoll)
                                         <li>
-                                            <a href="{{ route('protokolle.download', $protokoll['datei']) }}" class="text-blue-600 hover:underline">
-                                                {{ $protokoll['datum'] }} – {{ $protokoll['titel'] }}
+                                            <a
+                                                href="{{ route('protokolle.download', $protokoll['datei']) }}"
+                                                class="inline-flex items-center gap-2 text-blue-600 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                                            >
+                                                <span aria-hidden="true">📄</span>
+                                                <span>{{ $protokoll['datum'] }} – {{ $protokoll['titel'] }}</span>
                                             </a>
                                         </li>
                                     @endforeach
                                 </ul>
                             </div>
-                        </div>
+                        </details>
                     @endforeach
                 </div>
             </div>
         </div>
     </div>
-
-    <script>
-        function toggleAccordion(jahr) {
-            const content = document.getElementById('content-' + jahr);
-            const icon = document.getElementById('icon-' + jahr);
-            content.classList.toggle('hidden');
-            icon.textContent = content.classList.contains('hidden') ? '+' : '-';
-        }
-    </script>
 </x-app-layout>

--- a/tests/Unit/PageControllerProtokolleTest.php
+++ b/tests/Unit/PageControllerProtokolleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\PageController;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Tests\TestCase;
+
+class PageControllerProtokolleTest extends TestCase
+{
+    public function test_protokolle_view_contains_expected_structure(): void
+    {
+        $controller = new PageController();
+
+        $response = $controller->protokolle();
+
+        $this->assertSame('pages.protokolle', $response->name());
+
+        $viewData = $response->getData()['protokolle'] ?? [];
+
+        $this->assertArrayHasKey(2023, $viewData);
+        $this->assertSame('Gründungsversammlung', $viewData[2023][0]['titel']);
+        $this->assertArrayHasKey(2024, $viewData);
+        $this->assertCount(3, $viewData[2024]);
+    }
+
+    public function test_download_protokoll_streams_file_from_private_disk(): void
+    {
+        Storage::fake('private');
+        Storage::disk('private')->put('protokolle/example.pdf', 'demo');
+
+        $controller = new PageController();
+
+        $response = $controller->downloadProtokoll('example.pdf');
+
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        $this->assertStringContainsString('example.pdf', $response->headers->get('content-disposition'));
+    }
+}

--- a/tests/Vitest/protokolle-accordion.test.js
+++ b/tests/Vitest/protokolle-accordion.test.js
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { applyAccordionState, setupProtokolleAccordion } from '../../resources/js/protokolle/accordion.js';
+
+describe('Protokolle accordion', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <details data-protokolle-accordion-item>
+                <summary data-protokolle-accordion-button aria-controls="panel-2024" aria-expanded="false">
+                    <span data-protokolle-accordion-icon>+</span>
+                </summary>
+                <div id="panel-2024" data-protokolle-accordion-panel class="hidden" hidden aria-hidden="true"></div>
+            </details>
+        `;
+    });
+
+    it('updates aria attributes when applying accordion state', () => {
+        const button = document.querySelector('[data-protokolle-accordion-button]');
+        const panel = document.getElementById('panel-2024');
+        const container = button.closest('details');
+        const icon = button.querySelector('[data-protokolle-accordion-icon]');
+
+        applyAccordionState(button, panel, icon, true, container);
+
+        expect(button.getAttribute('aria-expanded')).toBe('true');
+        expect(panel.classList.contains('hidden')).toBe(false);
+        expect(panel.hasAttribute('hidden')).toBe(false);
+        expect(panel.getAttribute('aria-hidden')).toBe('false');
+        expect(icon.textContent).toBe('−');
+
+        applyAccordionState(button, panel, icon, false, container);
+
+        expect(button.getAttribute('aria-expanded')).toBe('false');
+        expect(panel.classList.contains('hidden')).toBe(true);
+        expect(panel.hasAttribute('hidden')).toBe(true);
+        expect(panel.getAttribute('aria-hidden')).toBe('true');
+        expect(icon.textContent).toBe('+');
+    });
+
+    it('registers toggle handlers that sync the panel state', () => {
+        const button = document.querySelector('[data-protokolle-accordion-button]');
+        const panel = document.getElementById('panel-2024');
+        const container = button.closest('details');
+
+        setupProtokolleAccordion();
+
+        expect(button.getAttribute('aria-expanded')).toBe('false');
+        expect(panel.classList.contains('hidden')).toBe(true);
+        expect(container?.open).toBe(false);
+
+        container?.setAttribute('open', '');
+        container?.dispatchEvent(new Event('toggle'));
+
+        expect(button.getAttribute('aria-expanded')).toBe('true');
+        expect(panel.classList.contains('hidden')).toBe(false);
+        expect(container?.open).toBe(true);
+
+        container?.removeAttribute('open');
+        container?.dispatchEvent(new Event('toggle'));
+
+        expect(button.getAttribute('aria-expanded')).toBe('false');
+        expect(panel.classList.contains('hidden')).toBe(true);
+        expect(window.__omxfcProtokolleAccordionInitialised).toBe(true);
+    });
+});

--- a/tests/e2e/protokolle.spec.js
+++ b/tests/e2e/protokolle.spec.js
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+
+const login = async (page, email, password = 'password') => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', email);
+    await page.fill('input[name="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((url) => !url.pathname.endsWith('/login'));
+};
+
+test.describe('Protokolle page', () => {
+    test('redirects unauthenticated visitors to the login page', async ({ page }) => {
+        await page.goto('/protokolle');
+
+        await expect(page).toHaveURL(/\/login/);
+        await expect(page.getByRole('heading', { name: /login/i })).toBeVisible();
+    });
+
+    test('allows members to open accordion sections and see documents', async ({ page }) => {
+        await login(page, 'playwright-member@example.com');
+
+        await page.goto('/protokolle');
+
+        await expect(page).toHaveURL(/\/protokolle$/);
+        await expect(page.getByRole('heading', { level: 1, name: 'Protokolle' })).toBeVisible();
+        await expect(page.getByText('3 Dokumente')).toBeVisible();
+
+        const firstAccordion = page.locator('details[data-protokolle-accordion-item]').first();
+        const accordionButton = page.getByRole('button', { name: /Protokolle 2023/i });
+        await expect(accordionButton).toHaveAttribute('aria-expanded', 'false');
+        await expect(firstAccordion).toHaveJSProperty('open', false);
+
+        await accordionButton.click();
+
+        await expect(firstAccordion).toHaveJSProperty('open', true);
+        const firstPanel = page.locator('#content-2023');
+        await expect(firstPanel).toBeVisible();
+        await expect(firstPanel).toContainText('Gründungsversammlung');
+        await accordionButton.focus();
+        await page.keyboard.press('Space');
+
+        await expect(firstAccordion).toHaveJSProperty('open', false);
+        await expect(page.locator('#content-2023')).toBeHidden();
+    });
+});


### PR DESCRIPTION
This pull request refactors the "Protokolle" (protocols/minutes) page to use an accessible, JavaScript-powered accordion component for displaying documents by year. It introduces a new accordion implementation with improved accessibility, updates the Blade template to match, and adds comprehensive tests (unit, feature, Vitest, and Playwright) to ensure correct behavior and access control.

**Accordion Refactor and Accessibility Improvements:**

- Replaced the previous manual accordion logic in `protokolle.blade.php` with a semantic and accessible `<details>/<summary>`-based accordion, using ARIA attributes and keyboard support. The new implementation displays document counts and improves accessibility for screen readers.
- Added a new JavaScript module `protokolle/accordion.js` that manages accordion state, synchronizes ARIA attributes, and ensures keyboard and screen reader accessibility. The module is auto-initialized and imported in the main JavaScript entrypoint. [[1]](diffhunk://#diff-0fc9ee0968a617b1b4fd5ab44a2b9d9ae14ac9a7f95cf0b1c10deb5bc15e9df5R1-R73) [[2]](diffhunk://#diff-583a1f586bc298813341bce6fec77a1f6338f2559471fe600f15a18316fe82bdR89)

**Testing Enhancements:**

- Added Vitest unit tests for the accordion JavaScript to verify ARIA attributes, toggle behavior, and state synchronization.
- Introduced Playwright end-to-end tests to check authentication redirects and interactive accordion behavior for members.
- Expanded Laravel feature tests to cover authentication requirements, document counts, and download access for the protocols page. [[1]](diffhunk://#diff-878ce3e235ea7bff26c5414a97ca55907d47f493fe3d8358e6861fdee17f1ef1R23-R29) [[2]](diffhunk://#diff-878ce3e235ea7bff26c5414a97ca55907d47f493fe3d8358e6861fdee17f1ef1R40-R54) [[3]](diffhunk://#diff-878ce3e235ea7bff26c5414a97ca55907d47f493fe3d8358e6861fdee17f1ef1L43-R65) [[4]](diffhunk://#diff-878ce3e235ea7bff26c5414a97ca55907d47f493fe3d8358e6861fdee17f1ef1R77-R83)
- Added a Laravel unit test for the `PageController` to verify the view structure and file download logic for protocols.