### PR TITLE
Hide upload status controls on audiobook detail page

### DIFF
--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -25,7 +25,6 @@
                     </div>
                 </div>
                 @if($episode->roles->isNotEmpty())
-                @php($canManageRoles = auth()->user()->hasVorstandRole() || auth()->user()->isOwnerOfTeam('AG Fanhörbücher'))
                 <div class="md:col-span-2">
                     <span class="font-medium">Rollen:</span>
                     <div class="mt-1 overflow-x-auto">
@@ -36,7 +35,6 @@
                                     <th class="px-2 py-1 text-left">Beschreibung</th>
                                     <th class="px-2 py-1 text-left">Takes</th>
                                     <th class="px-2 py-1 text-left">Sprecher</th>
-                                    <th class="px-2 py-1 text-left">Aufnahme hochgeladen</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -50,33 +48,6 @@
                                         @php($prev = $previousSpeakers[$role->name] ?? null)
                                         @if($prev)
                                             <div class="text-xs text-gray-500">Bisheriger Sprecher: {{ $prev }}</div>
-                                        @endif
-                                    </td>
-                                    <td class="px-2 py-1">
-                                        @if($canManageRoles)
-                                            <form action="{{ route('hoerbuecher.roles.uploaded', $role) }}" method="POST" data-auto-submit="change" class="inline-flex items-center gap-2">
-                                                @csrf
-                                                @method('PATCH')
-                                                <input type="hidden" name="uploaded" value="0">
-                                                @php($checkboxId = 'uploaded-role-' . $role->id)
-                                                <label for="{{ $checkboxId }}" class="inline-flex items-center gap-2 text-gray-700 dark:text-gray-300">
-                                                    <input
-                                                        id="{{ $checkboxId }}"
-                                                        type="checkbox"
-                                                        name="uploaded"
-                                                        value="1"
-                                                        {{ $role->uploaded ? 'checked' : '' }}
-                                                        class="rounded border-gray-300 dark:border-gray-600 text-[#8B0116] focus:ring-[#8B0116] dark:focus:ring-[#FF6B81]"
-                                                        aria-describedby="{{ $checkboxId }}-hint"
-                                                    >
-                                                    <span id="{{ $checkboxId }}-hint" class="text-sm">Hochgeladen</span>
-                                                </label>
-                                                <button type="submit" class="sr-only">Status speichern</button>
-                                            </form>
-                                        @else
-                                            <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium {{ $role->uploaded ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-300' }}">
-                                                {{ $role->uploaded ? 'Ja' : 'Nein' }}
-                                            </span>
                                         @endif
                                     </td>
                                 </tr>
@@ -104,7 +75,4 @@
             </div>
         </div>
     </x-member-page>
-    @unless(app()->environment('testing'))
-        @vite(['resources/js/hoerbuch-role-upload-toggle.js'])
-    @endunless
 </x-app-layout>

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -206,6 +206,39 @@ class HoerbuchControllerTest extends TestCase
             ->assertDontSee('Verborgene Stimme');
     }
 
+    public function test_detail_view_hides_upload_column_and_controls(): void
+    {
+        $user = $this->actingMember('Admin');
+
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F42',
+            'title' => 'Keine Upload Checkbox',
+            'author' => 'Autor',
+            'planned_release_date' => '12.2025',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 10,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+
+        $episode->roles()->create([
+            'name' => 'Erzähler',
+            'description' => 'Erzählt die Geschichte',
+            'takes' => 4,
+            'uploaded' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('hoerbuecher.show', $episode));
+
+        $response->assertOk();
+        $response->assertSee('Sprecher');
+        $response->assertDontSee('Aufnahme hochgeladen');
+        $response->assertDontSee('uploaded-role-');
+        $response->assertDontSee('data-auto-submit');
+    }
+
     public function test_vorstand_can_store_episode(): void
     {
         $user = $this->actingMember('Vorstand');


### PR DESCRIPTION
This pull request removes the "Aufnahme hochgeladen" (recording uploaded) column and its associated upload controls from the audiobook episode detail view. The related JavaScript is also no longer included, and a new test ensures these elements are not visible in the UI.

**View cleanup and feature removal:**

* Removed the "Aufnahme hochgeladen" column and its upload checkbox/control logic from the `hoerbuecher/show.blade.php` view. This includes both the table header and the per-role upload toggle, as well as the conditional logic for displaying the controls. [[1]](diffhunk://#diff-3a89ef24b9c79efccdef51ca4d7a67fab3d01dd6e100d6b08f8b821b8334ffcfL39) [[2]](diffhunk://#diff-3a89ef24b9c79efccdef51ca4d7a67fab3d01dd6e100d6b08f8b821b8334ffcfL55-L81)
* Removed the inclusion of the `hoerbuch-role-upload-toggle.js` script from the view, as the upload feature is no longer present.
* Removed the unused `$canManageRoles` variable, since the related controls have been deleted.

**Testing:**

* Added a new feature test `test_detail_view_hides_upload_column_and_controls` to verify that the upload column and controls are not rendered in the detail view.