### PR TITLE
Improve romantausch form accessibility and validation coverage

### DIFF
--- a/resources/views/romantausch/create_offer.blade.php
+++ b/resources/views/romantausch/create_offer.blade.php
@@ -11,44 +11,121 @@
                 <form action="{{ route('romantausch.store-offer') }}" method="POST" enctype="multipart/form-data" id="offer-form">
                     @csrf
 
+                    @php
+                        $selectedSeries = old('series', $types[0]->value ?? '');
+                        $seriesError = $errors->first('series');
+                        $bookNumberError = $errors->first('book_number');
+                        $conditionError = $errors->first('condition');
+                        $photoError = $errors->first('photos');
+                        $photoItemError = $errors->first('photos.*');
+                        $photosErrorMessage = $photoError ?: $photoItemError;
+                    @endphp
+
                     <div class="mb-4">
-                        <label class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Serie</label>
-                        <select name="series" id="series-select" class="w-full rounded bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200">
+                        <label for="series-select" class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Serie</label>
+                        <select
+                            name="series"
+                            id="series-select"
+                            @class([
+                                'w-full rounded bg-gray-50 dark:bg-gray-700 border text-gray-800 dark:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:focus-visible:ring-[#FF6B81]',
+                                'border-red-500 focus-visible:ring-red-500 dark:border-red-500' => $seriesError,
+                                'border-gray-300 dark:border-gray-600' => !$seriesError,
+                            ])
+                            @if($seriesError)
+                                aria-invalid="true"
+                                aria-describedby="series-error"
+                            @endif
+                        >
                             @foreach($types as $type)
-                                <option value="{{ $type->value }}">{{ $type->value }}</option>
+                                <option value="{{ $type->value }}" @selected($selectedSeries === $type->value)>{{ $type->value }}</option>
                             @endforeach
                         </select>
+                        @error('series')
+                            <p id="series-error" class="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">{{ $message }}</p>
+                        @enderror
                     </div>
 
                     <div class="mb-4">
-                        <label class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Angebotener Roman</label>
-                        <select name="book_number" id="book-select" class="w-full rounded bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200">
+                        <label for="book-select" class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Angebotener Roman</label>
+                        <select
+                            name="book_number"
+                            id="book-select"
+                            @class([
+                                'w-full rounded bg-gray-50 dark:bg-gray-700 border text-gray-800 dark:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:focus-visible:ring-[#FF6B81]',
+                                'border-red-500 focus-visible:ring-red-500 dark:border-red-500' => $bookNumberError,
+                                'border-gray-300 dark:border-gray-600' => !$bookNumberError,
+                            ])
+                            @if($bookNumberError)
+                                aria-invalid="true"
+                                aria-describedby="book_number-error"
+                            @endif
+                        >
                             @foreach($books as $book)
-                                <option value="{{ $book->roman_number }}" data-series="{{ $book->type->value }}">
+                                <option
+                                    value="{{ $book->roman_number }}"
+                                    data-series="{{ $book->type->value }}"
+                                    @selected((string) old('book_number') === (string) $book->roman_number)
+                                >
                                     {{ $book->roman_number }} - {{ $book->title }}
                                 </option>
                             @endforeach
                         </select>
+                        @error('book_number')
+                            <p id="book_number-error" class="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">{{ $message }}</p>
+                        @enderror
                     </div>
 
                     <div class="mb-6">
