### PR TITLE
Fix Romantausch matching to require reciprocal offers

### DIFF
--- a/app/Http/Controllers/RomantauschController.php
+++ b/app/Http/Controllers/RomantauschController.php
@@ -17,6 +17,7 @@ use App\Models\Activity;
 use App\Enums\BookType;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
 
 class RomantauschController extends Controller
 {
@@ -243,31 +244,97 @@ class RomantauschController extends Controller
     private function matchSwap(Model $model, string $type): void
     {
         if ($type === 'offer') {
-            $match = BookRequest::where('book_number', $model->book_number)
-                ->where('series', $model->series)
+            $offer = $model;
+
+            $potentialRequests = BookRequest::where('book_number', $offer->book_number)
+                ->where('series', $offer->series)
                 ->where('completed', false)
+                ->where('user_id', '!=', $offer->user_id)
                 ->doesntHave('swap')
-                ->first();
-            if ($match) {
-                $swap = BookSwap::create([
-                    'offer_id' => $model->id,
-                    'request_id' => $match->id,
-                ]);
-                Mail::to($match->user->email)->queue(new BookSwapMatched($swap));
+                ->get();
+
+            foreach ($potentialRequests as $request) {
+                if ($this->attemptReciprocalSwap($offer, $request)) {
+                    break;
+                }
             }
         } else {
-            $match = BookOffer::where('book_number', $model->book_number)
-                ->where('series', $model->series)
+            $request = $model;
+
+            $potentialOffers = BookOffer::where('book_number', $request->book_number)
+                ->where('series', $request->series)
                 ->where('completed', false)
+                ->where('user_id', '!=', $request->user_id)
                 ->doesntHave('swap')
-                ->first();
-            if ($match) {
-                $swap = BookSwap::create([
-                    'offer_id' => $match->id,
-                    'request_id' => $model->id,
-                ]);
-                Mail::to($model->user->email)->queue(new BookSwapMatched($swap));
+                ->get();
+
+            foreach ($potentialOffers as $offer) {
+                if ($this->attemptReciprocalSwap($offer, $request)) {
+                    break;
+                }
             }
         }
+    }
+
+    private function attemptReciprocalSwap(BookOffer $offer, BookRequest $request): bool
+    {
+        if ($offer->user_id === $request->user_id) {
+            return false;
+        }
+
+        $offerOwnerRequests = BookRequest::where('user_id', $offer->user_id)
+            ->where('completed', false)
+            ->doesntHave('swap')
+            ->get()
+            ->keyBy(fn ($item) => $item->series . '|' . $item->book_number);
+
+        if ($offerOwnerRequests->isEmpty()) {
+            return false;
+        }
+
+        $requestOwnerOffers = BookOffer::where('user_id', $request->user_id)
+            ->where('completed', false)
+            ->doesntHave('swap')
+            ->get()
+            ->keyBy(fn ($item) => $item->series . '|' . $item->book_number);
+
+        if ($requestOwnerOffers->isEmpty()) {
+            return false;
+        }
+
+        $matchingKey = $offerOwnerRequests->keys()->first(function ($key) use ($requestOwnerOffers) {
+            return $requestOwnerOffers->has($key);
+        });
+
+        if (!$matchingKey) {
+            return false;
+        }
+
+        $reciprocalRequest = $offerOwnerRequests->get($matchingKey);
+        $reciprocalOffer = $requestOwnerOffers->get($matchingKey);
+
+        if (!$reciprocalRequest || !$reciprocalOffer) {
+            return false;
+        }
+
+        $firstSwap = null;
+        $secondSwap = null;
+
+        DB::transaction(function () use ($offer, $request, $reciprocalOffer, $reciprocalRequest, &$firstSwap, &$secondSwap) {
+            $firstSwap = BookSwap::create([
+                'offer_id' => $offer->id,
+                'request_id' => $request->id,
+            ]);
+
+            $secondSwap = BookSwap::create([
+                'offer_id' => $reciprocalOffer->id,
+                'request_id' => $reciprocalRequest->id,
+            ]);
+        });
+
+        Mail::to($request->user->email)->queue(new BookSwapMatched($firstSwap));
+        Mail::to($reciprocalRequest->user->email)->queue(new BookSwapMatched($secondSwap));
+
+        return true;
     }
 }

--- a/tests/Feature/BookSwapProcessTest.php
+++ b/tests/Feature/BookSwapProcessTest.php
@@ -26,7 +26,7 @@ class BookSwapProcessTest extends TestCase
         return $user;
     }
 
-    public function test_match_created_and_mail_sent_when_offer_added(): void
+    public function test_offer_does_not_create_match_without_reciprocal_entries(): void
     {
         Mail::fake();
 
@@ -49,17 +49,71 @@ class BookSwapProcessTest extends TestCase
         ]);
 
         $this->actingAs($offerUser);
