### PR TITLE
Shorten audiobook role filter labels

### DIFF
--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -69,11 +69,11 @@
                 </div>
                 <label class="inline-flex items-center">
                     <input type="checkbox" id="roles-filter" class="form-checkbox">
-                    <span class="ml-2">Rollen besetzt</span>
+                    <span class="ml-2">Besetzt</span>
                 </label>
                 <label class="inline-flex items-center">
                     <input type="checkbox" id="roles-unfilled-filter" class="form-checkbox">
-                    <span class="ml-2">Rollen unbesetzt</span>
+                    <span class="ml-2">Unbesetzt</span>
                 </label>
                 <label class="inline-flex items-center">
                     <input

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -477,6 +477,19 @@ class HoerbuchControllerTest extends TestCase
         );
     }
 
+    public function test_index_uses_compact_role_filter_labels(): void
+    {
+        $user = $this->actingMember('Admin');
+
+        $response = $this->actingAs($user)->get(route('hoerbuecher.index'));
+
+        $response->assertOk();
+        $response->assertSee('<span class="ml-2">Besetzt</span>', false);
+        $response->assertSee('<span class="ml-2">Unbesetzt</span>', false);
+        $response->assertDontSee('Rollen besetzt');
+        $response->assertDontSee('Rollen unbesetzt');
+    }
+
     public function test_admin_can_view_episode_details(): void
     {
         $user = $this->actingMember('Admin');


### PR DESCRIPTION
This pull request updates the labels for the role filter checkboxes on the `hoerbuecher.index` view to use more compact wording, and adds a feature test to verify this change.

UI improvements:

* Updated the checkbox labels from "Rollen besetzt" and "Rollen unbesetzt" to "Besetzt" and "Unbesetzt" in `resources/views/hoerbuecher/index.blade.php` to make the filter wording more concise.

Test coverage:

* Added the `test_index_uses_compact_role_filter_labels` test in `tests/Feature/HoerbuchControllerTest.php` to ensure the new labels are rendered and the old labels are not present.