### PR TITLE
Refine membership form submission flow

### DIFF
--- a/app/Http/Controllers/MitgliedschaftController.php
+++ b/app/Http/Controllers/MitgliedschaftController.php
@@ -29,6 +29,7 @@ class MitgliedschaftController extends Controller
             'mitgliedsbeitrag' => 'required|numeric|min:12|max:120',
             'telefon' => 'nullable|string|max:20',
             'verein_gefunden' => 'nullable|string|max:255',
+            'satzung_check' => 'accepted',
         ]);
 
         $user = User::create([
@@ -60,9 +61,13 @@ class MitgliedschaftController extends Controller
         // Mailversand
         Mail::to($user->email)->queue(new MitgliedAntragEingereicht($user));
 
-        return response()->json([
-            'success' => true,
-            'message' => 'Mitgliedschaftsantrag erfolgreich eingereicht.'
-        ]);
+        if ($request->expectsJson()) {
+            return response()->json([
+                'success' => true,
+                'message' => 'Mitgliedschaftsantrag erfolgreich eingereicht.'
+            ]);
+        }
+
+        return redirect()->route('mitglied.werden.erfolgreich');
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -88,3 +88,8 @@ import './mitglieder/accessibility';
 import './mitglieder/map-utils';
 import './protokolle/accordion';
 import './kassenbuch/modals';
+import initMitgliedschaftForm from './mitgliedschaft/form';
+
+window.omxfc = window.omxfc || {};
+window.omxfc.initMitgliedschaftForm = (root = document, options = {}) =>
+    initMitgliedschaftForm(root, options);

--- a/resources/js/mitgliedschaft/form.js
+++ b/resources/js/mitgliedschaft/form.js
@@ -1,0 +1,345 @@
+const FIELD_RULES = {
+    vorname: { regex: /.+/, error: 'Vorname ist erforderlich.' },
+    nachname: { regex: /.+/, error: 'Nachname ist erforderlich.' },
+    strasse: { regex: /.+/, error: 'Straße ist erforderlich.' },
+    hausnummer: { regex: /.+/, error: 'Hausnummer ist erforderlich.' },
+    plz: { regex: /^\d{4,6}$/, error: 'Bitte gültige PLZ eingeben (4-6 Zahlen).' },
+    stadt: { regex: /.+/, error: 'Stadt ist erforderlich.' },
+    land: { regex: /^(Deutschland|Österreich|Schweiz)$/, error: 'Bitte wähle dein Land.' },
+    mail: { regex: /^[^@\s]+@[^@\s]+\.[^@\s]+$/, error: 'Bitte gültige Mailadresse eingeben.' },
+    passwort: { regex: /^.{6,}$/, error: 'Passwort mindestens 6 Zeichen.' },
+    passwort_confirmation: { matchWith: 'passwort', error: 'Passwörter stimmen nicht überein.' },
+    telefon: {
+        regex: /^(\+\d{1,3}\s?)?(\d{4,14})$/,
+        error: 'Bitte gültige Handynummer eingeben.',
+        optional: true,
+    },
+    verein_gefunden: {
+        regex: /^(Facebook|Instagram|Leserkontaktseite|Befreundete Person|Fantreffen\/MaddraxCon|Google|Sonstiges)$/,
+        error: 'Bitte wähle eine Option aus.',
+        optional: true,
+    },
+};
+
+function resolveDocument(root, customDocument) {
+    if (customDocument) {
+        return customDocument;
+    }
+
+    if (root?.ownerDocument) {
+        return root.ownerDocument;
+    }
+
+    return root ?? document;
+}
+
+export function createMitgliedschaftForm(root = document, options = {}) {
+    const win = options.window ?? window;
+    const fetchImpl = options.fetch ?? win.fetch;
+    const doc = resolveDocument(root, options.document);
+
+    const form = doc?.getElementById('mitgliedschaft-form');
+
+    if (!form || form.dataset.enhanced === 'true') {
+        return null;
+    }
+
+    const beitrag = doc.getElementById('mitgliedsbeitrag');
+    const beitragOutputId = beitrag?.dataset.outputTarget || 'beitrag-output';
+    const beitragOutput = doc.getElementById(beitragOutputId);
+    const satzungCheck = doc.getElementById('satzung_check');
+    const submitButton = doc.getElementById('submit-button');
+    const loadingIndicator = doc.getElementById('loading-indicator');
+    const messages = doc.getElementById('form-messages');
+    const csrfToken = () => doc.querySelector('meta[name="csrf-token"]')?.content ?? '';
+    const consoleRef = options.console ?? win.console;
+    const missingFieldWarnings = new Set();
+
+    const successUrl = form.dataset.successUrl || `${win.location.origin}/mitglied-werden/erfolgreich`;
+
+    function updateContributionOutput() {
+        if (!beitrag || !beitragOutput) {
+            return;
+        }
+
+        const prefix = beitrag.dataset.outputPrefix || '';
+        const suffix = beitrag.dataset.outputSuffix || '';
+        beitragOutput.textContent = `${prefix}${beitrag.value}${suffix}`;
+    }
+
+    function toggleSubmit() {
+        if (!submitButton) {
+            return;
+        }
+
+        const isCheckboxChecked = satzungCheck ? satzungCheck.checked : true;
+        submitButton.disabled = !isCheckboxChecked || !form.checkValidity();
+        submitButton.classList.toggle('opacity-50', submitButton.disabled);
+        submitButton.classList.toggle('cursor-not-allowed', submitButton.disabled);
+    }
+
+    function getErrorElement(id) {
+        return (
+            doc.getElementById(`error-${id}`) ||
+            doc.querySelector(`[data-error-for="${id}"]`)
+        );
+    }
+
+    function warnMissingField(id) {
+        if (missingFieldWarnings.has(id)) {
+            return;
+        }
+
+        missingFieldWarnings.add(id);
+
+        if (consoleRef && typeof consoleRef.warn === 'function') {
+            consoleRef.warn(
+                `[Mitgliedschaftsformular] Feld mit ID "${id}" wurde nicht gefunden. Bitte überprüfe die Formularstruktur.`,
+            );
+        }
+    }
+
+    function setFieldError(input, message) {
+        const errorElem = getErrorElement(input.id);
+
+        if (errorElem) {
+            errorElem.textContent = message;
+        }
+
+        if (message) {
+            input.setCustomValidity(message);
+            input.setAttribute('aria-invalid', 'true');
+            return false;
+        }
+
+        input.setCustomValidity('');
+        input.removeAttribute('aria-invalid');
+        return true;
+    }
+
+    function validateForm() {
+        let isValid = true;
+
+        for (const [id, rules] of Object.entries(FIELD_RULES)) {
+            const input = doc.getElementById(id);
+
+            if (!input) {
+                warnMissingField(id);
+                continue;
+            }
+
+            if (rules.optional && !input.value.trim()) {
+                setFieldError(input, '');
+                continue;
+            }
+
+            if (rules.matchWith) {
+                const matchElem = doc.getElementById(rules.matchWith);
+                const hasError = input.value !== (matchElem?.value ?? '');
+                isValid = setFieldError(input, hasError ? rules.error : '') && isValid;
+            } else {
+                const hasError = !rules.regex.test(input.value.trim());
+                isValid = setFieldError(input, hasError ? rules.error : '') && isValid;
+            }
+        }
+
+        toggleSubmit();
+        return isValid;
+    }
+
+    function setLoading(isLoading) {
+        if (!submitButton || !loadingIndicator) {
+            return;
+        }
+
+        if (isLoading) {
+            submitButton.disabled = true;
+            submitButton.classList.add('hidden');
+            loadingIndicator.classList.remove('hidden');
+            return;
+        }
+
+        loadingIndicator.classList.add('hidden');
+        submitButton.classList.remove('hidden');
+        toggleSubmit();
+    }
+
+    function showMessage(type, text) {
+        if (!messages) {
+            return;
+        }
+
+        const baseClasses = 'mb-4 p-4 border rounded';
+        const variants = {
+            error: `${baseClasses} bg-red-100 border-red-400 text-red-800`,
+            success: `${baseClasses} bg-green-100 border-green-400 text-green-800`,
+        };
+
+        messages.textContent = text;
+        messages.className = variants[type] ?? baseClasses;
+        messages.classList.remove('hidden');
+        messages.scrollIntoView({ behavior: 'smooth' });
+    }
+
+    function clearMessage() {
+        if (!messages) {
+            return;
+        }
+
+        messages.textContent = '';
+        messages.className = 'mb-4 hidden';
+    }
+
+    function submitWithFallback() {
+        setLoading(false);
+        form.submit();
+    }
+
+    async function handleSubmit(event) {
+        const canUseFetch = typeof fetchImpl === 'function';
+
+        if (canUseFetch) {
+            event?.preventDefault?.();
+        } else {
+            return;
+        }
+
+        if (!validateForm() || (satzungCheck && !satzungCheck.checked)) {
+            return;
+        }
+
+        clearMessage();
+        setLoading(true);
+
+        const formData = new FormData(form);
+
+        try {
+            const response = await fetchImpl(form.action || '/mitglied-werden', {
+                method: 'POST',
+                headers: {
+                    'X-CSRF-TOKEN': csrfToken(),
+                    Accept: 'application/json',
+                },
+                body: formData,
+                credentials: 'same-origin',
+            });
+
+            let result = null;
+
+            try {
+                result = await response.clone().json();
+            } catch (jsonError) {
+                if (consoleRef && typeof consoleRef.error === 'function') {
+                    consoleRef.error('JSON parsing error:', jsonError);
+                }
+            }
+
+            if ((response.ok && result?.success) || result?.success) {
+                win.location.assign(successUrl);
+                return;
+            }
+
+            if (response.status === 422 && result?.errors) {
+                for (const [field, messagesForField] of Object.entries(result.errors)) {
+                    const input = doc.getElementById(field);
+                    const message = Array.isArray(messagesForField)
+                        ? messagesForField.join(' ')
+                        : String(messagesForField ?? '');
+
+                    if (input) {
+                        setFieldError(input, message);
+                    } else {
+                        warnMissingField(field);
+                        const errorElem = getErrorElement(field);
+                        if (errorElem) {
+                            errorElem.textContent = message;
+                        }
+                    }
+                }
+
+                showMessage('error', 'Bitte korrigiere die markierten Felder.');
+                setLoading(false);
+                return;
+            }
+
+            showMessage('error', 'Unbekannter Fehler aufgetreten.');
+            setLoading(false);
+        } catch (error) {
+            if (error?.name === 'AbortError') {
+                submitWithFallback();
+                return;
+            }
+
+            showMessage('error', 'Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut.');
+
+            if (consoleRef && typeof consoleRef.error === 'function') {
+                consoleRef.error('Fehler:', error);
+            }
+
+            setLoading(false);
+        }
+    }
+
+    function init() {
+        if (form.dataset.enhanced === 'true') {
+            return null;
+        }
+
+        form.dataset.enhanced = 'true';
+
+        updateContributionOutput();
+
+        if (beitrag) {
+            beitrag.addEventListener('input', updateContributionOutput);
+        }
+
+        if (satzungCheck) {
+            satzungCheck.addEventListener('change', toggleSubmit);
+        }
+
+        form.addEventListener('input', validateForm);
+        form.addEventListener('submit', handleSubmit);
+
+        toggleSubmit();
+
+        return controller;
+    }
+
+    function destroy() {
+        if (beitrag) {
+            beitrag.removeEventListener('input', updateContributionOutput);
+        }
+
+        if (satzungCheck) {
+            satzungCheck.removeEventListener('change', toggleSubmit);
+        }
+
+        form.removeEventListener('input', validateForm);
+        form.removeEventListener('submit', handleSubmit);
+
+        delete form.dataset.enhanced;
+    }
+
+    const controller = {
+        init,
+        destroy,
+        validateForm,
+        toggleSubmit,
+        updateContributionOutput,
+        handleSubmit,
+    };
+
+    return controller;
+}
+
+export function initMitgliedschaftForm(root = document, options = {}) {
+    const controller = createMitgliedschaftForm(root, options);
+
+    if (!controller) {
+        return null;
+    }
+
+    return controller.init();
+}
+
+export default initMitgliedschaftForm;

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -62,5 +62,6 @@
 
     <!-- Alpine/JS -->
     @vite(['resources/js/app.js'])
+    @stack('scripts')
 </body>
 </html>

--- a/resources/views/pages/mitglied_werden.blade.php
+++ b/resources/views/pages/mitglied_werden.blade.php
@@ -3,7 +3,9 @@
         <h1 class="text-2xl sm:text-3xl font-bold text-[#8B0116] dark:text-[#ff4b63] mb-4 sm:mb-8">Mitglied werden</h1>
         <!-- Erfolg-/Fehlermeldungen -->
         <div id="form-messages" class="mb-4 hidden"></div>
-        <form id="mitgliedschaft-form" class="w-full">
+        <form id="mitgliedschaft-form" class="w-full" method="POST" action="{{ route('mitglied.store') }}"
+            data-success-url="{{ route('mitglied.werden.erfolgreich') }}">
+            @csrf
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
                 <x-forms.text-field name="vorname" label="Vorname" required class="w-full" autocomplete="given-name" />
 
@@ -67,7 +69,7 @@
 
                 <!-- Checkbox über volle Breite -->
                 <div class="col-span-1 md:col-span-2 flex items-start mt-2">
-                    <input type="checkbox" id="satzung_check" name="satzung_check"
+                    <input type="checkbox" id="satzung_check" name="satzung_check" required
                         class="mt-1 rounded border-gray-300 shadow-sm">
                     <label for="satzung_check" class="ml-2 text-sm">
                         Ich habe die <a href="{{ route('satzung') }}" target="_blank"
@@ -90,221 +92,11 @@
             </div>
         </form>
     </x-public-page>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const form = document.getElementById('mitgliedschaft-form');
-            const beitrag = document.getElementById('mitgliedsbeitrag');
-            const beitragOutputId = beitrag?.dataset.outputTarget || 'beitrag-output';
-            const beitragOutput = document.getElementById(beitragOutputId);
-            const beitragOutputPrefix = beitrag?.dataset.outputPrefix || '';
-            const beitragOutputSuffix = beitrag?.dataset.outputSuffix || '';
-            const satzungCheck = document.getElementById('satzung_check');
-            const submitButton = document.getElementById('submit-button');
-            const missingFieldWarnings = new Set();
-
-            const fields = {
-                vorname: { regex: /.+/, error: 'Vorname ist erforderlich.' },
-                nachname: { regex: /.+/, error: 'Nachname ist erforderlich.' },
-                strasse: { regex: /.+/, error: 'Straße ist erforderlich.' },
-                hausnummer: { regex: /.+/, error: 'Hausnummer ist erforderlich.' },
-                plz: { regex: /^\d{4,6}$/, error: 'Bitte gültige PLZ eingeben (4-6 Zahlen).' },
-                stadt: { regex: /.+/, error: 'Stadt ist erforderlich.' },
-                land: { regex: /^(Deutschland|Österreich|Schweiz)$/, error: 'Bitte wähle dein Land.' },
-                mail: { regex: /^[^@\s]+@[^@\s]+\.[^@\s]+$/, error: 'Bitte gültige Mailadresse eingeben.' },
-                passwort: { regex: /^.{6,}$/, error: 'Passwort mindestens 6 Zeichen.' },
-                passwort_confirmation: { matchWith: 'passwort', error: 'Passwörter stimmen nicht überein.' },
-                telefon: {
-                    regex: /^(\+\d{1,3}\s?)?(\d{4,14})$/,
-                    error: 'Bitte gültige Handynummer eingeben.',
-                    optional: true,
-                },
-                verein_gefunden: {
-                    regex: /^(Facebook|Instagram|Leserkontaktseite|Befreundete Person|Fantreffen\/MaddraxCon|Google|Sonstiges)$/,
-                    error: 'Bitte wähle eine Option aus.',
-                    optional: true,
-                },
-            };
-
-            function updateContributionOutput() {
-                if (!beitrag || !beitragOutput) {
-                    return;
-                }
-
-                beitragOutput.textContent = `${beitragOutputPrefix}${beitrag.value}${beitragOutputSuffix}`;
-            }
-
-            updateContributionOutput();
-
-            if (beitrag) {
-                beitrag.addEventListener('input', updateContributionOutput);
-            }
-
-            satzungCheck.addEventListener('change', toggleSubmit);
-            form.addEventListener('input', validateForm);
-            form.addEventListener('submit', handleSubmit);
-
-            function toggleSubmit() {
-                submitButton.disabled = !satzungCheck.checked || !form.checkValidity();
-                submitButton.classList.toggle('opacity-50', submitButton.disabled);
-                submitButton.classList.toggle('cursor-not-allowed', submitButton.disabled);
-            }
-
-            function getErrorElement(id) {
-                return (
-                    document.getElementById(`error-${id}`) ||
-                    document.querySelector(`[data-error-for="${id}"]`)
-                );
-            }
-
-            function warnMissingField(id) {
-                if (missingFieldWarnings.has(id)) {
-                    return;
-                }
-
-                missingFieldWarnings.add(id);
-
-                if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-                    console.warn(`[Mitgliedschaftsformular] Feld mit ID "${id}" wurde nicht gefunden. Bitte überprüfe die Formularstruktur.`);
-                }
-            }
-
-            function setFieldError(input, message) {
-                const errorElem = getErrorElement(input.id);
-
-                if (errorElem) {
-                    errorElem.textContent = message;
-                }
-
-                if (message) {
-                    input.setCustomValidity(message);
-                    input.setAttribute('aria-invalid', 'true');
-                    return false;
-                }
-
-                input.setCustomValidity('');
-                input.removeAttribute('aria-invalid');
-                return true;
-            }
-
-            function validateForm() {
-                let isValid = true;
-
-                for (const [id, rules] of Object.entries(fields)) {
-                    const input = document.getElementById(id);
-
-                    if (!input) {
-                        warnMissingField(id);
-                        continue;
-                    }
-
-                    if (rules.optional && !input.value.trim()) {
-                        setFieldError(input, '');
-                        continue;
-                    }
-
-                    if (rules.matchWith) {
-                        const matchElem = document.getElementById(rules.matchWith);
-                        const hasError = input.value !== matchElem.value;
-                        isValid = setFieldError(input, hasError ? rules.error : '') && isValid;
-                    } else {
-                        const hasError = !rules.regex.test(input.value.trim());
-                        isValid = setFieldError(input, hasError ? rules.error : '') && isValid;
-                    }
-                }
-
-                toggleSubmit();
-                return isValid;
-            }
-
-            async function handleSubmit(e) {
-                e.preventDefault();
-
-                if (!validateForm() || !satzungCheck.checked) {
-                    return;
-                }
-
-                const formData = new FormData(form);
-                const messages = document.getElementById('form-messages');
-                const submitButton = document.getElementById('submit-button');
-                const loadingIndicator = document.getElementById('loading-indicator');
-
-                // Button deaktivieren und Lade-Indikator zeigen
-                submitButton.disabled = true;
-                submitButton.classList.add('hidden');
-                loadingIndicator.classList.remove('hidden');
-
-                try {
-                    const response = await fetch('/mitglied-werden', {
-                        method: 'POST',
-                        headers: {
-                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-                            'Accept': 'application/json'
-                        },
-                        body: formData,
-                        credentials: 'same-origin'
-                    });
-
-                    let result = null;
-                    try {
-                        result = await response.json();
-                    } catch (jsonError) {
-                        console.error('JSON parsing error:', jsonError);
-                    }
-
-                    if ((response.ok && result && result.success) || (result && result.success)) {
-                        window.location.href = '/mitglied-werden/erfolgreich';
-                    } else if (response.status === 422 && result && result.errors) {
-                        // Serverseitige Validierungsfehler den jeweiligen Feldern zuordnen
-                        for (const [field, msgs] of Object.entries(result.errors)) {
-                            const input = document.getElementById(field);
-                            const message = msgs.join(' ');
-                            if (input) {
-                                setFieldError(input, message);
-                            } else {
-                                warnMissingField(field);
-                                const errorElem = getErrorElement(field);
-                                if (errorElem) {
-                                    errorElem.textContent = message;
-                                }
-                            }
-                        }
-
-                        messages.textContent = 'Bitte korrigiere die markierten Felder.';
-                        messages.className = 'mb-4 p-4 bg-red-100 border border-red-400 text-red-800 rounded';
-                        messages.classList.remove('hidden');
-                        messages.scrollIntoView({ behavior: 'smooth' });
-
-                        // Button und Indikator zurücksetzen bei Fehler
-                        submitButton.disabled = false;
-                        submitButton.classList.remove('hidden');
-                        loadingIndicator.classList.add('hidden');
-                    } else {
-                        messages.textContent = 'Unbekannter Fehler aufgetreten.';
-                        messages.className = 'mb-4 p-4 bg-red-100 border border-red-400 text-red-800 rounded';
-                        messages.classList.remove('hidden');
-                        messages.scrollIntoView({ behavior: 'smooth' });
-
-                        // Button und Indikator zurücksetzen bei Fehler
-                        submitButton.disabled = false;
-                        submitButton.classList.remove('hidden');
-                        loadingIndicator.classList.add('hidden');
-                    }
-                } catch (error) {
-                    messages.className = 'mb-4 p-4 bg-red-100 border border-red-400 text-red-800 rounded';
-                    messages.textContent = 'Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut.';
-                    messages.classList.remove('hidden');
-                    messages.scrollIntoView({ behavior: 'smooth' });
-                    console.error('Fehler:', error);
-
-                    // Button und Indikator zurücksetzen bei Fehler
-                    submitButton.disabled = false;
-                    submitButton.classList.remove('hidden');
-                    loadingIndicator.classList.add('hidden');
-                }
-            }
-
-            // Initialer Check beim Laden der Seite
-            toggleSubmit();
-        });
-    </script>
+    @push('scripts')
+        <script>
+            document.addEventListener('DOMContentLoaded', () => {
+                window.omxfc?.initMitgliedschaftForm?.();
+            });
+        </script>
+    @endpush
 </x-app-layout>