-                        <label class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Zustand</label>
-                        <select name="condition" class="w-full rounded bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200">
-                            <option value="Z0">Z0 - Druckfrisch (Top Zustand)</option>
-                            <option value="Z0-1">Z0-1 - Druckfrisch, minimale Mängel</option>
-                            <option value="Z1">Z1 - Sehr gut, Kleinstfehler</option>
-                            <option value="Z1-2">Z1-2 - Sehr gut, leichte Gebrauchsspuren</option>
-                            <option value="Z2">Z2 - Gut, kleine Mängel</option>
-                            <option value="Z2-3">Z2-3 - Gut, stärker gebraucht</option>
-                            <option value="Z3">Z3 - Deutlich gebraucht</option>
-                            <option value="Z3-4">Z3-4 - Sehr stark gebraucht</option>
-                            <option value="Z4">Z4 - Sehr schlecht erhalten</option>
+                        <label for="condition-select" class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Zustand</label>
+                        <select
+                            name="condition"
+                            id="condition-select"
+                            @class([
+                                'w-full rounded bg-gray-50 dark:bg-gray-700 border text-gray-800 dark:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:focus-visible:ring-[#FF6B81]',
+                                'border-red-500 focus-visible:ring-red-500 dark:border-red-500' => $conditionError,
+                                'border-gray-300 dark:border-gray-600' => !$conditionError,
+                            ])
+                            @if($conditionError)
+                                aria-invalid="true"
+                                aria-describedby="condition-error"
+                            @endif
+                        >
+                            <option value="Z0" @selected(old('condition') === 'Z0')>Z0 - Druckfrisch (Top Zustand)</option>
+                            <option value="Z0-1" @selected(old('condition') === 'Z0-1')>Z0-1 - Druckfrisch, minimale Mängel</option>
+                            <option value="Z1" @selected(old('condition') === 'Z1')>Z1 - Sehr gut, Kleinstfehler</option>
+                            <option value="Z1-2" @selected(old('condition') === 'Z1-2')>Z1-2 - Sehr gut, leichte Gebrauchsspuren</option>
+                            <option value="Z2" @selected(old('condition') === 'Z2')>Z2 - Gut, kleine Mängel</option>
+                            <option value="Z2-3" @selected(old('condition') === 'Z2-3')>Z2-3 - Gut, stärker gebraucht</option>
+                            <option value="Z3" @selected(old('condition') === 'Z3')>Z3 - Deutlich gebraucht</option>
+                            <option value="Z3-4" @selected(old('condition') === 'Z3-4')>Z3-4 - Sehr stark gebraucht</option>
+                            <option value="Z4" @selected(old('condition') === 'Z4')>Z4 - Sehr schlecht erhalten</option>
                         </select>
+                        @error('condition')
+                            <p id="condition-error" class="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">{{ $message }}</p>
+                        @enderror
                     </div>
 
                     <div class="mb-6">
-                        <label class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Fotos (max. 3)</label>
-                        <input type="file" name="photos[]" multiple accept="image/*" class="w-full rounded bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200" />
+                        <label for="photos" class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Fotos (max. 3)</label>
+                        <input
+                            type="file"
+                            name="photos[]"
+                            id="photos"
+                            multiple
+                            accept="image/*"
+                            @class([
+                                'w-full rounded bg-gray-50 dark:bg-gray-700 border text-gray-800 dark:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:focus-visible:ring-[#FF6B81]',
+                                'border-red-500 focus-visible:ring-red-500 dark:border-red-500' => $photosErrorMessage,
+                                'border-gray-300 dark:border-gray-600' => !$photosErrorMessage,
+                            ])
+                            @if($photosErrorMessage)
+                                aria-invalid="true"
+                                aria-describedby="photos-error"
+                            @endif
+                        />
+                        @if($photosErrorMessage)
+                            <p id="photos-error" class="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">{{ $photosErrorMessage }}</p>
+                        @endif
                     </div>
 
                     <button type="submit"
