### PR TITLE
Add role name filter for audiobook episodes

### DIFF
--- a/resources/js/hoerbuecher.js
+++ b/resources/js/hoerbuecher.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
         status: document.getElementById('status-filter'),
         type: document.getElementById('type-filter'),
         year: document.getElementById('year-filter'),
+        roleName: document.getElementById('role-name-filter'),
         roles: document.getElementById('roles-filter'),
         rolesUnfilled: document.getElementById('roles-unfilled-filter'),
         hideReleased: document.getElementById('hide-released-filter'),
@@ -27,6 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const statusVal = filters.status?.value;
         const typeVal = filters.type?.value;
         const yearVal = filters.year?.value;
+        const roleNameVal = filters.roleName?.value;
         const rolesChecked = filters.roles?.checked;
         const rolesUnfilledChecked = filters.rolesUnfilled?.checked;
         const hideReleasedChecked = filters.hideReleased?.checked;
@@ -37,6 +39,16 @@ document.addEventListener('DOMContentLoaded', () => {
             const matchStatus = !statusVal || row.dataset.status === statusVal;
             const matchType = !typeVal || row.dataset.type === typeVal;
             const matchYear = !yearVal || (row.dataset.year ?? '') === yearVal;
+            let roleNames = [];
+            const datasetRoleNames = row.dataset.roleNames;
+            if (datasetRoleNames) {
+                try {
+                    roleNames = JSON.parse(datasetRoleNames);
+                } catch (error) {
+                    roleNames = datasetRoleNames.split('|');
+                }
+            }
+            const matchRoleName = !roleNameVal || roleNames.includes(roleNameVal);
             const rolesFilled = row.dataset.rolesFilled === '1';
             let matchRoles = true;
             if (rolesChecked) {
@@ -57,6 +69,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 matchStatus &&
                 matchType &&
                 matchYear &&
+                matchRoleName &&
                 matchRoles &&
                 matchEpisode &&
                 !isReleased
@@ -65,7 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    ['status', 'type', 'year'].forEach(key => {
+    ['status', 'type', 'year', 'roleName'].forEach(key => {
         const el = filters[key];
         el?.addEventListener('change', applyFilters);
     });
@@ -106,6 +119,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (filters.status) {
             filters.status.value = status;
         }
+        if (filters.roleName) {
+            filters.roleName.value = '';
+        }
         if (!filters.rolesUnfilled) {
             return;
         }
@@ -133,6 +149,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (filters.status) {
                 filters.status.value = '';
+            }
+            if (filters.roleName) {
+                filters.roleName.value = '';
             }
             applyFilters();
         }

--- a/resources/js/hoerbuecher.js
+++ b/resources/js/hoerbuecher.js
@@ -43,9 +43,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const datasetRoleNames = row.dataset.roleNames;
             if (datasetRoleNames) {
                 try {
-                    roleNames = JSON.parse(datasetRoleNames);
+                    const parsed = JSON.parse(datasetRoleNames);
+                    if (Array.isArray(parsed)) {
+                        roleNames = parsed;
+                    }
                 } catch (error) {
-                    roleNames = datasetRoleNames.split('|');
+                    console.error('Konnte Rollenliste nicht parsen', error);
                 }
             }
             const matchRoleName = !roleNameVal || roleNames.includes(roleNameVal);

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -54,6 +54,19 @@
                         <option value="{{ $year }}">{{ $year }}</option>
                     @endforeach
                 </select>
+                <div class="flex flex-col">
+                    <label for="role-name-filter" class="sr-only">Nach Rolle filtern</label>
+                    <select
+                        id="role-name-filter"
+                        class="border-gray-300 dark:border-gray-600 rounded-md"
+                        aria-label="Hörbuchfolgen nach Rolle filtern"
+                    >
+                        <option value="">Alle Rollen</option>
+                        @foreach($roleNames as $roleName)
+                            <option value="{{ $roleName }}">{{ $roleName }}</option>
+                        @endforeach
+                    </select>
+                </div>
                 <label class="inline-flex items-center">
                     <input type="checkbox" id="roles-filter" class="form-checkbox">
                     <span class="ml-2">Rollen besetzt</span>
@@ -103,6 +116,7 @@
                                 data-year="{{ $episode->release_year ?? '' }}"
                                 data-episode-id="{{ $episode->id }}"
                                 data-planned-release-date="{{ optional($episode->planned_release_date_parsed)->toDateString() }}"
+                                data-role-names='@json($episode->roles->pluck('name')->filter()->values())'
                             >
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->episode_number }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $episode->title }}</td>

--- a/tests/Jest/hoerbuecher.test.js
+++ b/tests/Jest/hoerbuecher.test.js
@@ -7,13 +7,14 @@ describe('hoerbuecher module', () => {
     jest.setSystemTime(new Date('2024-01-15T00:00:00Z'));
     document.body.innerHTML = `
       <table>
-        <tr data-href="/1" data-status="done" data-type="A" data-year="2024" data-roles-filled="1" data-episode-id="1" data-planned-release-date="2023-12-01"></tr>
-        <tr data-href="/2" data-status="open" data-type="B" data-year="2023" data-roles-filled="0" data-episode-id="2" data-planned-release-date="2024-02-01"></tr>
-        <tr data-href="/3" data-status="Rollenbesetzung" data-type="C" data-year="2023" data-roles-filled="0" data-episode-id="3" data-planned-release-date="2024-03-15"></tr>
+        <tr data-href="/1" data-status="done" data-type="A" data-year="2024" data-roles-filled="1" data-episode-id="1" data-planned-release-date="2023-12-01" data-role-names='["Held"]'></tr>
+        <tr data-href="/2" data-status="open" data-type="B" data-year="2023" data-roles-filled="0" data-episode-id="2" data-planned-release-date="2024-02-01" data-role-names='["Schurke","Nebenfigur"]'></tr>
+        <tr data-href="/3" data-status="Rollenbesetzung" data-type="C" data-year="2023" data-roles-filled="0" data-episode-id="3" data-planned-release-date="2024-03-15" data-role-names='[]'></tr>
       </table>
       <select id="status-filter"><option value=""></option><option value="open">open</option><option value="Rollenbesetzung">Rollenbesetzung</option></select>
       <select id="type-filter"><option value=""></option><option value="A">A</option><option value="B">B</option><option value="C">C</option></select>
       <select id="year-filter"><option value=""></option><option value="2023">2023</option><option value="2024">2024</option></select>
+      <select id="role-name-filter"><option value=""></option><option value="Held">Held</option><option value="Schurke">Schurke</option><option value="Nebenfigur">Nebenfigur</option></select>
       <input type="checkbox" id="roles-filter" />
       <input type="checkbox" id="roles-unfilled-filter" />
       <input type="checkbox" id="hide-released-filter" checked />
@@ -59,6 +60,25 @@ describe('hoerbuecher module', () => {
     typeFilter.value = 'A';
     typeFilter.dispatchEvent(new Event('change'));
     expect(rows[1].style.display).toBe('none');
+  });
+
+  test('filters rows by selected role name', () => {
+    const roleFilter = document.getElementById('role-name-filter');
+    const rows = document.querySelectorAll('tr[data-href]');
+
+    roleFilter.value = 'Schurke';
+    roleFilter.dispatchEvent(new Event('change'));
+
+    expect(rows[0].style.display).toBe('none');
+    expect(rows[1].style.display).toBe('');
+    expect(rows[2].style.display).toBe('none');
+
+    roleFilter.value = '';
+    roleFilter.dispatchEvent(new Event('change'));
+
+    expect(rows[0].style.display).toBe('none');
+    expect(rows[1].style.display).toBe('');
+    expect(rows[2].style.display).toBe('');
   });
 
   test('row click and Enter key navigate to dataset href', () => {


### PR DESCRIPTION
This pull request adds a new filter to the Hörbuch (audiobook) episodes list, allowing users to filter episodes by the names of roles present in each episode. It updates the backend to collect and provide distinct role names, adjusts the frontend to display and handle the new filter, and includes comprehensive tests for the new functionality.

**Role-based filtering for episodes:**

* The backend (`HoerbuchController`) now gathers all unique role names from episodes and passes them to the view for use in the filter dropdown. Each episode row now includes a `data-role-names` attribute containing its role names as a JSON array. [[1]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL23-R38) [[2]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdR61)
* The frontend (`hoerbuecher.js`) adds a new dropdown filter for role names, parses the `data-role-names` attribute for each episode, and updates filtering logic to show only episodes matching the selected role. The filter state is properly reset when clearing filters. [[1]](diffhunk://#diff-5046ec5ab2d0da1fc73fe9b3c505a5fd4836575443481948ebb0b44c83c75ecfR19) [[2]](diffhunk://#diff-5046ec5ab2d0da1fc73fe9b3c505a5fd4836575443481948ebb0b44c83c75ecfR31) [[3]](diffhunk://#diff-5046ec5ab2d0da1fc73fe9b3c505a5fd4836575443481948ebb0b44c83c75ecfR42-R54) [[4]](diffhunk://#diff-5046ec5ab2d0da1fc73fe9b3c505a5fd4836575443481948ebb0b44c83c75ecfR75) [[5]](diffhunk://#diff-5046ec5ab2d0da1fc73fe9b3c505a5fd4836575443481948ebb0b44c83c75ecfL68-R84) [[6]](diffhunk://#diff-5046ec5ab2d0da1fc73fe9b3c505a5fd4836575443481948ebb0b44c83c75ecfR125-R127) [[7]](diffhunk://#diff-5046ec5ab2d0da1fc73fe9b3c505a5fd4836575443481948ebb0b44c83c75ecfR156-R158)
* The view (`index.blade.php`) adds the new filter dropdown and ensures each episode row includes its role names for filtering. [[1]](diffhunk://#diff-62028215bf1b51ad419e1ba1ed5fc53eac5411544afb5da3fd5718deb40c541fR57-R69) [[2]](diffhunk://#diff-62028215bf1b51ad419e1ba1ed5fc53eac5411544afb5da3fd5718deb40c541fR119)

**Testing and validation:**

* Feature tests (`HoerbuchControllerTest.php`) verify that the filter dropdown is rendered with all distinct role names and that the correct data attributes are present on episode rows. [[1]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1R13) [[2]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1R400-R479)
* Jest tests (`hoerbuecher.test.js`) are updated to cover the new filter, including verifying that episodes are correctly shown or hidden based on the selected role name. [[1]](diffhunk://#diff-a0aace8e313232a9c8aa8381d27c38932949a7aeda110a5b9f3ab60a32a3287aL10-R17) [[2]](diffhunk://#diff-a0aace8e313232a9c8aa8381d27c38932949a7aeda110a5b9f3ab60a32a3287aR65-R83)