--- a/tests/Feature/MembershipMailTest.php
+++ b/tests/Feature/MembershipMailTest.php
@@ -17,7 +17,7 @@ class MembershipMailTest extends TestCase
     {
         Mail::fake();
 
-        $response = $this->post(route('mitglied.store'), [
+        $response = $this->postJson(route('mitglied.store'), [
             'vorname' => 'Test',
             'nachname' => 'Applicant',
             'strasse' => 'Teststr',
@@ -31,9 +31,10 @@ class MembershipMailTest extends TestCase
             'mitgliedsbeitrag' => 12,
             'telefon' => null,
             'verein_gefunden' => null,
+            'satzung_check' => 'on',
         ]);
 
-        $response->assertJson(['success' => true]);
+        $response->assertOk()->assertJson(['success' => true]);
 
         Mail::assertQueued(MitgliedAntragEingereicht::class, function ($mail) {
             return $mail->user->email === 'applicant@example.com';
@@ -61,6 +62,7 @@ class MembershipMailTest extends TestCase
             'mitgliedsbeitrag' => 12,
             'telefon' => null,
             'verein_gefunden' => null,
+            'satzung_check' => 'on',
         ]);
 
         $response->assertStatus(422);
@@ -89,6 +91,7 @@ class MembershipMailTest extends TestCase
             'mitgliedsbeitrag' => 12,
             'telefon' => null,
             'verein_gefunden' => null,
+            'satzung_check' => 'on',
         ]);
 
         $response->assertStatus(422);

--- a/tests/Feature/RegistrationTest.php
+++ b/tests/Feature/RegistrationTest.php
@@ -44,9 +44,11 @@ class RegistrationTest extends TestCase
             'mitgliedsbeitrag' => 12.00,
             'telefon' => null,
             'verein_gefunden' => null,
+            'satzung_check' => 'on',
         ]);
 
