### PR TITLE
Add admin Maddraxikon navigation page

### DIFF
--- a/app/Http/Controllers/AdminMaddraxikonController.php
+++ b/app/Http/Controllers/AdminMaddraxikonController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\View\View;
+use Throwable;
+
+class AdminMaddraxikonController extends Controller
+{
+    private const CACHE_KEY = 'admin.maddraxikon.navigation';
+    private const CACHE_TTL_MINUTES = 10;
+    private const API_ENDPOINT = 'https://de.maddraxikon.com/api.php';
+
+    public function index(): View
+    {
+        $errorMessage = null;
+        $content = null;
+
+        try {
+            $content = Cache::remember(self::CACHE_KEY, now()->addMinutes(self::CACHE_TTL_MINUTES), function () {
+                $response = Http::timeout(5)
+                    ->retry(2, 500)
+                    ->acceptJson()
+                    ->get(self::API_ENDPOINT, [
+                        'action' => 'parse',
+                        'page' => 'Vorlage:Hauptseite/Navigation',
+                        'prop' => 'text',
+                        'format' => 'json',
+                        'formatversion' => 2,
+                    ]);
+
+                if ($response->failed()) {
+                    $response->throw();
+                }
+
+                $html = $response->json('parse.text');
+
+                if (!is_string($html) || $html === '') {
+                    throw new \RuntimeException('MediaWiki response did not contain expected HTML content.');
+                }
+
+                return $html;
+            });
+        } catch (Throwable $exception) {
+            report($exception);
+            $errorMessage = __('Der Inhalt des Maddraxikon konnte aktuell nicht geladen werden. Bitte versuchen Sie es später erneut.');
+        }
+
+        return view('admin.maddraxikon', [
+            'content' => $content,
+            'errorMessage' => $errorMessage,
+        ]);
+    }
+}

--- a/resources/views/admin/maddraxikon.blade.php
+++ b/resources/views/admin/maddraxikon.blade.php
@@ -1,0 +1,70 @@
+<x-app-layout>
+    <x-member-page>
+        <div class="max-w-5xl mx-auto space-y-6">
+            <header class="space-y-2">
+                <p class="text-sm font-semibold uppercase tracking-wide text-[#8B0116] dark:text-[#FCA5A5]">
+                    Maddraxikon
+                </p>
+                <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">
+                    Navigation aus dem Maddraxikon
+                </h1>
+                <p class="text-base text-gray-600 dark:text-gray-300">
+                    Auf dieser Seite findest du die aktuelle Navigationsübersicht aus dem Maddraxikon. Die Inhalte werden
+                    automatisch aus dem MediaWiki geladen und regelmäßig aktualisiert. Externe Links öffnen im selben
+                    Fenster.
+                </p>
+            </header>
+
+            @if($errorMessage)
+                <section
+                    class="rounded-lg border border-rose-200 bg-rose-50 p-4 text-rose-900 dark:border-rose-400/40 dark:bg-rose-900/30 dark:text-rose-100"
+                    role="alert"
+                >
+                    <h2 class="text-lg font-semibold">Laden fehlgeschlagen</h2>
+                    <p class="mt-2 leading-relaxed">
+                        {{ $errorMessage }}
+                    </p>
+                </section>
+            @elseif($content)
+                <section
+                    class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+                    aria-labelledby="maddraxikon-navigation-heading"
+                >
+                    <div class="flex items-center justify-between gap-4">
+                        <h2 id="maddraxikon-navigation-heading" class="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                            Navigationsinhalte
+                        </h2>
+                        <a
+                            href="https://de.maddraxikon.com/index.php?title=Vorlage:Hauptseite/Navigation"
+                            class="inline-flex items-center gap-2 rounded-md border border-transparent bg-[#8B0116] px-4 py-2 text-sm font-semibold text-white transition hover:bg-[#A61228] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#8B0116] focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            Original anzeigen
+                            <span aria-hidden="true" class="inline-flex h-4 w-4 items-center justify-center">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
+                                    <path d="M10.75 2.75a.75.75 0 0 1 .75-.75h5.75a.75.75 0 0 1 .75.75v5.75a.75.75 0 0 1-1.5 0V4.56l-5.97 5.97a.75.75 0 1 1-1.06-1.06l5.97-5.97h-3.94a.75.75 0 0 1-.75-.75Z" />
+                                    <path d="M3.5 4a1.5 1.5 0 0 0-1.5 1.5v10a1.5 1.5 0 0 0 1.5 1.5h10a1.5 1.5 0 0 0 1.5-1.5v-3a.75.75 0 0 0-1.5 0v3a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h3a.75.75 0 0 0 0-1.5h-3Z" />
+                                </svg>
+                            </span>
+                        </a>
+                    </div>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+                        Alle Links im eingebetteten Inhalt führen direkt zum Maddraxikon.
+                    </p>
+                    <div
+                        class="prose mt-6 max-w-none text-gray-800 dark:prose-invert dark:text-gray-100"
+                        role="navigation"
+                        aria-label="Navigationsbereich des Maddraxikon"
+                    >
+                        {!! $content !!}
+                    </div>
+                </section>
+            @else
+                <p class="text-sm text-gray-600 dark:text-gray-300">
+                    Es sind derzeit keine Inhalte verfügbar.
+                </p>
+            @endif
+        </div>
+    </x-member-page>
+</x-app-layout>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -109,6 +109,7 @@
                                 Admin
                             </button>
                             <div id="admin-menu" x-show="open" x-cloak class="absolute left-0 top-full mt-px w-48 bg-white dark:bg-gray-700 rounded-md shadow-lg z-50 py-2 group-hover:block" role="menu" aria-labelledby="admin-button">
