### PR TITLE
Add device usage donut chart to admin statistics

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -135,6 +135,7 @@ class AdminController extends Controller
             'homepageVisits' => $homepageVisits,
             'browserUsageByBrowser' => $browserUsage['browserCounts'],
             'browserUsageByFamily' => $browserUsage['familyCounts'],
+            'deviceUsage' => $browserUsage['deviceTypeCounts'],
         ]);
     }
 

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -50,6 +50,7 @@
 
         @php($hasBrowserUsageByBrowser = $browserUsageByBrowser->isNotEmpty())
         @php($hasBrowserUsageByFamily = $browserUsageByFamily->isNotEmpty())
+        @php($hasDeviceUsage = $deviceUsage->isNotEmpty())
         <section
             class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6 mt-8"
             aria-labelledby="browser-usage-heading"
@@ -64,7 +65,7 @@
                 </p>
             </div>
 
-            <div class="mt-6 grid grid-cols-1 gap-10 xl:grid-cols-2">
+            <div class="mt-6 grid grid-cols-1 gap-10 xl:grid-cols-3">
                 <figure class="flex flex-col items-center">
                     <h3 id="browserUsageChartTitle" class="text-lg font-semibold text-gray-900 dark:text-gray-100 text-center">
                         Beliebteste Browser
@@ -140,6 +141,50 @@
                     @else
                         <p
                             id="browserFamilyChartSummary"
+                            class="mt-5 text-sm text-gray-600 dark:text-gray-400 text-center"
+                        >
+                            Noch keine Login-Daten vorhanden.
+                        </p>
+                    @endif
+                </figure>
+
+                <figure class="flex flex-col items-center">
+                    <h3 id="deviceUsageChartTitle" class="text-lg font-semibold text-gray-900 dark:text-gray-100 text-center">
+                        Endgeräte unserer Mitglieder
+                    </h3>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 text-center max-w-xl">
+                        Vergleicht den Anteil von Mobil- und Festgeräten auf Basis der zuletzt verwendeten Sitzungen.
+                    </p>
+                    <div data-chart-wrapper class="mt-4 w-full max-w-xl">
+                        <canvas
+                            id="deviceUsageChart"
+                            class="h-72 w-full {{ $hasDeviceUsage ? '' : 'opacity-50' }}"
+                            role="img"
+                            aria-labelledby="deviceUsageChartTitle deviceUsageChartSummary"
+                            aria-hidden="{{ $hasDeviceUsage ? 'false' : 'true' }}"
+                        ></canvas>
+                    </div>
+                    @if ($hasDeviceUsage)
+                        @php($totalDeviceUsage = max($deviceUsage->sum('value'), 1))
+                        <ul
+                            id="deviceUsageChartSummary"
+                            class="mt-5 w-full space-y-2 text-sm text-gray-700 dark:text-gray-300"
+                        >
+                            @foreach ($deviceUsage as $entry)
+                                @php($percentage = round(($entry['value'] / $totalDeviceUsage) * 100))
+                                <li class="flex items-center justify-between gap-2 rounded-lg bg-gray-50/80 px-3 py-2 dark:bg-gray-900/50">
+                                    <span class="font-medium">{{ $entry['label'] }}</span>
+                                    <span class="flex items-baseline gap-1">
+                                        <span class="font-semibold text-gray-900 dark:text-gray-100">{{ $entry['value'] }}</span>
+                                        <span class="text-xs text-gray-500 dark:text-gray-400" aria-hidden="true">{{ $percentage }}&nbsp;%</span>
+                                        <span class="sr-only">{{ $percentage }} Prozent</span>
+                                    </span>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @else
+                        <p
+                            id="deviceUsageChartSummary"
                             class="mt-5 text-sm text-gray-600 dark:text-gray-400 text-center"
                         >
                             Noch keine Login-Daten vorhanden.
