### PR TITLE
Add accessible swap guidance panel to Romantausch index

### DIFF
--- a/lang/de/romantausch.php
+++ b/lang/de/romantausch.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    'info' => [
+        'title' => 'So funktioniert die Romantauschbörse',
+        'intro' => 'Mit wenigen Schritten findest du passende Tauschpartner*innen und behältst jederzeit die Kontrolle über deinen Ablauf.',
+        'steps_aria_label' => 'Schritte für den Tauschprozess',
+        'steps' => [
+            'offer' => [
+                'title' => 'Angebot einstellen',
+                'description' => 'Lege ein Angebot mit Seriennummer, Zustand und optionalen Fotos an, damit andere schnell erkennen, was du tauschen möchtest.',
+                'cta' => 'Angebot erstellen',
+                'cta_aria' => 'Angebot erstellen und zum Formular wechseln',
+            ],
+            'request' => [
+                'title' => 'Gesuch anlegen',
+                'description' => 'Erstelle ein Gesuch mit deinen Wunschromanen, damit dich passende Angebote direkt erreichen können.',
+                'cta' => 'Gesuch erstellen',
+                'cta_aria' => 'Gesuch erstellen und zum Formular wechseln',
+            ],
+            'match' => [
+                'title' => 'Automatisches Matchen',
+                'description' => 'Unsere Plattform gleicht Angebote und Gesuche ab und informiert euch, sobald sich eine passende Kombination ergibt.',
+            ],
+            'confirm' => [
+                'title' => 'Tausch bestätigen',
+                'description' => 'Nach erfolgreicher Kontaktaufnahme bestätigt ihr den Tausch mit einem Klick und sammelt zusätzliche Baxx.',
+            ],
+        ],
+    ],
+];
+

--- a/lang/en/romantausch.php
+++ b/lang/en/romantausch.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    'info' => [
+        'title' => 'How the novel swap works',
+        'intro' => 'Follow these quick steps to find matching trade partners while staying in control of every stage.',
+        'steps_aria_label' => 'Steps of the swapping process',
+        'steps' => [
+            'offer' => [
+                'title' => 'Publish an offer',
+                'description' => 'Create an offer with series number, condition, and optional photos so others immediately know what you provide.',
+                'cta' => 'Create offer',
+                'cta_aria' => 'Create an offer and open the form',
+            ],
+            'request' => [
+                'title' => 'Create a request',
+                'description' => 'Add the novels you are looking for so matching offers can find you instantly.',
+                'cta' => 'Create request',
+                'cta_aria' => 'Create a request and open the form',
+            ],
+            'match' => [
+                'title' => 'Automatic matching',
+                'description' => 'The platform compares offers and requests and notifies you as soon as a fitting combination appears.',
+            ],
+            'confirm' => [
+                'title' => 'Confirm the swap',
+                'description' => 'After reaching out, confirm the swap with one click and earn extra Baxx.',
+            ],
+        ],
+    ],
+];
+

--- a/resources/views/romantausch/index.blade.php
+++ b/resources/views/romantausch/index.blade.php
@@ -16,6 +16,78 @@
                 jeweils <strong>2 Baxx</strong> zusätzlich gutgeschrieben.
             </p>
         </div>
