### PR TITLE
Add upload status tracking to audiobook roles

### DIFF
--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -8,6 +8,8 @@ use App\Models\AudiobookRole;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use App\Http\Requests\AudiobookEpisodeRequest;
 use App\Http\Requests\AudiobookPreviousSpeakerRequest;
 
@@ -139,6 +141,7 @@ class HoerbuchController extends Controller
                 'takes' => $role['takes'] ?? 0,
                 'user_id' => $role['member_id'] ?? null,
                 'speaker_name' => $role['member_name'] ?? null,
+                'uploaded' => ! empty($role['uploaded']),
             ]);
         }
 
@@ -201,6 +204,7 @@ class HoerbuchController extends Controller
                 'takes' => $role['takes'] ?? 0,
                 'user_id' => $role['member_id'] ?? null,
                 'speaker_name' => $role['member_name'] ?? null,
+                'uploaded' => ! empty($role['uploaded']),
             ]);
         }
         $episode->update([
@@ -223,6 +227,26 @@ class HoerbuchController extends Controller
         return response()->json([
             'speaker' => $speakers[$name] ?? null,
         ]);
+    }
+
+    /**
+     * Aktualisiert den Upload-Status einer Rolle.
+     */
+    public function updateRoleUploaded(Request $request, AudiobookRole $role): RedirectResponse|JsonResponse
+    {
+        $validated = $request->validate([
+            'uploaded' => ['required', 'boolean'],
+        ]);
+
+        $role->update(['uploaded' => (bool) $validated['uploaded']]);
+
+        if ($request->wantsJson()) {
+            return response()->json([
+                'uploaded' => $role->uploaded,
+            ]);
+        }
+
+        return back()->with('status', 'Upload-Status wurde aktualisiert.');
     }
 
     /**

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -141,7 +141,7 @@ class HoerbuchController extends Controller
                 'takes' => $role['takes'] ?? 0,
                 'user_id' => $role['member_id'] ?? null,
                 'speaker_name' => $role['member_name'] ?? null,
-                'uploaded' => ! empty($role['uploaded']),
+                'uploaded' => (bool) ($role['uploaded'] ?? false),
             ]);
         }
 
@@ -204,7 +204,7 @@ class HoerbuchController extends Controller
                 'takes' => $role['takes'] ?? 0,
                 'user_id' => $role['member_id'] ?? null,
                 'speaker_name' => $role['member_name'] ?? null,
-                'uploaded' => ! empty($role['uploaded']),
+                'uploaded' => (bool) ($role['uploaded'] ?? false),
             ]);
         }
         $episode->update([

--- a/app/Http/Requests/AudiobookEpisodeRequest.php
+++ b/app/Http/Requests/AudiobookEpisodeRequest.php
@@ -38,6 +38,7 @@ class AudiobookEpisodeRequest extends FormRequest
             'roles.*.takes' => 'required|integer|min:0',
             'roles.*.member_id' => 'nullable|exists:users,id',
             'roles.*.member_name' => 'nullable|string|max:255',
+            'roles.*.uploaded' => 'nullable|boolean',
         ];
     }
 }

--- a/app/Models/AudiobookRole.php
+++ b/app/Models/AudiobookRole.php
@@ -17,6 +17,11 @@ class AudiobookRole extends Model
         'takes',
         'user_id',
         'speaker_name',
+        'uploaded',
+    ];
+
+    protected $casts = [
+        'uploaded' => 'boolean',
     ];
 
     public function episode(): BelongsTo

--- a/database/migrations/2025_09_26_094551_add_uploaded_to_audiobook_roles_table.php
+++ b/database/migrations/2025_09_26_094551_add_uploaded_to_audiobook_roles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('audiobook_roles', function (Blueprint $table) {
+            $table->boolean('uploaded')->default(false)->after('speaker_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('audiobook_roles', function (Blueprint $table) {
+            $table->dropColumn('uploaded');
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -68,6 +68,7 @@ CREATE TABLE `audiobook_roles` (
   `takes` smallint(5) unsigned NOT NULL DEFAULT 0,
   `user_id` bigint(20) unsigned DEFAULT NULL,
   `speaker_name` varchar(255) DEFAULT NULL,
+  `uploaded` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
@@ -617,3 +618,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (43,'2025_09_21_000
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (44,'2025_09_22_000000_add_name_user_speaker_index_to_audiobook_roles_table',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (45,'2025_10_01_000000_update_book_type_enum',2);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (46,'2025_09_25_052816_create_member_client_snapshots_table',2);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (47,'2025_09_26_094551_add_uploaded_to_audiobook_roles_table',2);

--- a/resources/js/hoerbuch-role-form.js
+++ b/resources/js/hoerbuch-role-form.js
@@ -66,17 +66,23 @@ if (data) {
     function addRole() {
         const container = document.getElementById('roles_list');
         const wrapper = document.createElement('div');
-        wrapper.className = 'grid grid-cols-5 gap-2 mb-2 items-start role-row';
+        const checkboxId = `roles-${roleIndex}-uploaded`;
+        wrapper.className = 'grid grid-cols-1 md:grid-cols-5 gap-2 mb-2 items-start role-row';
         wrapper.innerHTML = `
-            <input type="text" name="roles[${roleIndex}][name]" placeholder="Rolle" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-            <input type="text" name="roles[${roleIndex}][description]" placeholder="Beschreibung" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-            <input type="number" name="roles[${roleIndex}][takes]" min="0" placeholder="Takes" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-            <div class="col-span-1">
+            <input type="text" name="roles[${roleIndex}][name]" placeholder="Rolle" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+            <input type="text" name="roles[${roleIndex}][description]" placeholder="Beschreibung" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+            <input type="number" name="roles[${roleIndex}][takes]" min="0" placeholder="Takes" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+            <div>
                 <input type="text" name="roles[${roleIndex}][member_name]" list="members" placeholder="Sprecher" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
                 <input type="hidden" name="roles[${roleIndex}][member_id]" />
+                <input type="hidden" name="roles[${roleIndex}][uploaded]" value="0" />
+                <label for="${checkboxId}" class="mt-2 inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                    <input id="${checkboxId}" type="checkbox" name="roles[${roleIndex}][uploaded]" value="1" class="rounded border-gray-300 dark:border-gray-600 text-[#8B0116] focus:ring-[#8B0116] dark:focus:ring-[#FF6B81]" />
+                    <span>Aufnahme hochgeladen</span>
+                </label>
                 <div class="text-xs text-gray-500 mt-1 previous-speaker"></div>
             </div>
-            <button type="button" class="col-span-1 text-red-600" aria-label="Remove">&times;</button>
+            <button type="button" class="text-red-600" aria-label="Remove">&times;</button>
         `;
         bindRoleRow(wrapper);
         container.appendChild(wrapper);

--- a/resources/js/hoerbuch-role-form.js
+++ b/resources/js/hoerbuch-role-form.js
@@ -1,8 +1,17 @@
-const data = window.roleFormData;
-if (data) {
-    const members = data.members || [];
-    const previousSpeakerUrl = data.previousSpeakerUrl;
-    let roleIndex = data.roleIndex || 0;
+const container = document.getElementById('roles_list');
+
+if (container) {
+    const datalistSelector = container.dataset.membersTarget;
+    const datalist = datalistSelector ? document.querySelector(datalistSelector) : null;
+    const members = datalist ? Array.from(datalist.options).map(option => ({
+        id: option.dataset.id,
+        name: option.value,
+    })) : [];
+    const previousSpeakerUrl = container.dataset.previousSpeakerUrl;
+    let roleIndex = Number.parseInt(container.dataset.roleIndex || container.querySelectorAll('.role-row').length || '0', 10);
+    if (Number.isNaN(roleIndex)) {
+        roleIndex = 0;
+    }
 
     function debounce(fn, delay = 300) {
         let timeout;
@@ -17,7 +26,16 @@ if (data) {
         const hidden = row.querySelector('input[type="hidden"]');
         const roleNameInput = row.querySelector('input[name$="[name]"]');
         const hint = row.querySelector('.previous-speaker');
+        const uploadCheckbox = row.querySelector('input[type="checkbox"][name$="[uploaded]"]');
+        const uploadHidden = row.querySelector('input[type="hidden"][name$="[uploaded]"]');
         let controller;
+
+        if (uploadCheckbox && uploadHidden) {
+            uploadHidden.disabled = uploadCheckbox.checked;
+            uploadCheckbox.addEventListener('change', () => {
+                uploadHidden.disabled = uploadCheckbox.checked;
+            });
+        }
 
         memberInput.addEventListener('input', e => {
             const option = members.find(m => m.name === e.target.value);
@@ -27,7 +45,7 @@ if (data) {
         function updateHint() {
             const name = roleNameInput.value.trim();
             controller?.abort();
-            if (!name) {
+            if (!name || !previousSpeakerUrl) {
                 hint.textContent = '';
                 return;
             }
@@ -64,7 +82,6 @@ if (data) {
     }
 
     function addRole() {
-        const container = document.getElementById('roles_list');
         const wrapper = document.createElement('div');
         const checkboxId = `roles-${roleIndex}-uploaded`;
         wrapper.className = 'grid grid-cols-1 md:grid-cols-5 gap-2 mb-2 items-start role-row';
@@ -90,5 +107,5 @@ if (data) {
     }
 
     document.getElementById('add_role')?.addEventListener('click', addRole);
-    document.querySelectorAll('#roles_list .role-row').forEach(bindRoleRow);
+    container.querySelectorAll('.role-row').forEach(bindRoleRow);
 }

--- a/resources/js/hoerbuch-role-upload-toggle.js
+++ b/resources/js/hoerbuch-role-upload-toggle.js
@@ -21,9 +21,7 @@ function initializeUploadToggles() {
                     form.requestSubmit();
                     return;
                 } catch (error) {
-                    if (!(error && error.name === 'NotImplementedError')) {
-                        throw error;
-                    }
+                    // Some legacy browsers expose requestSubmit but throw immediately.
                 }
             }
 

--- a/resources/js/hoerbuch-role-upload-toggle.js
+++ b/resources/js/hoerbuch-role-upload-toggle.js
@@ -1,0 +1,39 @@
+function initializeUploadToggles() {
+    document.querySelectorAll('form[data-auto-submit="change"]').forEach(form => {
+        const checkbox = form.querySelector('input[type="checkbox"]');
+        const hidden = form.querySelector('input[type="hidden"][name="uploaded"]');
+
+        if (!checkbox) {
+            return;
+        }
+
+        if (hidden) {
+            hidden.disabled = checkbox.checked;
+        }
+
+        checkbox.addEventListener('change', () => {
+            if (hidden) {
+                hidden.disabled = checkbox.checked;
+            }
+
+            if (typeof form.requestSubmit === 'function') {
+                try {
+                    form.requestSubmit();
+                    return;
+                } catch (error) {
+                    if (!(error && error.name === 'NotImplementedError')) {
+                        throw error;
+                    }
+                }
+            }
+
+            form.submit();
+        });
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeUploadToggles);
+} else {
+    initializeUploadToggles();
+}

--- a/resources/views/hoerbuecher/create.blade.php
+++ b/resources/views/hoerbuecher/create.blade.php
@@ -78,7 +78,12 @@
 
                 <div class="mb-6">
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Rollen</label>
-                    <div id="roles_list"></div>
+                    <div
+                        id="roles_list"
+                        data-members-target="#members"
+                        data-previous-speaker-url="{{ route('hoerbuecher.previous-speaker') }}"
+                        data-role-index="{{ count(old('roles', [])) }}"
+                    ></div>
                     <button type="button" id="add_role" class="mt-2 inline-flex items-center px-2 py-1 bg-gray-200 dark:bg-gray-600 rounded">Rolle hinzufügen</button>
                     <datalist id="members">
                         @foreach($users as $member)
@@ -105,12 +110,5 @@
             </form>
         </div>
     </x-member-page>
-    <script>
-        window.roleFormData = {
-            members: Array.from(document.querySelectorAll('#members option')).map(o => ({ id: o.dataset.id, name: o.value })),
-            previousSpeakerUrl: "{{ route('hoerbuecher.previous-speaker') }}",
-            roleIndex: 0,
-        };
-    </script>
     @vite(['resources/js/hoerbuch-role-form.js'])
 </x-app-layout>

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -79,7 +79,12 @@
 
                 <div class="mb-6">
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Rollen</label>
-                    <div id="roles_list">
+                    <div
+                        id="roles_list"
+                        data-members-target="#members"
+                        data-previous-speaker-url="{{ route('hoerbuecher.previous-speaker') }}"
+                        data-role-index="{{ count(old('roles', $episode->roles->toArray())) }}"
+                    >
                         @foreach(old('roles', $episode->roles->toArray()) as $i => $role)
                             @php($uploaded = $role['uploaded'] ?? false)
                             @php($checkboxId = 'roles-' . $i . '-uploaded')
@@ -137,12 +142,5 @@
             </form>
         </div>
     </x-member-page>
-    <script>
-        window.roleFormData = {
-            members: Array.from(document.querySelectorAll('#members option')).map(o => ({ id: o.dataset.id, name: o.value })),
-            previousSpeakerUrl: "{{ route('hoerbuecher.previous-speaker') }}",
-            roleIndex: document.querySelectorAll('#roles_list .role-row').length,
-        };
-    </script>
     @vite(['resources/js/hoerbuch-role-form.js'])
 </x-app-layout>

--- a/resources/views/hoerbuecher/edit.blade.php
+++ b/resources/views/hoerbuecher/edit.blade.php
@@ -81,19 +81,33 @@
                     <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Rollen</label>
                     <div id="roles_list">
                         @foreach(old('roles', $episode->roles->toArray()) as $i => $role)
-                            <div class="grid grid-cols-5 gap-2 mb-2 items-start role-row">
-                                <input type="text" name="roles[{{ $i }}][name]" value="{{ $role['name'] ?? '' }}" placeholder="Rolle" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                                <input type="text" name="roles[{{ $i }}][description]" value="{{ $role['description'] ?? '' }}" placeholder="Beschreibung" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                                <input type="number" name="roles[{{ $i }}][takes]" value="{{ $role['takes'] ?? 0 }}" min="0" placeholder="Takes" class="col-span-1 w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
-                                <div class="col-span-1">
+                            @php($uploaded = $role['uploaded'] ?? false)
+                            @php($checkboxId = 'roles-' . $i . '-uploaded')
+                            <div class="grid grid-cols-1 md:grid-cols-5 gap-2 mb-2 items-start role-row">
+                                <input type="text" name="roles[{{ $i }}][name]" value="{{ $role['name'] ?? '' }}" placeholder="Rolle" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+                                <input type="text" name="roles[{{ $i }}][description]" value="{{ $role['description'] ?? '' }}" placeholder="Beschreibung" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+                                <input type="number" name="roles[{{ $i }}][takes]" value="{{ $role['takes'] ?? 0 }}" min="0" placeholder="Takes" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
+                                <div>
                                     <input type="text" name="roles[{{ $i }}][member_name]" value="{{ $role['speaker_name'] ?? ($role['member_name'] ?? '') }}" list="members" placeholder="Sprecher" class="w-full rounded-md shadow-sm border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white focus:border-[#8B0116] dark:focus:border-[#FF6B81] focus:ring focus:ring-[#8B0116] dark:focus:ring-[#FF6B81] focus:ring-opacity-50" />
                                     <input type="hidden" name="roles[{{ $i }}][member_id]" value="{{ $role['user_id'] ?? ($role['member_id'] ?? '') }}" />
+                                    <input type="hidden" name="roles[{{ $i }}][uploaded]" value="0">
+                                    <label for="{{ $checkboxId }}" class="mt-2 inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                                        <input
+                                            id="{{ $checkboxId }}"
+                                            type="checkbox"
+                                            name="roles[{{ $i }}][uploaded]"
+                                            value="1"
+                                            {{ $uploaded ? 'checked' : '' }}
+                                            class="rounded border-gray-300 dark:border-gray-600 text-[#8B0116] focus:ring-[#8B0116] dark:focus:ring-[#FF6B81]"
+                                        >
+                                        <span>Aufnahme hochgeladen</span>
+                                    </label>
                                     @php($prev = $previousSpeakers[$role['name'] ?? ''] ?? null)
                                     <div class="text-xs text-gray-500 mt-1 previous-speaker">
                                         {{ $prev ? 'Bisheriger Sprecher: ' . $prev : '' }}
                                     </div>
                                 </div>
-                                <button type="button" class="col-span-1 text-red-600" aria-label="Remove">&times;</button>
+                                <button type="button" class="text-red-600" aria-label="Remove">&times;</button>
                             </div>
                         @endforeach
                     </div>

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -25,6 +25,7 @@
                     </div>
                 </div>
                 @if($episode->roles->isNotEmpty())
+                @php($canManageRoles = auth()->user()->hasVorstandRole() || auth()->user()->isOwnerOfTeam('AG Fanhörbücher'))
                 <div class="md:col-span-2">
                     <span class="font-medium">Rollen:</span>
                     <div class="mt-1 overflow-x-auto">
@@ -35,6 +36,7 @@
                                     <th class="px-2 py-1 text-left">Beschreibung</th>
                                     <th class="px-2 py-1 text-left">Takes</th>
                                     <th class="px-2 py-1 text-left">Sprecher</th>
+                                    <th class="px-2 py-1 text-left">Aufnahme hochgeladen</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -48,6 +50,33 @@
                                         @php($prev = $previousSpeakers[$role->name] ?? null)
                                         @if($prev)
                                             <div class="text-xs text-gray-500">Bisheriger Sprecher: {{ $prev }}</div>
+                                        @endif
+                                    </td>
+                                    <td class="px-2 py-1">
+                                        @if($canManageRoles)
+                                            <form action="{{ route('hoerbuecher.roles.uploaded', $role) }}" method="POST" data-auto-submit="change" class="inline-flex items-center gap-2">
+                                                @csrf
+                                                @method('PATCH')
+                                                <input type="hidden" name="uploaded" value="0">
+                                                @php($checkboxId = 'uploaded-role-' . $role->id)
+                                                <label for="{{ $checkboxId }}" class="inline-flex items-center gap-2 text-gray-700 dark:text-gray-300">
+                                                    <input
+                                                        id="{{ $checkboxId }}"
+                                                        type="checkbox"
+                                                        name="uploaded"
+                                                        value="1"
+                                                        {{ $role->uploaded ? 'checked' : '' }}
+                                                        class="rounded border-gray-300 dark:border-gray-600 text-[#8B0116] focus:ring-[#8B0116] dark:focus:ring-[#FF6B81]"
+                                                        aria-describedby="{{ $checkboxId }}-hint"
+                                                    >
+                                                    <span id="{{ $checkboxId }}-hint" class="text-sm">Hochgeladen</span>
+                                                </label>
+                                                <button type="submit" class="sr-only">Status speichern</button>
+                                            </form>
+                                        @else
+                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium {{ $role->uploaded ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-300' }}">
+                                                {{ $role->uploaded ? 'Ja' : 'Nein' }}
+                                            </span>
                                         @endif
                                     </td>
                                 </tr>
@@ -75,4 +104,26 @@
             </div>
         </div>
     </x-member-page>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            document.querySelectorAll('form[data-auto-submit="change"]').forEach(form => {
+                const checkbox = form.querySelector('input[type="checkbox"]');
+                const hidden = form.querySelector('input[type="hidden"][name="uploaded"]');
+                if (!checkbox) {
+                    return;
+                }
+
+                if (hidden) {
+                    hidden.disabled = checkbox.checked;
+                }
+
+                checkbox.addEventListener('change', () => {
+                    if (hidden) {
+                        hidden.disabled = checkbox.checked;
+                    }
+                    form.submit();
+                });
+            });
+        });
+    </script>
 </x-app-layout>

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -104,26 +104,5 @@
             </div>
         </div>
     </x-member-page>
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            document.querySelectorAll('form[data-auto-submit="change"]').forEach(form => {
-                const checkbox = form.querySelector('input[type="checkbox"]');
-                const hidden = form.querySelector('input[type="hidden"][name="uploaded"]');
-                if (!checkbox) {
-                    return;
-                }
-
-                if (hidden) {
-                    hidden.disabled = checkbox.checked;
-                }
-
-                checkbox.addEventListener('change', () => {
-                    if (hidden) {
-                        hidden.disabled = checkbox.checked;
-                    }
-                    form.submit();
-                });
-            });
-        });
-    </script>
+    @vite(['resources/js/hoerbuch-role-upload-toggle.js'])
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -118,6 +118,7 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::middleware('hoerbuch-manage')->group(function () {
             Route::get('erstellen', 'create')->name('create');
             Route::post('/', 'store')->name('store');
+            Route::patch('rollen/{role}/hochgeladen', 'updateRoleUploaded')->name('roles.uploaded');
             Route::get('{episode}/bearbeiten', 'edit')->name('edit');
             Route::put('{episode}', 'update')->name('update');
             Route::delete('{episode}', 'destroy')->name('destroy');

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -79,8 +79,8 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => $responsible->id,
             'progress' => 50,
             'roles' => [
-                ['name' => 'R1', 'description' => 'Desc1', 'takes' => 3, 'member_name' => 'Extern', 'uploaded' => true],
-                ['name' => 'R2', 'description' => 'Desc2', 'takes' => 2, 'member_id' => $responsible->id],
+                ['name' => 'R1', 'description' => 'Desc1', 'takes' => 3, 'member_name' => 'Extern', 'uploaded' => '1'],
+                ['name' => 'R2', 'description' => 'Desc2', 'takes' => 2, 'member_id' => $responsible->id, 'uploaded' => '0'],
             ],
             'notes' => 'Bemerkung',
         ];
@@ -541,7 +541,7 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => null,
             'progress' => 100,
             'roles' => [
-                ['name' => 'Neue Rolle', 'description' => 'desc', 'takes' => 1, 'member_name' => 'Extern'],
+                ['name' => 'Neue Rolle', 'description' => 'desc', 'takes' => 1, 'member_name' => 'Extern', 'uploaded' => '1'],
             ],
             'notes' => 'Aktualisiert',
         ];
@@ -560,6 +560,12 @@ class HoerbuchControllerTest extends TestCase
             'roles_total' => 1,
             'roles_filled' => 1,
             'notes' => 'Aktualisiert',
+        ]);
+
+        $this->assertDatabaseHas('audiobook_roles', [
+            'episode_id' => $episode->id,
+            'name' => 'Neue Rolle',
+            'uploaded' => true,
         ]);
     }
 

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -79,7 +79,7 @@ class HoerbuchControllerTest extends TestCase
             'responsible_user_id' => $responsible->id,
             'progress' => 50,
             'roles' => [
-                ['name' => 'R1', 'description' => 'Desc1', 'takes' => 3, 'member_name' => 'Extern'],
+                ['name' => 'R1', 'description' => 'Desc1', 'takes' => 3, 'member_name' => 'Extern', 'uploaded' => true],
                 ['name' => 'R2', 'description' => 'Desc2', 'takes' => 2, 'member_id' => $responsible->id],
             ],
             'notes' => 'Bemerkung',
@@ -102,6 +102,17 @@ class HoerbuchControllerTest extends TestCase
         ]);
 
         $this->assertDatabaseCount('audiobook_roles', 2);
+        $episodeId = AudiobookEpisode::where('episode_number', 'F30')->value('id');
+        $this->assertDatabaseHas('audiobook_roles', [
+            'episode_id' => $episodeId,
+            'name' => 'R1',
+            'uploaded' => true,
+        ]);
+        $this->assertDatabaseHas('audiobook_roles', [
+            'episode_id' => $episodeId,
+            'name' => 'R2',
+            'uploaded' => false,
+        ]);
     }
 
     public function test_vorstand_can_store_episode(): void
@@ -764,6 +775,83 @@ class HoerbuchControllerTest extends TestCase
         $this->actingAs($user)
             ->get(route('hoerbuecher.create'))
             ->assertOk();
+    }
+
+    public function test_ag_leader_can_toggle_role_uploaded(): void
+    {
+        $leader = $this->actingAgLeader();
+
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F99',
+            'title' => 'Upload Test',
+            'author' => 'Autor',
+            'planned_release_date' => '01.01.2026',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+
+        $role = AudiobookRole::create([
+            'episode_id' => $episode->id,
+            'name' => 'Testrolle',
+            'description' => null,
+            'takes' => 0,
+            'user_id' => null,
+            'speaker_name' => 'Speaker',
+            'uploaded' => false,
+        ]);
+
+        $this->actingAs($leader)
+            ->from(route('hoerbuecher.show', $episode))
+            ->patch(route('hoerbuecher.roles.uploaded', $role), ['uploaded' => true])
+            ->assertRedirect();
+
+        $this->assertTrue($role->fresh()->uploaded);
+
+        $this->actingAs($leader)
+            ->from(route('hoerbuecher.show', $episode))
+            ->patch(route('hoerbuecher.roles.uploaded', $role), ['uploaded' => false])
+            ->assertRedirect();
+
+        $this->assertFalse($role->fresh()->uploaded);
+    }
+
+    public function test_ag_member_cannot_toggle_role_uploaded(): void
+    {
+        $member = $this->actingAgMember();
+
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F98',
+            'title' => 'Upload Forbidden',
+            'author' => 'Autor',
+            'planned_release_date' => '01.02.2026',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 0,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+
+        $role = AudiobookRole::create([
+            'episode_id' => $episode->id,
+            'name' => 'Verboten',
+            'description' => null,
+            'takes' => 0,
+            'user_id' => null,
+            'speaker_name' => 'Speaker',
+            'uploaded' => false,
+        ]);
+
+        $this->actingAs($member)
+            ->from(route('hoerbuecher.show', $episode))
+            ->patch(route('hoerbuecher.roles.uploaded', $role), ['uploaded' => true])
+            ->assertForbidden();
+
+        $this->assertFalse($role->fresh()->uploaded);
     }
 
     public function test_previous_speaker_endpoint_returns_last_assigned_member(): void

--- a/tests/Jest/hoerbuch-role-upload-toggle.test.js
+++ b/tests/Jest/hoerbuch-role-upload-toggle.test.js
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+
+describe('hoerbuch role upload toggle module', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <form data-auto-submit="change">
+        <input type="hidden" name="uploaded" value="0" />
+        <input type="checkbox" />
+      </form>
+    `;
+  });
+
+  test('disables hidden input when checkbox is checked and submits form', async () => {
+    const form = document.querySelector('form');
+    const hidden = form.querySelector('input[type="hidden"]');
+    const checkbox = form.querySelector('input[type="checkbox"]');
+    form.requestSubmit = undefined;
+    form.submit = jest.fn();
+
+    await import('../../resources/js/hoerbuch-role-upload-toggle.js');
+
+    expect(hidden.disabled).toBe(false);
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(hidden.disabled).toBe(true);
+    expect(form.submit).toHaveBeenCalledTimes(1);
+  });
+
+  test('uses requestSubmit when available', async () => {
+    const form = document.querySelector('form');
+    const hidden = form.querySelector('input[type="hidden"]');
+    const checkbox = form.querySelector('input[type="checkbox"]');
+    form.requestSubmit = jest.fn();
+    form.submit = jest.fn();
+
+    await import('../../resources/js/hoerbuch-role-upload-toggle.js');
+
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(hidden.disabled).toBe(true);
+    expect(form.requestSubmit).toHaveBeenCalledTimes(1);
+    expect(form.submit).not.toHaveBeenCalled();
+  });
+});

--- a/tests/Jest/hoerbuch-role-upload-toggle.test.js
+++ b/tests/Jest/hoerbuch-role-upload-toggle.test.js
@@ -44,4 +44,21 @@ describe('hoerbuch role upload toggle module', () => {
     expect(form.requestSubmit).toHaveBeenCalledTimes(1);
     expect(form.submit).not.toHaveBeenCalled();
   });
+
+  test('falls back to submit when requestSubmit throws', async () => {
+    const form = document.querySelector('form');
+    const checkbox = form.querySelector('input[type="checkbox"]');
+    form.requestSubmit = jest.fn(() => {
+      throw new Error('unsupported');
+    });
+    form.submit = jest.fn();
+
+    await import('../../resources/js/hoerbuch-role-upload-toggle.js');
+
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(form.requestSubmit).toHaveBeenCalledTimes(1);
+    expect(form.submit).toHaveBeenCalledTimes(1);
+  });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
                 'resources/js/changelog.js',
                 'resources/js/hoerbuecher.js',
                 'resources/js/hoerbuch-role-form.js',
+                'resources/js/hoerbuch-role-upload-toggle.js',
             ],
             refresh: true,
             // Explizit den public-Pfad setzen


### PR DESCRIPTION
This pull request introduces an "uploaded" status for audiobook roles, allowing the system to track whether a recording has been uploaded for each role. The changes span the backend (database, models, controllers, validation), frontend forms, and JavaScript logic to support this new feature in both creation and editing of audiobook episodes.

**Key changes include:**

**Backend & Database:**

- Added a new boolean `uploaded` column to the `audiobook_roles` table, including migration and schema updates. (`database/migrations/2025_09_26_094551_add_uploaded_to_audiobook_roles_table.php`, `database/schema/mysql-schema.sql`) [[1]](diffhunk://#diff-019aadf0e83422daf028d1d0400e668f18ad26cf0f6e4ba0fd782918e166077aR1-R28) [[2]](diffhunk://#diff-9f611797ecac538e43ae8149ee92ced6b58c8587375deb6f505d395312288643R71) [[3]](diffhunk://#diff-9f611797ecac538e43ae8149ee92ced6b58c8587375deb6f505d395312288643R621)
- Updated the `AudiobookRole` model to include the `uploaded` attribute as fillable and cast it to boolean. (`app/Models/AudiobookRole.php`)
- Modified the `HoerbuchController` to handle the `uploaded` field when storing and updating roles, and added a new `updateRoleUploaded` method for updating the upload status via API or form submission. (`app/Http/Controllers/HoerbuchController.php`) [[1]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdR144) [[2]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdR207) [[3]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdR232-R251)
- Updated validation rules to allow the `uploaded` field in role data. (`app/Http/Requests/AudiobookEpisodeRequest.php`)

**Frontend (Forms & JS):**

- Enhanced the role creation and edit forms to include a checkbox for marking a role as "uploaded", including proper handling of the checkbox and hidden input for form submission. (`resources/views/hoerbuecher/create.blade.php`, `resources/views/hoerbuecher/edit.blade.php`, `resources/js/hoerbuch-role-form.js`) [[1]](diffhunk://#diff-8e28b6fec934859bc265eb37fcf51b3b26984bef31410eadc5a951785e27c6e7L82-R115) [[2]](diffhunk://#diff-8e28b6fec934859bc265eb37fcf51b3b26984bef31410eadc5a951785e27c6e7L126-L132) [[3]](diffhunk://#diff-13cfb60cd8d7ae7c6a2bab580893097dc1b200140291c0b66fa258f153adb28bL81-R86) [[4]](diffhunk://#diff-13cfb60cd8d7ae7c6a2bab580893097dc1b200140291c0b66fa258f153adb28bL108-L114) [[5]](diffhunk://#diff-d9ce304b18849e9a13782d40fb59316ee62ef3d87b192a32ec912c0d977242e3L1-R14) [[6]](diffhunk://#diff-d9ce304b18849e9a13782d40fb59316ee62ef3d87b192a32ec912c0d977242e3R29-R39) [[7]](diffhunk://#diff-d9ce304b18849e9a13782d40fb59316ee62ef3d87b192a32ec912c0d977242e3L30-R48) [[8]](diffhunk://#diff-d9ce304b18849e9a13782d40fb59316ee62ef3d87b192a32ec912c0d977242e3L67-R110)
- Refactored JS logic to dynamically extract member data and previous speaker URLs from the DOM instead of relying on global variables, improving maintainability. (`resources/js/hoerbuch-role-form.js`, `resources/views/hoerbuecher/create.blade.php`, `resources/views/hoerbuecher/edit.blade.php`) [[1]](diffhunk://#diff-d9ce304b18849e9a13782d40fb59316ee62ef3d87b192a32ec912c0d977242e3L1-R14) [[2]](diffhunk://#diff-13cfb60cd8d7ae7c6a2bab580893097dc1b200140291c0b66fa258f153adb28bL108-L114) [[3]](diffhunk://#diff-8e28b6fec934859bc265eb37fcf51b3b26984bef31410eadc5a951785e27c6e7L126-L132)
- Added a new JS file to auto-submit forms when the "uploaded" checkbox is toggled, supporting both modern and legacy browsers. (`resources/js/hoerbuch-role-upload-toggle.js`)

**Other:**

- Minor UI adjustments to role forms for improved layout and accessibility. (`resources/views/hoerbuecher/edit.blade.php`, `resources/js/hoerbuch-role-form.js`) [[1]](diffhunk://#diff-8e28b6fec934859bc265eb37fcf51b3b26984bef31410eadc5a951785e27c6e7L82-R115) [[2]](diffhunk://#diff-d9ce304b18849e9a13782d40fb59316ee62ef3d87b192a32ec912c0d977242e3L67-R110)
- Prepared the show view for potential role management enhancements. (`resources/views/hoerbuecher/show.blade.php`)