### PR TITLE
Add daily active users card to admin statistics dashboard

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -155,7 +155,7 @@ class AdminController extends Controller
         }
 
         $raw = $baseQuery
-            ->where('created_at', '>=', now()->subDays(29)->startOfDay())
+            ->where('created_at', '>=', Carbon::now()->subDays(29)->startOfDay())
             ->groupBy('visit_date')
             ->orderByDesc('visit_date')
             ->get();

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -145,16 +145,8 @@ class AdminController extends Controller
 
     private function dailyActiveUsers(): array
     {
-        $driver = DB::getDriverName();
-
-        $baseQuery = PageVisit::query();
-        if ($driver === 'sqlite') {
-            $baseQuery->selectRaw('date(created_at) as visit_date, COUNT(DISTINCT user_id) as total');
-        } else {
-            $baseQuery->selectRaw('DATE(created_at) as visit_date, COUNT(DISTINCT user_id) as total');
-        }
-
-        $raw = $baseQuery
+        $raw = PageVisit::query()
+            ->selectRaw('DATE(created_at) as visit_date, COUNT(DISTINCT user_id) as total')
             ->where('created_at', '>=', Carbon::now()->subDays(29)->startOfDay())
             ->groupBy('visit_date')
             ->orderByDesc('visit_date')

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -2,7 +2,7 @@
     <x-member-page>
         <h1 class="text-2xl font-semibold text-[#8B0116] dark:text-[#FCA5A5] mb-6">Seitenaufrufe</h1>
 
-        <div class="grid gap-8 lg:grid-cols-3">
+        <div class="grid gap-8 lg:grid-cols-4">
             @php($hasRouteData = $visitData->isNotEmpty())
             <section
                 class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6 flex flex-col justify-between"
@@ -19,8 +19,95 @@
                 </p>
             </section>
 
+            @php($dailyActiveSeries = collect($dailyActiveUsers['series']))
+            @php($recentDailyActiveSeries = $dailyActiveSeries->slice(-7)->values())
+            @php($recentDailyActiveMax = max($recentDailyActiveSeries->max('total') ?? 0, 1))
             <section
-                class="lg:col-span-2 bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6"
+                class="bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6 flex flex-col"
+                aria-labelledby="daily-active-users-heading"
+                aria-describedby="daily-active-users-description"
+            >
+                <div>
+                    <h2 id="daily-active-users-heading" class="text-lg font-semibold text-[#8B0116] dark:text-[#FCA5A5]">
+                        Daily Active Users
+                    </h2>
+                    <p class="mt-6 text-4xl font-bold text-gray-900 dark:text-gray-100">
+                        {{ number_format($dailyActiveUsers['today'], 0, ',', '.') }}
+                    </p>
+                    <p id="daily-active-users-description" class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Aktive Mitglieder heute (einzigartige Logins).
+                    </p>
+                    @php($trendPositive = $dailyActiveUsers['trend'] > 0)
+                    @php($trendNegative = $dailyActiveUsers['trend'] < 0)
+                    @if($trendPositive || $trendNegative)
+                        <p class="mt-4 inline-flex items-center gap-2 text-sm {{ $trendPositive ? 'text-emerald-600' : 'text-rose-500' }}">
+                            <span aria-hidden="true" class="flex h-6 w-6 items-center justify-center rounded-full bg-current/10">
+                                @if($trendPositive)
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
+                                        <path fill-rule="evenodd" d="M10 3a1 1 0 0 1 .832.445l5 7a1 1 0 0 1-1.664 1.11L11 6.882V16a1 1 0 1 1-2 0V6.882l-3.168 4.673a1 1 0 1 1-1.664-1.11l5-7A1 1 0 0 1 10 3Z" clip-rule="evenodd" />
+                                    </svg>
+                                @else
+                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
+                                        <path fill-rule="evenodd" d="M10 17a1 1 0 0 1-.832-.445l-5-7a1 1 0 0 1 1.664-1.11L9 13.118V4a1 1 0 1 1 2 0v9.118l3.168-4.673a1 1 0 1 1 1.664 1.11l-5 7A1 1 0 0 1 10 17Z" clip-rule="evenodd" />
+                                    </svg>
+                                @endif
+                            </span>
+                            <span>
+                                {{ abs($dailyActiveUsers['trend']) }}
+                                {{ $trendPositive ? 'mehr' : 'weniger' }}
+                                aktive Mitglieder als gestern.
+                            </span>
+                            <span class="sr-only">Im Vergleich zu gestern.</span>
+                        </p>
+                    @else
+                        <p class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                            Genau so viele aktive Mitglieder wie gestern.
+                        </p>
+                    @endif
+                </div>
+
+                <dl class="mt-6 grid grid-cols-1 gap-3 text-sm text-gray-600 dark:text-gray-400">
+                    <div class="flex items-center justify-between">
+                        <dt>Gestern</dt>
+                        <dd class="font-semibold text-gray-900 dark:text-gray-100">
+                            {{ number_format($dailyActiveUsers['yesterday'], 0, ',', '.') }}
+                        </dd>
+                    </div>
+                    <div class="flex items-center justify-between">
+                        <dt>7-Tage-Schnitt</dt>
+                        <dd class="font-semibold text-gray-900 dark:text-gray-100">
+                            {{ number_format($dailyActiveUsers['seven_day_average'], 1, ',', '.') }}
+                        </dd>
+                    </div>
+                </dl>
+
+                <div class="mt-6" aria-hidden="true">
+                    @if($recentDailyActiveSeries->isEmpty())
+                        <p class="text-sm text-gray-500 dark:text-gray-400 text-center">
+                            Noch keine Login-Daten vorhanden.
+                        </p>
+                    @else
+                        <ul class="flex items-end justify-between gap-1 h-24">
+                            @foreach ($recentDailyActiveSeries as $entry)
+                                @php($barHeight = $recentDailyActiveMax > 0 ? (int) round(($entry['total'] / $recentDailyActiveMax) * 100) : 0)
+                                @php($dayLabel = \Carbon\Carbon::parse($entry['date'])->translatedFormat('D'))
+                                <li class="flex-1 flex flex-col items-center text-[11px] text-gray-500 dark:text-gray-400">
+                                    <span class="flex h-full w-full items-end">
+                                        <span
+                                            class="w-full rounded-t-md {{ $entry['total'] === 0 ? 'bg-gray-200 dark:bg-gray-700' : 'bg-gradient-to-t from-[#8B0116]/30 to-[#8B0116]' }}"
+                                            style="height: {{ $entry['total'] === 0 ? '4px' : max($barHeight, 12) . '%' }}"
+                                        ></span>
+                                    </span>
+                                    <span class="mt-1 block text-[10px] uppercase tracking-wide">{{ $dayLabel }}</span>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </div>
+            </section>
+
+            <section
+                class="lg:col-span-2 xl:col-span-2 bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6"
                 aria-labelledby="route-visits-heading"
             >
                 <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-2 mb-4">

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -107,7 +107,7 @@
             </section>
 
             <section
-                class="lg:col-span-2 xl:col-span-2 bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6"
+                class="lg:col-span-2 bg-white dark:bg-gray-800 overflow-hidden shadow-xl sm:rounded-lg p-6"
                 aria-labelledby="route-visits-heading"
             >
                 <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-2 mb-4">

--- a/tests/Feature/AdminPageTest.php
+++ b/tests/Feature/AdminPageTest.php
@@ -91,6 +91,8 @@ class AdminPageTest extends TestCase
 
         $response->assertOk();
         $response->assertViewHas('homepageVisits', 3);
+        $response->assertSee('lg:col-span-2 bg-white', false);
+        $response->assertDontSee('xl:col-span-2', false);
 
         $response->assertViewHas('visitData', function ($data) {
             $collection = collect($data);

--- a/tests/Feature/AdminPageTest.php
+++ b/tests/Feature/AdminPageTest.php
@@ -91,8 +91,8 @@ class AdminPageTest extends TestCase
 
         $response->assertOk();
         $response->assertViewHas('homepageVisits', 3);
-        $response->assertSee('lg:col-span-2 bg-white', false);
-        $response->assertDontSee('xl:col-span-2', false);
+        $response->assertSeeText('Seitenaufrufe nach Route');
+        $response->assertSee('aria-labelledby="route-visits-heading"', false);
 
         $response->assertViewHas('visitData', function ($data) {
             $collection = collect($data);


### PR DESCRIPTION
This pull request adds a new "Daily Active Users" statistics card to the admin dashboard, showing unique logins per day, their trends, and a 7-day average. It includes backend logic to calculate these stats, updates the admin view to display them, and introduces a feature test to ensure correct behavior.

**New feature: Daily Active Users statistics**

* Added a `dailyActiveUsers()` method to `AdminController` that calculates unique daily logins for the past 30 days, including today's count, yesterday's count, 7-day average, trend, and a time series for charting. (`app/Http/Controllers/AdminController.php`) [[1]](diffhunk://#diff-1c6494e1e9cbdc520eac89f9be1dcaff36c5a7aad7d0efaf22beddb70d8c1dc5R129-R130) [[2]](diffhunk://#diff-1c6494e1e9cbdc520eac89f9be1dcaff36c5a7aad7d0efaf22beddb70d8c1dc5R139-R197)
* Passed the computed `dailyActiveUsers` data to the admin dashboard view. (`app/Http/Controllers/AdminController.php`)

**Admin dashboard UI updates**

* Updated `admin/index.blade.php` to add a new card displaying daily active users, their trend compared to yesterday, the 7-day average, and a mini bar chart for the last 7 days. The dashboard grid was expanded from 3 to 4 columns to accommodate the new card. (`resources/views/admin/index.blade.php`) [[1]](diffhunk://#diff-8e5c607808a978c97781cb5d023a4c72c35bece50d9bbc66d3b8e153bbf9fc85L5-R5) [[2]](diffhunk://#diff-8e5c607808a978c97781cb5d023a4c72c35bece50d9bbc66d3b8e153bbf9fc85R22-R108)

**Testing**

* Added a feature test to verify that the daily active users card displays correct statistics and UI elements, including unique login counts and trend calculation. (`tests/Feature/AdminPageTest.php`)

**Dependency updates**

* Imported `Carbon\Carbon` where necessary to support date calculations in both controller and tests. (`app/Http/Controllers/AdminController.php`, `tests/Feature/AdminPageTest.php`) [[1]](diffhunk://#diff-1c6494e1e9cbdc520eac89f9be1dcaff36c5a7aad7d0efaf22beddb70d8c1dc5R7) [[2]](diffhunk://#diff-119b2ff3fba0e4ca4990e3f4366e30612dd5b288246d18e3fd6d198fa52e8d61R9)