+        <section class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6" aria-labelledby="swap-process-heading">
+            <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <h2 id="swap-process-heading" class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81]">
+                        {{ __('romantausch.info.title') }}
+                    </h2>
+                    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 max-w-3xl">
+                        {{ __('romantausch.info.intro') }}
+                    </p>
+                </div>
+            </div>
+            <ol class="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4" aria-label="{{ __('romantausch.info.steps_aria_label') }}">
+                <li class="flex h-full flex-col gap-3 rounded-lg border border-gray-200 bg-white/60 p-4 dark:border-gray-700 dark:bg-gray-800/60">
+                    <div class="flex items-center gap-3">
+                        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-[#8B0116] text-sm font-semibold text-white dark:bg-[#FF6B81]">1</span>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                            {{ __('romantausch.info.steps.offer.title') }}
+                        </h3>
+                    </div>
+                    <p class="text-sm text-gray-600 dark:text-gray-300">
+                        {{ __('romantausch.info.steps.offer.description') }}
+                    </p>
+                    <div class="mt-auto">
+                        <a href="{{ route('romantausch.create-offer') }}"
+                           class="inline-flex items-center justify-center rounded-md bg-[#8B0116] px-4 py-2 text-sm font-semibold text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] hover:bg-[#A50019] dark:bg-[#C41E3A] dark:hover:bg-[#D63A4D] dark:focus-visible:ring-[#FF6B81]"
+                           aria-label="{{ __('romantausch.info.steps.offer.cta_aria') }}">
+                            {{ __('romantausch.info.steps.offer.cta') }}
+                        </a>
+                    </div>
+                </li>
+                <li class="flex h-full flex-col gap-3 rounded-lg border border-gray-200 bg-white/60 p-4 dark:border-gray-700 dark:bg-gray-800/60">
+                    <div class="flex items-center gap-3">
+                        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-[#8B0116] text-sm font-semibold text-white dark:bg-[#FF6B81]">2</span>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                            {{ __('romantausch.info.steps.request.title') }}
+                        </h3>
+                    </div>
+                    <p class="text-sm text-gray-600 dark:text-gray-300">
+                        {{ __('romantausch.info.steps.request.description') }}
+                    </p>
+                    <div class="mt-auto">
+                        <a href="{{ route('romantausch.create-request') }}"
+                           class="inline-flex items-center justify-center rounded-md bg-gray-700 px-4 py-2 text-sm font-semibold text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-700 hover:bg-gray-800 dark:bg-gray-500 dark:hover:bg-gray-400 dark:focus-visible:ring-[#FF6B81]"
+                           aria-label="{{ __('romantausch.info.steps.request.cta_aria') }}">
+                            {{ __('romantausch.info.steps.request.cta') }}
+                        </a>
+                    </div>
+                </li>
+                <li class="flex h-full flex-col gap-3 rounded-lg border border-gray-200 bg-white/60 p-4 dark:border-gray-700 dark:bg-gray-800/60">
+                    <div class="flex items-center gap-3">
+                        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-[#8B0116] text-sm font-semibold text-white dark:bg-[#FF6B81]">3</span>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                            {{ __('romantausch.info.steps.match.title') }}
+                        </h3>
+                    </div>
+                    <p class="text-sm text-gray-600 dark:text-gray-300">
+                        {{ __('romantausch.info.steps.match.description') }}
+                    </p>
+                </li>
+                <li class="flex h-full flex-col gap-3 rounded-lg border border-gray-200 bg-white/60 p-4 dark:border-gray-700 dark:bg-gray-800/60">
+                    <div class="flex items-center gap-3">
+                        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-[#8B0116] text-sm font-semibold text-white dark:bg-[#FF6B81]">4</span>
+                        <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                            {{ __('romantausch.info.steps.confirm.title') }}
+                        </h3>
+                    </div>
+                    <p class="text-sm text-gray-600 dark:text-gray-300">
+                        {{ __('romantausch.info.steps.confirm.description') }}
+                    </p>
+                </li>
+            </ol>
+        </section>
         @if($activeSwaps->isNotEmpty())
             <div class="bg-white dark:bg-gray-800 shadow-xl sm:rounded-lg p-6 mb-6">
                 <h2 class="text-xl font-semibold text-[#8B0116] dark:text-[#FF6B81] mb-2">Deine Matches</h2>

--- a/tests/Feature/RomantauschControllerTest.php
+++ b/tests/Feature/RomantauschControllerTest.php
@@ -54,6 +54,30 @@ class RomantauschControllerTest extends TestCase
         ]);
     }
 
+    public function test_index_displays_structured_information_panel(): void
+    {
+        $this->putBookData();
+
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        app()->setLocale('de');
+
+        $response = $this->get('/romantauschboerse');
+
+        $response->assertOk();
+        $response->assertSee('aria-label="' . __('romantausch.info.steps_aria_label') . '"', false);
+        $response->assertSeeText(__('romantausch.info.title'));
+        $response->assertSeeTextInOrder([
+            __('romantausch.info.steps.offer.title'),
+            __('romantausch.info.steps.request.title'),
+            __('romantausch.info.steps.match.title'),
+            __('romantausch.info.steps.confirm.title'),
+        ]);
+        $response->assertSeeText(__('romantausch.info.steps.offer.cta'));
+        $response->assertSeeText(__('romantausch.info.steps.request.cta'));
+    }
+
     public function test_complete_swap_marks_entries_completed(): void
     {
         $this->putBookData();


### PR DESCRIPTION
## Summary
- add a responsive, screen-reader-friendly swap steps panel to the Romantausch index view
- extract panel copy into new German and English translation files for future localisation
- cover the new content with a feature test that ensures the key steps and CTA texts are rendered

## Testing
- php artisan test --filter=RomantauschControllerTest

------
https://chatgpt.com/codex/tasks/task_e_68e3a8bc8b88832ea160147500c55786