+                                <x-dropdown-link href="{{ route('admin.maddraxikon.index') }}">Maddraxikon</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('admin.statistiken.index') }}">Statistik</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('admin.messages.index') }}">Kurznachrichten</x-dropdown-link>
@@ -230,6 +231,7 @@
             <button id="admin-mobile-button" type="button" @click="openMenu = (openMenu === 'admin' ? null : 'admin')" class="w-full text-left px-4 py-2 font-bold text-gray-600 dark:text-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :class="{ 'bg-gray-100 dark:bg-gray-700': openMenu === 'admin' }" :aria-expanded="openMenu === 'admin'" aria-controls="admin-mobile-menu" @keydown.enter.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')" @keydown.space.prevent="openMenu = (openMenu === 'admin' ? null : 'admin')">
             Admin</button>
             <div id="admin-mobile-menu" x-show="openMenu === 'admin'" x-cloak class="italic" aria-labelledby="admin-mobile-button">
+                <x-responsive-nav-link href="{{ route('admin.maddraxikon.index') }}">Maddraxikon</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('admin.statistiken.index') }}">Statistik</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('newsletter.create') }}">Newsletter versenden</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('admin.messages.index') }}">Kurznachrichten</x-responsive-nav-link>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AdminController;
+use App\Http\Controllers\AdminMaddraxikonController;
 use App\Http\Controllers\AdminMessageController;
 use App\Http\Controllers\ArbeitsgruppenController;
 use App\Http\Controllers\Auth\CustomEmailVerificationController;
@@ -56,6 +57,7 @@ Route::get('/email/bestaetigen/{id}/{hash}', CustomEmailVerificationController::
 // Nur für eingeloggte und verifizierte Mitglieder, die NICHT Anwärter sind
 Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function () {
     Route::get('/admin/statistiken', [AdminController::class, 'index'])->name('admin.statistiken.index')->middleware('admin');
+    Route::get('/admin/maddraxikon', [AdminMaddraxikonController::class, 'index'])->name('admin.maddraxikon.index')->middleware('admin');
     Route::controller(DashboardController::class)->group(function () {
         Route::get('/dashboard', 'index')->name('dashboard');
         Route::post('/anwaerter/{user}/freigeben', 'approveAnwaerter')->name('anwaerter.approve');

--- a/tests/Feature/AdminMaddraxikonControllerTest.php
+++ b/tests/Feature/AdminMaddraxikonControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class AdminMaddraxikonControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    public function test_admin_can_view_maddraxikon_page(): void
+    {
+        Http::fake([
+            'https://de.maddraxikon.com/api.php*' => Http::response([
+                'parse' => [
+                    'text' => '<div class="mw-parser-output"><p>Test Navigation</p></div>',
+                ],
+            ], 200),
+        ]);
+
+        $team = Team::membersTeam();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => Role::Admin->value]);
+
+        $response = $this->actingAs($user)->get(route('admin.maddraxikon.index'));
+
+        $response->assertOk();
+        $response->assertSee('Navigationsinhalte');
+        $response->assertSee('<p>Test Navigation</p>', false);
+
+        Http::assertSent(function (Request $request) {
+            return str_starts_with($request->url(), 'https://de.maddraxikon.com/api.php')
+                && $request['page'] === 'Vorlage:Hauptseite/Navigation'
+                && (string) $request['formatversion'] === '2';
+        });
+    }
+
+    public function test_non_admin_users_cannot_access_maddraxikon_page(): void
+    {
+        Http::fake();
+
+        $team = Team::membersTeam();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => Role::Mitglied->value]);
+
+        $response = $this->actingAs($user)->get(route('admin.maddraxikon.index'));
+
+        $response->assertForbidden();
+        Http::assertNotSent(function (Request $request) {
+            return $request->url() === 'https://de.maddraxikon.com/api.php';
+        });
+    }
+
+    public function test_error_message_is_shown_when_mediawiki_request_fails(): void
+    {
+        Http::fake([
+            'https://de.maddraxikon.com/api.php*' => Http::response([], 500),
+        ]);
+
+        $team = Team::membersTeam();
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => Role::Admin->value]);
+
+        $response = $this->actingAs($user)->get(route('admin.maddraxikon.index'));
+
+        $response->assertOk();
+        $response->assertSee('Laden fehlgeschlagen');
+        $response->assertSee('Der Inhalt des Maddraxikon konnte aktuell nicht geladen werden', false);
+    }
+}

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -36,6 +36,7 @@ class NavigationMenuTest extends TestCase
         $response = $this->actingAs($user)->get('/');
 
         $response->assertSee(route('admin.statistiken.index'));
+        $response->assertSee(route('admin.maddraxikon.index'));
         $response->assertSee('Admin');
         $response->assertSee('admin-button');
         $response->assertSee('admin-mobile-button');
@@ -50,6 +51,7 @@ class NavigationMenuTest extends TestCase
         $response = $this->actingAs($user)->get('/');
 
         $response->assertDontSee(route('admin.statistiken.index'));
+        $response->assertDontSee(route('admin.maddraxikon.index'));
         $response->assertDontSee('admin-button');
         $response->assertDontSee('admin-mobile-button');
     }


### PR DESCRIPTION
## Summary
- add an admin-only Maddraxikon controller and view that embeds the MediaWiki navigation template with caching and graceful error handling
- expose the new page through the existing Admin dropdown in both desktop and mobile navigation
- cover the new endpoint and navigation visibility rules with feature tests

## Testing
- php artisan test --filter=AdminMaddraxikonControllerTest
- php artisan test --filter=NavigationMenuTest

------
https://chatgpt.com/codex/tasks/task_e_68d9f80ea9b0832eb0b9c5022255bafc