### PR TITLE
Fix duplicate counting of unfilled audiobook roles

### DIFF
--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -56,7 +56,9 @@ class HoerbuchController extends Controller
             ->count();
 
         $openRolesEpisodes = $episodes
-            ->filter(fn ($e) => $e->roles_total > $e->roles_filled)
+            ->filter(fn ($episode) => $episode->roles->contains(
+                fn ($role) => blank($role->user_id) && blank($role->speaker_name)
+            ))
             ->count();
 
         $nextEpisode = $episodes

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -31,16 +31,17 @@ class HoerbuchController extends Controller
         $years = $episodes->pluck('release_year')->filter()->unique()->sort()->values();
 
         $roleNames = $episodes
-            ->flatMap(fn ($episode) => $episode->roles->pluck('name'))
+            ->flatMap->roles
+            ->pluck('name')
             ->filter()
             ->unique()
             ->sort()
             ->values();
 
-        // totalUnfilledRoles intentionally counts unique, case-insensitive role names that
-        // are missing both an assigned member and a speaker name across all episodes.
+        // totalUnfilledRoles counts unique, case-insensitive role names among roles that
+        // individually have neither an assigned member nor a speaker name.
         $totalUnfilledRoles = $episodes
-            ->flatMap(fn ($episode) => $episode->roles)
+            ->flatMap->roles
             ->map(function ($role) {
                 $normalizedName = trim((string) $role->name);
 

--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -55,7 +55,10 @@ class HoerbuchController extends Controller
             ->unique('normalized')
             ->count();
 
-        $openRolesEpisodes = $episodes
+        // episodesWithUnassignedRoles counts episodes that contain at least one role
+        // without an assigned member or speaker name, mirroring the
+        // totalUnfilledRoles aggregation but on an episode basis.
+        $episodesWithUnassignedRoles = $episodes
             ->filter(fn ($episode) => $episode->roles->contains(
                 fn ($role) => blank($role->user_id) && blank($role->speaker_name)
             ))
@@ -78,7 +81,7 @@ class HoerbuchController extends Controller
             'years' => $years,
             'roleNames' => $roleNames,
             'totalUnfilledRoles' => $totalUnfilledRoles,
-            'openRolesEpisodes' => $openRolesEpisodes,
+            'episodesWithUnassignedRoles' => $episodesWithUnassignedRoles,
             'nextEpisode' => $nextEpisode,
             'daysUntilNextEvt' => $daysUntilNextEvt,
         ]);

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -29,8 +29,8 @@
                         <div class="text-gray-600 dark:text-gray-400">Kein Termin</div>
                     @endif
                 </div>
-                <div id="card-open-episodes" data-open-episodes="{{ $openRolesEpisodes }}" class="p-4 border border-gray-200 dark:border-gray-700 rounded cursor-pointer text-center hover:bg-gray-100 dark:hover:bg-gray-700">
-                    <div class="text-3xl font-bold text-gray-800 dark:text-gray-200">{{ $openRolesEpisodes }}</div>
+                <div id="card-open-episodes" data-open-episodes="{{ $episodesWithUnassignedRoles }}" class="p-4 border border-gray-200 dark:border-gray-700 rounded cursor-pointer text-center hover:bg-gray-100 dark:hover:bg-gray-700">
+                    <div class="text-3xl font-bold text-gray-800 dark:text-gray-200">{{ $episodesWithUnassignedRoles }}</div>
                     <div class="text-gray-600 dark:text-gray-400">Folgen mit offenen Rollen</div>
                 </div>
             </div>

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -782,7 +782,7 @@ class HoerbuchControllerTest extends TestCase
             'notes' => null,
         ]);
 