@@ -245,6 +290,7 @@
         const activityTimeline = @json($activityTimeline);
         const browserUsageByBrowser = @json($browserUsageByBrowser);
         const browserUsageByFamily = @json($browserUsageByFamily);
+        const deviceUsage = @json($deviceUsage);
 
         const numberFormatter = new Intl.NumberFormat('de-DE');
         const isDarkMode = document.documentElement.classList.contains('dark');
@@ -414,6 +460,7 @@
 
         renderDoughnutChart('browserUsageChart', browserUsageByBrowser);
         renderDoughnutChart('browserFamilyChart', browserUsageByFamily);
+        renderDoughnutChart('deviceUsageChart', deviceUsage);
 
         const userSelect = document.getElementById('userSelect');
         const userVisitsEmptyMessage = document.getElementById('userVisitsEmptyMessage');

--- a/tests/Feature/AdminPageTest.php
+++ b/tests/Feature/AdminPageTest.php
@@ -157,16 +157,28 @@ class AdminPageTest extends TestCase
             'last_activity' => now()->timestamp,
         ]);
 
+        DB::table('sessions')->insert([
+            'id' => Str::uuid()->toString(),
+            'user_id' => $member->id,
+            'ip_address' => '127.0.0.1',
+            'user_agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, wie Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+            'payload' => 'test',
+            'last_activity' => now()->addSecond()->timestamp,
+        ]);
+
         $response = $this->actingAs($admin)->get('/admin/statistiken');
 
         $response->assertOk();
         $response->assertSee('Browsernutzung unserer Mitglieder');
         $response->assertSee('Beliebteste Browser');
         $response->assertSee('Browser-Familien');
+        $response->assertSee('Endgeräte unserer Mitglieder');
         $response->assertSeeText('Google Chrome');
         $response->assertSeeText('Safari');
         $response->assertSeeText('Chromium');
         $response->assertSeeText('WebKit');
+        $response->assertSeeText('Festgerät');
+        $response->assertSeeText('Mobilgerät');
         $response->assertDontSee('Noch keine Login-Daten vorhanden.');
     }
 }

--- a/tests/Feature/AdminPageTest.php
+++ b/tests/Feature/AdminPageTest.php
@@ -143,7 +143,7 @@ class AdminPageTest extends TestCase
             'id' => Str::uuid()->toString(),
             'user_id' => $admin->id,
             'ip_address' => '127.0.0.1',
-            'user_agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, wie Gecko) Chrome/122.0.0.0 Safari/537.36',
+            'user_agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
             'payload' => 'test',
             'last_activity' => now()->timestamp,
         ]);
@@ -152,7 +152,7 @@ class AdminPageTest extends TestCase
             'id' => Str::uuid()->toString(),
             'user_id' => $member->id,
             'ip_address' => '127.0.0.1',
-            'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, wie Gecko) Version/17.0 Safari/605.1.15',
+            'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
             'payload' => 'test',
             'last_activity' => now()->timestamp,
         ]);
@@ -161,7 +161,7 @@ class AdminPageTest extends TestCase
             'id' => Str::uuid()->toString(),
             'user_id' => $member->id,
             'ip_address' => '127.0.0.1',
-            'user_agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, wie Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+            'user_agent' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
             'payload' => 'test',
             'last_activity' => now()->addSecond()->timestamp,
         ]);

--- a/tests/Unit/BrowserStatsServiceTest.php
+++ b/tests/Unit/BrowserStatsServiceTest.php
@@ -38,6 +38,16 @@ class BrowserStatsServiceTest extends TestCase
         );
     }
 