-        $response->assertJson(['success' => true]);
+        $response->assertRedirect(route('mitglied.werden.erfolgreich'));
+        $response->assertSessionHasNoErrors();
         $this->assertGuest();
     }
 
@@ -72,6 +74,7 @@ class RegistrationTest extends TestCase
             'mitgliedsbeitrag' => 12.00,
             'telefon' => null,
             'verein_gefunden' => null,
+            'satzung_check' => 'on',
         ]);
 
         $response->assertRedirect('/register');
@@ -96,11 +99,12 @@ class RegistrationTest extends TestCase
             'passwort' => '',
             'passwort_confirmation' => '',
             'mitgliedsbeitrag' => '',
+            'satzung_check' => null,
         ]);
 
         $response->assertRedirect('/mitglied-werden');
         $response->assertSessionHasErrors([
-            'vorname', 'nachname', 'strasse', 'hausnummer', 'plz', 'stadt', 'land', 'mail', 'passwort', 'mitgliedsbeitrag'
+            'vorname', 'nachname', 'strasse', 'hausnummer', 'plz', 'stadt', 'land', 'mail', 'passwort', 'mitgliedsbeitrag', 'satzung_check'
         ]);
     }
 }

--- a/tests/Vitest/mitgliedschaft/form.test.js
+++ b/tests/Vitest/mitgliedschaft/form.test.js
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initMitgliedschaftForm } from '../../../resources/js/mitgliedschaft/form';
+
+const ALL_FIELDS = [
+    'vorname',
+    'nachname',
+    'strasse',
+    'hausnummer',
+    'plz',
+    'stadt',
+    'land',
+    'mail',
+    'passwort',
+    'passwort_confirmation',
+    'mitgliedsbeitrag',
+    'telefon',
+    'verein_gefunden',
+];
+
+function buildFormHtml() {
+    return `
+        <meta name="csrf-token" content="csrf-token-value">
+        <div id="form-messages" class="hidden"></div>
+        <form id="mitgliedschaft-form" action="/mitglied-werden" data-success-url="/mitglied-werden/erfolgreich">
+            ${ALL_FIELDS.map((field) => {
+                if (field === 'mitgliedsbeitrag') {
+                    return `
+                        <label for="mitgliedsbeitrag"></label>
+                        <input id="mitgliedsbeitrag" value="12" data-output-target="beitrag-output" data-output-suffix="€">
+                        <span id="beitrag-output"></span>
+                    `;
+                }
+
+                if (field === 'passwort_confirmation') {
+                    return `<input id="passwort_confirmation" value="secret123">`;
+                }
+
+                if (field === 'telefon' || field === 'verein_gefunden') {
+                    return `<input id="${field}" value="">`;
+                }
+
+                if (field === 'land') {
+                    return `<select id="land"><option value="Deutschland" selected>Deutschland</option></select>`;
+                }
+
+                if (field === 'mail') {
+                    return `<input id="mail" type="email" value="max@example.com">`;
+                }
+
+                if (field === 'plz') {
+                    return `<input id="plz" value="12345">`;
+                }
+
+                return `<input id="${field}" value="secret123">`;
+            }).join('')}
+            <div class="col-span-2">
+                <input type="checkbox" id="satzung_check" required checked>
+            </div>
+            <button type="submit" id="submit-button" class="opacity-50 cursor-not-allowed" disabled>Antrag absenden</button>
+            <div id="loading-indicator" class="hidden"></div>
+        </form>
+    `;
+}
+
+function setupDom() {
+    document.body.innerHTML = buildFormHtml();
+
+    const form = document.getElementById('mitgliedschaft-form');
+    const submitButton = document.getElementById('submit-button');
+    const loadingIndicator = document.getElementById('loading-indicator');
+    const formMessages = document.getElementById('form-messages');
+    formMessages.scrollIntoView = vi.fn();
+
+    return { form, submitButton, loadingIndicator, formMessages };
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+});
+
+describe('initMitgliedschaftForm', () => {
+    it('submits via fetch and redirects on success', async () => {
+        const { form, submitButton, loadingIndicator } = setupDom();
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            clone: () => ({ json: () => Promise.resolve({ success: true }) }),
+        });
+        const assignMock = vi.fn();
+        const consoleMock = { warn: vi.fn(), error: vi.fn() };
+        const windowMock = { location: { assign: assignMock, origin: 'https://example.test' } };
+
+        initMitgliedschaftForm(document, {
+            fetch: fetchMock,
+            window: windowMock,
+            console: consoleMock,
+        });
+
+        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+        form.dispatchEvent(submitEvent);
+
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+        const [url, options] = fetchMock.mock.calls[0];
+        expect(url).toContain('/mitglied-werden');
+        expect(options.method).toBe('POST');
+
+        expect(submitButton.classList.contains('hidden')).toBe(true);
+        expect(loadingIndicator.classList.contains('hidden')).toBe(false);
+        await vi.waitFor(() =>
+            expect(assignMock).toHaveBeenCalledWith('/mitglied-werden/erfolgreich'),
+        );
+    });
+
+    it('resets the button state and shows errors when fetch fails', async () => {
+        const { form, submitButton, loadingIndicator, formMessages } = setupDom();
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            clone: () => ({ json: () => Promise.resolve({}) }),
+        });
+        const consoleMock = { warn: vi.fn(), error: vi.fn() };
+        const windowMock = { location: { assign: vi.fn(), origin: 'https://example.test' } };
+
+        initMitgliedschaftForm(document, {
+            fetch: fetchMock,
+            window: windowMock,
+            console: consoleMock,
+        });
+
+        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+        form.dispatchEvent(submitEvent);
+
+        await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+        await vi.waitFor(() => expect(submitButton.disabled).toBe(false));
+        expect(submitButton.classList.contains('hidden')).toBe(false);
+        expect(loadingIndicator.classList.contains('hidden')).toBe(true);
+        expect(formMessages.className).not.toContain('hidden');
+        expect(formMessages.textContent).toBe('Unbekannter Fehler aufgetreten.');
+    });
+
+    it('falls back to native submission when fetch is unavailable', () => {
+        const { form, submitButton } = setupDom();
+        const preventDefault = vi.fn();
+
+        const controller = initMitgliedschaftForm(document, {
+            fetch: undefined,
+            window: { location: { assign: vi.fn(), origin: 'https://example.test' } },
+            console: { warn: vi.fn(), error: vi.fn() },
+        });
+
+        expect(controller).not.toBeNull();
+
+        controller.handleSubmit({ preventDefault });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+        expect(submitButton.disabled).toBe(false);
+    });
+
+    it('submits the form natively when fetch is aborted', async () => {
+        const { form, submitButton, loadingIndicator } = setupDom();
+        const abortError = { name: 'AbortError' };
+        const fetchMock = vi.fn().mockRejectedValue(abortError);
+        const submitSpy = vi.spyOn(form, 'submit').mockImplementation(() => {});
+        const windowMock = { location: { assign: vi.fn(), origin: 'https://example.test' } };
+
+        initMitgliedschaftForm(document, {
+            fetch: fetchMock,
+            window: windowMock,
+            console: { warn: vi.fn(), error: vi.fn() },
+        });
+
+        const submitEvent = new Event('submit', { bubbles: true, cancelable: true });
+        form.dispatchEvent(submitEvent);
+
+        await vi.waitFor(() => expect(submitSpy).toHaveBeenCalledTimes(1));
+
+        expect(fetchMock).toHaveBeenCalled();
+        expect(submitButton.classList.contains('hidden')).toBe(false);
+        expect(loadingIndicator.classList.contains('hidden')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- convert the membership sign-up form to a POST submission with CSRF protection, success redirect metadata and stack-driven initialization
- replace the inline membership JavaScript with a Vite module that validates the form, handles fetch fallbacks and reuses the global app bundle
- require Satzung acceptance server-side and expand feature/Vitest coverage for registration, mail workflows and the new form module

## Testing
- php artisan test --filter=RegistrationTest
- php artisan test --filter=MembershipMailTest
- php artisan test --filter=MitgliedschaftControllerTest
- npm run test:vitest

------
https://chatgpt.com/codex/tasks/task_e_68d6159d4494832eb53035eaa55b6614