-        $episodeWithOpenRoles?->roles()->createMany([
+        $episodeWithOpenRoles->roles()->createMany([
             ['name' => 'Alpha'],
             ['name' => 'Beta'],
             ['name' => 'Gamma'],
@@ -803,7 +803,7 @@ class HoerbuchControllerTest extends TestCase
             'notes' => null,
         ]);
 
-        $episodeWithoutOpenRoles?->roles()->createMany([
+        $episodeWithoutOpenRoles->roles()->createMany([
             ['name' => 'Zeta', 'speaker_name' => 'Sprecher Zeta'],
             ['name' => 'Eta', 'speaker_name' => 'Sprecher Eta'],
             ['name' => 'Theta', 'speaker_name' => 'Sprecher Theta'],
@@ -862,10 +862,10 @@ class HoerbuchControllerTest extends TestCase
             'notes' => null,
         ]);
 
-        $firstEpisode->roles()->create(['name' => 'Alex']);
+        $firstEpisode->roles()->create(['name' => '  Alex  ']);
         $secondEpisode->roles()->createMany([
-            ['name' => 'Alex'],
-            ['name' => 'Chris'],
+            ['name' => 'alex'],
+            ['name' => 'CHRIS'],
         ]);
         $thirdEpisode->roles()->create([
             'name' => 'Chris',

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -809,12 +809,14 @@ class HoerbuchControllerTest extends TestCase
             ['name' => 'Theta', 'speaker_name' => 'Sprecher Theta'],
         ]);
 
-        $this->actingAs($user)
-            ->get(route('hoerbuecher.index'))
+        $response = $this->actingAs($user)->get(route('hoerbuecher.index'));
+
+        $response
             ->assertSee('data-unfilled-roles="3"', false)
             ->assertSee('data-open-episodes="1"', false)
             ->assertSee('data-days-left="1"', false)
-            ->assertSee('Tage bis Erste veröffentlicht wird (02.01.2025)', false);
+            ->assertSee('Tage bis Erste veröffentlicht wird (02.01.2025)', false)
+            ->assertViewHas('episodesWithUnassignedRoles', 1);
     }
 
     public function test_index_counts_unique_unfilled_role_names(): void

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -777,8 +777,8 @@ class HoerbuchControllerTest extends TestCase
             'status' => 'Rollenbesetzung',
             'responsible_user_id' => null,
             'progress' => 0,
-            'roles_total' => 5,
-            'roles_filled' => 2,
+            'roles_total' => 0,
+            'roles_filled' => 0,
             'notes' => null,
         ]);
 
@@ -798,8 +798,8 @@ class HoerbuchControllerTest extends TestCase
             'status' => 'Skripterstellung',
             'responsible_user_id' => null,
             'progress' => 0,
-            'roles_total' => 3,
-            'roles_filled' => 3,
+            'roles_total' => 0,
+            'roles_filled' => 0,
             'notes' => null,
         ]);
 
@@ -819,7 +819,7 @@ class HoerbuchControllerTest extends TestCase
 
     public function test_index_counts_unique_unfilled_role_names(): void
     {
-        Carbon::setTestNow();
+        Carbon::setTestNow(null);
 
         $user = $this->actingMember('Admin');
 


### PR DESCRIPTION
This pull request refines how unfilled audiobook roles are counted and displayed, ensuring that the count reflects unique, case-insensitive role names that are missing both an assigned member and a speaker name across all episodes. It also adds comprehensive test coverage for the new counting logic.

### Improvements to unfilled roles counting logic

* The calculation of `totalUnfilledRoles` in `HoerbuchController@index` now counts unique, case-insensitive role names that are unassigned and have no speaker name, rather than simply summing open roles. This prevents duplicate counting for roles like "Alex" and "alex" across episodes. [[1]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL23-R24) [[2]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdR40-R55)
* Added `Illuminate\Support\Str` import to support case-insensitive normalization of role names.

### Test coverage enhancements

* Updated `test_index_displays_statistics_cards` to create episodes and roles reflecting the new logic, ensuring the statistics card displays the correct count of unfilled roles. [[1]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1L772-R772) [[2]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1L785-R793) [[3]](diffhunk://#diff-85b35cd02802d48462155ce5750b180b4235b575b740e5cd68c8d980e57130a1R806-R811)
* Added a new test `test_index_counts_unique_unfilled_role_names` to verify that unfilled roles are counted uniquely and case-insensitively, and that filled roles are excluded from the count.