+    public function test_detect_device_type_classifies_common_agents(): void
+    {
+        $service = app(BrowserStatsService::class);
+
+        $this->assertSame('Mobilgerät', $service->detectDeviceType('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'));
+        $this->assertSame('Mobilgerät', $service->detectDeviceType('Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.144 Mobile Safari/537.36'));
+        $this->assertSame('Festgerät', $service->detectDeviceType('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'));
+        $this->assertSame('Festgerät', $service->detectDeviceType(null));
+    }
+
     public function test_browser_usage_counts_latest_sessions_for_each_member(): void
     {
         $service = app(BrowserStatsService::class);
@@ -76,6 +86,7 @@ class BrowserStatsServiceTest extends TestCase
 
         $browserCounts = $usage['browserCounts']->pluck('value', 'label')->all();
         $familyCounts = $usage['familyCounts']->pluck('value', 'label')->all();
+        $deviceTypeCounts = $usage['deviceTypeCounts']->pluck('value', 'label')->all();
 
         $this->assertSame(1, $browserCounts['Google Chrome']);
         $this->assertSame(1, $browserCounts['Safari']);
@@ -83,5 +94,8 @@ class BrowserStatsServiceTest extends TestCase
 
         $this->assertSame(1, $familyCounts['Chromium']);
         $this->assertSame(1, $familyCounts['WebKit']);
+
+        $this->assertSame(1, $deviceTypeCounts['Festgerät']);
+        $this->assertSame(1, $deviceTypeCounts['Mobilgerät']);
     }
 }


### PR DESCRIPTION
This pull request adds device type statistics to the admin dashboard, allowing admins to see the distribution of mobile and desktop devices used by members in their latest sessions. The backend now detects device types from user agents, aggregates this data, and exposes it alongside browser statistics. The frontend displays this information as a new chart, and tests have been updated to cover the new functionality.

**Backend enhancements:**

* Added a new method `detectDeviceType` to `BrowserStatsService` to classify user agents as either 'Mobilgerät' (mobile device) or 'Festgerät' (desktop device).
* Updated `browserUsage` in `BrowserStatsService` to collect and return device type counts, and updated its return type documentation. [[1]](diffhunk://#diff-fd860f3e5daabcfb9abd613c94237a6fcbc63ac961ee0f6cc73216a761a61945L12-R18) [[2]](diffhunk://#diff-fd860f3e5daabcfb9abd613c94237a6fcbc63ac961ee0f6cc73216a761a61945R28-R30) [[3]](diffhunk://#diff-fd860f3e5daabcfb9abd613c94237a6fcbc63ac961ee0f6cc73216a761a61945R45-R54)
* Modified `AdminController@index` to pass the new `deviceUsage` data to the view.

**Frontend changes:**

* Added a third chart to the admin dashboard for device usage, including summary statistics and accessibility improvements. Adjusted layout to accommodate the new chart. [[1]](diffhunk://#diff-8e5c607808a978c97781cb5d023a4c72c35bece50d9bbc66d3b8e153bbf9fc85R53) [[2]](diffhunk://#diff-8e5c607808a978c97781cb5d023a4c72c35bece50d9bbc66d3b8e153bbf9fc85L67-R68) [[3]](diffhunk://#diff-8e5c607808a978c97781cb5d023a4c72c35bece50d9bbc66d3b8e153bbf9fc85R150-R193) [[4]](diffhunk://#diff-8e5c607808a978c97781cb5d023a4c72c35bece50d9bbc66d3b8e153bbf9fc85R293) [[5]](diffhunk://#diff-8e5c607808a978c97781cb5d023a4c72c35bece50d9bbc66d3b8e153bbf9fc85R463)

**Testing improvements:**

* Added new unit tests for device type detection and updated feature/unit tests to verify device statistics are shown and calculated correctly. [[1]](diffhunk://#diff-e9fad523ee6c1ad56fab650723906d10cc4ae46c6a9aac369f2525cda146cd1dR41-R50) [[2]](diffhunk://#diff-e9fad523ee6c1ad56fab650723906d10cc4ae46c6a9aac369f2525cda146cd1dR89-R99) [[3]](diffhunk://#diff-119b2ff3fba0e4ca4990e3f4366e30612dd5b288246d18e3fd6d198fa52e8d61R160-R181)