@@ -67,15 +144,21 @@
             function filterBooks() {
                 const series = seriesSelect.value;
                 let firstVisibleIndex = -1;
+                let hasVisibleSelection = false;
                 Array.from(bookSelect.options).forEach((option, idx) => {
                     const match = option.dataset.series === series;
                     option.hidden = !match;
                     option.disabled = !match;
-                    if (match && firstVisibleIndex === -1) {
-                        firstVisibleIndex = idx;
+                    if (match) {
+                        if (firstVisibleIndex === -1) {
+                            firstVisibleIndex = idx;
+                        }
+                        if (option.selected) {
+                            hasVisibleSelection = true;
+                        }
                     }
                 });
-                if (firstVisibleIndex !== -1) {
+                if (!hasVisibleSelection && firstVisibleIndex !== -1) {
                     bookSelect.selectedIndex = firstVisibleIndex;
                 }
             }

--- a/resources/views/romantausch/create_request.blade.php
+++ b/resources/views/romantausch/create_request.blade.php
@@ -6,39 +6,95 @@
                 <form action="{{ route('romantausch.store-request') }}" method="POST" id="request-form">
                     @csrf
 
+                    @php
+                        $selectedSeries = old('series', $types[0]->value ?? '');
+                        $seriesError = $errors->first('series');
+                        $bookNumberError = $errors->first('book_number');
+                        $conditionError = $errors->first('condition');
+                    @endphp
+
                     <div class="mb-4">
-                        <label class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Serie</label>
-                        <select name="series" id="series-select" class="w-full rounded bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200">
+                        <label for="series-select" class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Serie</label>
+                        <select
+                            name="series"
+                            id="series-select"
+                            @class([
+                                'w-full rounded bg-gray-50 dark:bg-gray-700 border text-gray-800 dark:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:focus-visible:ring-[#FF6B81]',
+                                'border-red-500 focus-visible:ring-red-500 dark:border-red-500' => $seriesError,
+                                'border-gray-300 dark:border-gray-600' => !$seriesError,
+                            ])
+                            @if($seriesError)
+                                aria-invalid="true"
+                                aria-describedby="series-error"
+                            @endif
+                        >
                             @foreach($types as $type)
-                                <option value="{{ $type->value }}">{{ $type->value }}</option>
+                                <option value="{{ $type->value }}" @selected($selectedSeries === $type->value)>{{ $type->value }}</option>
                             @endforeach
                         </select>
+                        @error('series')
+                            <p id="series-error" class="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">{{ $message }}</p>
+                        @enderror
                     </div>
 
                     <div class="mb-4">
-                        <label class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Gesuchter Roman</label>
-                        <select name="book_number" id="book-select" class="w-full rounded bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200">
+                        <label for="book-select" class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Gesuchter Roman</label>
+                        <select
+                            name="book_number"
+                            id="book-select"
+                            @class([
+                                'w-full rounded bg-gray-50 dark:bg-gray-700 border text-gray-800 dark:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:focus-visible:ring-[#FF6B81]',
+                                'border-red-500 focus-visible:ring-red-500 dark:border-red-500' => $bookNumberError,
+                                'border-gray-300 dark:border-gray-600' => !$bookNumberError,
+                            ])
+                            @if($bookNumberError)
+                                aria-invalid="true"
+                                aria-describedby="book_number-error"
+                            @endif
+                        >
                             @foreach($books as $book)
-                                <option value="{{ $book->roman_number }}" data-series="{{ $book->type->value }}">
+                                <option
+                                    value="{{ $book->roman_number }}"
+                                    data-series="{{ $book->type->value }}"
+                                    @selected((string) old('book_number') === (string) $book->roman_number)
+                                >
                                     {{ $book->roman_number }} - {{ $book->title }}
                                 </option>
                             @endforeach
                         </select>
+                        @error('book_number')
+                            <p id="book_number-error" class="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">{{ $message }}</p>
+                        @enderror
                     </div>
 
                     <div class="mb-6">
-                        <label class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Zustand bis einschließlich</label>
-                        <select name="condition" class="w-full rounded bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-200">
-                            <option value="Z0">Z0 - Druckfrisch (Top Zustand)</option>
-                            <option value="Z0-1">Z0-1 - Druckfrisch, minimale Mängel</option>
-                            <option value="Z1">Z1 - Sehr gut, Kleinstfehler</option>
-                            <option value="Z1-2">Z1-2 - Sehr gut, leichte Gebrauchsspuren</option>
-                            <option value="Z2">Z2 - Gut, kleine Mängel</option>
-                            <option value="Z2-3">Z2-3 - Gut, stärker gebraucht</option>
-                            <option value="Z3">Z3 - Deutlich gebraucht</option>
-                            <option value="Z3-4">Z3-4 - Sehr stark gebraucht</option>
-                            <option value="Z4">Z4 - Sehr schlecht erhalten</option>
+                        <label for="condition-select" class="block font-medium text-gray-700 dark:text-gray-200 mb-2">Zustand bis einschließlich</label>
+                        <select
+                            name="condition"
+                            id="condition-select"
+                            @class([
+                                'w-full rounded bg-gray-50 dark:bg-gray-700 border text-gray-800 dark:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:focus-visible:ring-[#FF6B81]',
+                                'border-red-500 focus-visible:ring-red-500 dark:border-red-500' => $conditionError,
+                                'border-gray-300 dark:border-gray-600' => !$conditionError,
+                            ])
+                            @if($conditionError)
+                                aria-invalid="true"
+                                aria-describedby="condition-error"
+                            @endif
+                        >
+                            <option value="Z0" @selected(old('condition') === 'Z0')>Z0 - Druckfrisch (Top Zustand)</option>
+                            <option value="Z0-1" @selected(old('condition') === 'Z0-1')>Z0-1 - Druckfrisch, minimale Mängel</option>
+                            <option value="Z1" @selected(old('condition') === 'Z1')>Z1 - Sehr gut, Kleinstfehler</option>
+                            <option value="Z1-2" @selected(old('condition') === 'Z1-2')>Z1-2 - Sehr gut, leichte Gebrauchsspuren</option>
+                            <option value="Z2" @selected(old('condition') === 'Z2')>Z2 - Gut, kleine Mängel</option>
+                            <option value="Z2-3" @selected(old('condition') === 'Z2-3')>Z2-3 - Gut, stärker gebraucht</option>
+                            <option value="Z3" @selected(old('condition') === 'Z3')>Z3 - Deutlich gebraucht</option>
+                            <option value="Z3-4" @selected(old('condition') === 'Z3-4')>Z3-4 - Sehr stark gebraucht</option>
+                            <option value="Z4" @selected(old('condition') === 'Z4')>Z4 - Sehr schlecht erhalten</option>
                         </select>
+                        @error('condition')
+                            <p id="condition-error" class="mt-2 text-sm text-red-600 dark:text-red-400" role="alert">{{ $message }}</p>
+                        @enderror
                     </div>
 
                     <button type="submit"
@@ -57,15 +113,21 @@
             function filterBooks() {
                 const series = seriesSelect.value;
                 let firstVisibleIndex = -1;
+                let hasVisibleSelection = false;
                 Array.from(bookSelect.options).forEach((option, idx) => {
                     const match = option.dataset.series === series;
                     option.hidden = !match;
                     option.disabled = !match;
-                    if (match && firstVisibleIndex === -1) {
-                        firstVisibleIndex = idx;
+                    if (match) {
+                        if (firstVisibleIndex === -1) {
+                            firstVisibleIndex = idx;
+                        }
+                        if (option.selected) {
+                            hasVisibleSelection = true;
+                        }
                     }
                 });
-                if (firstVisibleIndex !== -1) {
+                if (!hasVisibleSelection && firstVisibleIndex !== -1) {
                     bookSelect.selectedIndex = firstVisibleIndex;
                 }
             }


### PR DESCRIPTION
This pull request improves the user experience and accessibility of the "Create Offer" and "Create Request" forms for the Romantausch feature. It adds better validation error handling, ensures form fields retain user input on validation failure, and enhances accessibility for users relying on assistive technologies. Additionally, it updates the logic for filtering book options to preserve the user's selection when changing the series. Comprehensive feature tests have been added to verify these improvements.

**Form validation and accessibility improvements:**

* Added dynamic error highlighting, ARIA attributes, and error messages to the `series`, `book_number`, `condition`, and `photos` fields in `create_offer.blade.php` and `create_request.blade.php`, improving accessibility and clarity for validation errors. [[1]](diffhunk://#diff-64fe200ab8cf28a90c063321fa02e3d5323e2f6331a53acd99a3ff4b1be0c817R14-R128) [[2]](diffhunk://#diff-078168115d23b5aefae42aa0b2d4aa0dec5bb7aea4d957ca6d3db99eda9bf21bR9-R97)
* Modified form fields to retain user selections (`old()` values) after validation errors, so users do not lose their input when correcting mistakes. [[1]](diffhunk://#diff-64fe200ab8cf28a90c063321fa02e3d5323e2f6331a53acd99a3ff4b1be0c817R14-R128) [[2]](diffhunk://#diff-078168115d23b5aefae42aa0b2d4aa0dec5bb7aea4d957ca6d3db99eda9bf21bR9-R97)

**Book selection filtering logic:**

* Updated the JavaScript book filtering logic in both forms to preserve the user's selected book if it matches the newly chosen series, rather than always resetting to the first available option. [[1]](diffhunk://#diff-64fe200ab8cf28a90c063321fa02e3d5323e2f6331a53acd99a3ff4b1be0c817R147-R161) [[2]](diffhunk://#diff-078168115d23b5aefae42aa0b2d4aa0dec5bb7aea4d957ca6d3db99eda9bf21bR116-R130)

**Testing enhancements:**

* Added feature tests in `RomantauschControllerTest.php` to verify that validation errors are shown correctly, ARIA attributes are present, and user input is preserved after validation failures for both offer and request forms.