### PR TITLE
feat: collapse changelog releases by default

### DIFF
--- a/resources/js/changelog.js
+++ b/resources/js/changelog.js
@@ -3,41 +3,78 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!container) {
         return;
     }
+
     try {
         const response = await fetch('/changelog.json');
         const releases = await response.json();
-        releases.forEach(release => {
-            const section = document.createElement('section');
-            section.className = 'mb-8';
+        const sortedReleases = Array.isArray(releases)
+            ? [...releases].sort((a, b) => new Date(b.pub_date) - new Date(a.pub_date))
+            : [];
 
-            const header = document.createElement('header');
-            header.className = 'flex items-center mb-4';
+        container.innerHTML = '';
+
+        sortedReleases.forEach((release, index) => {
+            const section = document.createElement('section');
+            section.className = 'mb-6';
+
+            const details = document.createElement('details');
+            details.className = 'group border border-gray-200 dark:border-gray-700 rounded-lg bg-white/80 dark:bg-gray-900/60 shadow-sm transition';
+            if (index === 0) {
+                details.open = true;
+            }
+
+            const summaryId = `release-summary-${release.version.replace(/[^a-zA-Z0-9]+/g, '-').toLowerCase()}`;
+            const panelId = `${summaryId}-panel`;
+
+            const summary = document.createElement('summary');
+            summary.className = 'flex flex-wrap items-center justify-between gap-4 p-4 cursor-pointer text-lg font-semibold text-gray-900 dark:text-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900';
+            summary.id = summaryId;
+            summary.setAttribute('role', 'button');
+            summary.setAttribute('aria-controls', panelId);
+            summary.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+
+            const headerContent = document.createElement('div');
+            headerContent.className = 'flex items-center gap-3';
 
             const badge = document.createElement('span');
-            badge.className = 'bg-purple-100 text-purple-800 dark:bg-purple-600 dark:text-white text-lg font-bold rounded px-2 py-1 mr-2';
+            badge.className = 'bg-purple-100 text-purple-800 dark:bg-purple-600 dark:text-white text-base sm:text-lg font-bold rounded px-3 py-1';
             badge.innerText = release.version;
 
             const date = document.createElement('span');
-            date.className = 'text-lg';
+            date.className = 'text-sm sm:text-base text-gray-700 dark:text-gray-300';
             const d = new Date(release.pub_date);
             date.innerText = d.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' });
 
-            header.appendChild(badge);
-            header.appendChild(date);
+            headerContent.appendChild(badge);
+            headerContent.appendChild(date);
+
+            const indicator = document.createElement('span');
+            indicator.className = 'ml-auto text-gray-500 dark:text-gray-400 transition-transform group-open:-rotate-180';
+            indicator.setAttribute('aria-hidden', 'true');
+            indicator.innerHTML = '<svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m6 9 6 6 6-6" /></svg>';
+
+            summary.appendChild(headerContent);
+            summary.appendChild(indicator);
+
+            const content = document.createElement('div');
+            content.id = panelId;
+            content.setAttribute('role', 'region');
+            content.setAttribute('aria-labelledby', summaryId);
+            content.className = 'px-4 pb-4 pt-2 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900';
 
             const list = document.createElement('ul');
-            list.className = 'list-none';
+            list.className = 'list-none space-y-2';
 
             release.notes.forEach(note => {
                 const item = document.createElement('li');
-                item.className = 'flex items-start mb-2';
+                item.className = 'flex items-start gap-2';
                 const match = note.match(/^\[(\w+)\]\s*(.*)$/);
                 if (match) {
                     const type = match[1].toLowerCase();
                     const text = match[2];
 
                     const typeBadge = document.createElement('span');
-                    typeBadge.className = `text-xs font-bold rounded px-2 py-1 mr-2 w-28 text-center ${
+                    typeBadge.className = `text-xs font-bold rounded px-2 py-1 min-w-[6rem] text-center ${
                         type === 'new' || type === 'added'
                             ? 'bg-green-600 text-white'
                             : type === 'fixed'
@@ -59,8 +96,15 @@ document.addEventListener('DOMContentLoaded', async () => {
                 list.appendChild(item);
             });
 
-            section.appendChild(header);
-            section.appendChild(list);
+            details.appendChild(summary);
+            content.appendChild(list);
+            details.appendChild(content);
+
+            details.addEventListener('toggle', () => {
+                summary.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+            });
+
+            section.appendChild(details);
             container.appendChild(section);
         });
     } catch (e) {

--- a/resources/js/changelog.js
+++ b/resources/js/changelog.js
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                     const text = match[2];
 
                     const typeBadge = document.createElement('span');
-                    typeBadge.className = `text-xs font-bold rounded px-2 py-1 min-w-[6rem] text-center ${
+                    typeBadge.className = `text-xs font-bold rounded px-2 py-1 min-w-[7rem] text-center ${
                         type === 'new' || type === 'added'
                             ? 'bg-green-600 text-white'
                             : type === 'fixed'

--- a/tests/Jest/changelog.test.js
+++ b/tests/Jest/changelog.test.js
@@ -86,6 +86,9 @@ describe('changelog module', () => {
     await domContentLoaded();
     const items = Array.from(document.querySelectorAll('#release-notes li'));
     const classes = items.map((li) => li.querySelector('span')?.className || '');
+    classes.forEach((className) => {
+      expect(className).toContain('min-w-[7rem]');
+    });
     expect(classes[0]).toContain('bg-red-600');
     expect(classes[1]).toContain('bg-blue-600');
     expect(classes[2]).toContain('bg-gray-600');

--- a/tests/Jest/changelog.test.js
+++ b/tests/Jest/changelog.test.js
@@ -32,7 +32,11 @@ describe('changelog module', () => {
     await domContentLoaded();
     expect(global.fetch).toHaveBeenCalledWith('/changelog.json');
     const container = document.getElementById('release-notes');
-    expect(container.querySelectorAll('section').length).toBe(1);
+    const sections = container.querySelectorAll('section');
+    expect(sections.length).toBe(1);
+    const details = sections[0].querySelector('details');
+    expect(details).not.toBeNull();
+    expect(details?.open).toBe(true);
   });
 
   test('does nothing when container missing', async () => {
@@ -85,5 +89,29 @@ describe('changelog module', () => {
     expect(classes[0]).toContain('bg-red-600');
     expect(classes[1]).toContain('bg-blue-600');
     expect(classes[2]).toContain('bg-gray-600');
+  });
+
+  test('only the most recent release is expanded on load', async () => {
+    document.body.innerHTML = '<div id="release-notes"></div>';
+    global.fetch.mockResolvedValue({
+      json: () => Promise.resolve([
+        { version: '1.0.0', pub_date: '2024-01-02', notes: [] },
+        { version: '1.1.0', pub_date: '2024-02-15', notes: [] },
+        { version: '0.9.5', pub_date: '2023-12-20', notes: [] },
+      ]),
+    });
+
+    await import('../../resources/js/changelog.js');
+    await domContentLoaded();
+
+    const detailElements = Array.from(document.querySelectorAll('#release-notes details'));
+    expect(detailElements.length).toBe(3);
+    expect(detailElements[0].open).toBe(true);
+    expect(detailElements.slice(1).every((el) => el.open === false)).toBe(true);
+
+    const summary = detailElements[0].querySelector('summary');
+    expect(summary?.getAttribute('aria-expanded')).toBe('true');
+    const collapsedSummary = detailElements[1].querySelector('summary');
+    expect(collapsedSummary?.getAttribute('aria-expanded')).toBe('false');
   });
 });


### PR DESCRIPTION
This pull request updates the changelog display to use collapsible sections for each release, improving usability and accessibility. Only the most recent release is expanded by default, and the UI is enhanced with better styling and ARIA attributes. Corresponding tests are added and updated to ensure correct behavior.

**Changelog UI/UX improvements:**

* Refactored the changelog rendering to group each release in a collapsible `details` element, with only the most recent release expanded by default. Added ARIA attributes for accessibility and improved the visual styling of version badges, notes, and summary headers. [[1]](diffhunk://#diff-08f836f0a331b5a41bceadfe612251bf4bd2873303f8b0d9329c51b84d1377fbR6-R77) [[2]](diffhunk://#diff-08f836f0a331b5a41bceadfe612251bf4bd2873303f8b0d9329c51b84d1377fbL62-R107)

**Testing updates:**

* Updated and added Jest tests to verify that only the most recent release is expanded on load, and to check the presence and state of the new `details` structure. [[1]](diffhunk://#diff-8c8ac16fd80e6a342abf6b7daaad5915aaf9b0cbb5e84fcc0308aca51827798cL35-R39) [[2]](diffhunk://#diff-8c8ac16fd80e6a342abf6b7daaad5915aaf9b0cbb5e84fcc0308aca51827798cR93-R116)