-        $this->post(route('romantausch.store-offer'), [
+        $response = $this->post(route('romantausch.store-offer'), [
             'series' => BookType::MaddraxDieDunkleZukunftDerErde->value,
             'book_number' => 1,
             'condition' => 'neu',
         ]);
 
-        $this->assertDatabaseCount('book_swaps', 1);
-        $swap = BookSwap::first();
-        $this->assertEquals($request->id, $swap->request_id);
+        $response->assertRedirect(route('romantausch.index'));
+        $this->assertDatabaseCount('book_swaps', 0);
+        Mail::assertNothingQueued();
+    }
 
-        Mail::assertQueued(BookSwapMatched::class);
+    public function test_reciprocal_match_creates_two_swaps_and_notifies_both_users(): void
+    {
+        Mail::fake();
+
+        $userA = $this->createMember();
+        $userB = $this->createMember();
+
+        $bookOne = Book::create([
+            'roman_number' => 1,
+            'title' => 'Roman Eins',
+            'author' => 'Autor Eins',
+            'type' => BookType::MaddraxDieDunkleZukunftDerErde,
+        ]);
+
+        $bookTwo = Book::create([
+            'roman_number' => 2,
+            'title' => 'Roman Zwei',
+            'author' => 'Autor Zwei',
+            'type' => BookType::MaddraxDieDunkleZukunftDerErde,
+        ]);
+
+        $this->actingAs($userA)->post(route('romantausch.store-request'), [
+            'series' => $bookTwo->type->value,
+            'book_number' => $bookTwo->roman_number,
+            'condition' => 'gut',
+        ])->assertRedirect(route('romantausch.index'));
+
+        $this->actingAs($userB)->post(route('romantausch.store-request'), [
+            'series' => $bookOne->type->value,
+            'book_number' => $bookOne->roman_number,
+            'condition' => 'gut',
+        ])->assertRedirect(route('romantausch.index'));
+
+        $this->actingAs($userB)->post(route('romantausch.store-offer'), [
+            'series' => $bookTwo->type->value,
+            'book_number' => $bookTwo->roman_number,
+            'condition' => 'gut',
+        ])->assertRedirect(route('romantausch.index'));
+
+        $this->actingAs($userA)->post(route('romantausch.store-offer'), [
+            'series' => $bookOne->type->value,
+            'book_number' => $bookOne->roman_number,
+            'condition' => 'gut',
+        ])->assertRedirect(route('romantausch.index'));
+
+        $this->assertDatabaseCount('book_swaps', 2);
+
+        $userASwap = BookSwap::whereHas('request', fn ($query) => $query->where('user_id', $userA->id))->first();
+        $userBSwap = BookSwap::whereHas('request', fn ($query) => $query->where('user_id', $userB->id))->first();
+
+        $this->assertNotNull($userASwap);
+        $this->assertNotNull($userBSwap);
+
+        Mail::assertQueued(BookSwapMatched::class, 2);
     }
 
     public function test_confirmations_complete_swap_and_award_points(): void


### PR DESCRIPTION
## Summary
- require both users to have complementary offers and requests before creating Romantausch swaps
- create paired swap records and notifications once a reciprocal match is found
- add feature tests covering reciprocal matching scenarios

## Testing
- php artisan test --filter=BookSwapProcessTest
- php artisan test --filter=RomantauschControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68dd2f3751f4832e91b87ed24ec1299d