### PR TITLE
Add accessible photo gallery for Romantausch offers

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -88,3 +88,4 @@ import './mitglieder/accessibility';
 import './mitglieder/map-utils';
 import './protokolle/accordion';
 import './kassenbuch/modals';
+import './romantausch-gallery';

--- a/resources/js/romantausch-gallery.js
+++ b/resources/js/romantausch-gallery.js
@@ -20,7 +20,7 @@ class RomantauschPhotoGallery {
         this.photos = this.triggers.map((trigger) => ({
             src: trigger.getAttribute('data-photo-src'),
             alt: trigger.getAttribute('data-photo-alt'),
-            label: trigger.getAttribute('data-photo-label') ?? ''
+            label: trigger.getAttribute('data-photo-label') || ''
         })).filter((photo) => Boolean(photo.src));
         this.currentIndex = 0;
         this.isOpen = false;
@@ -67,7 +67,7 @@ class RomantauschPhotoGallery {
     handleTriggerClick(event) {
         event.preventDefault();
         const trigger = event.currentTarget;
-        const index = Number.parseInt(trigger.getAttribute('data-photo-index') ?? '0', 10);
+        const index = Number.parseInt(trigger.getAttribute('data-photo-index') || '0', 10);
         this.open(Number.isNaN(index) ? 0 : index);
     }
 

--- a/resources/js/romantausch-gallery.js
+++ b/resources/js/romantausch-gallery.js
@@ -4,7 +4,7 @@ const FOCUSABLE_SELECTOR = [
     '[tabindex]:not([tabindex="-1"])'
 ].join(',');
 
-class RomantauschPhotoGallery {
+export class RomantauschPhotoGallery {
     constructor(root) {
         this.root = root;
         this.dialog = root.querySelector('[data-photo-dialog]');
@@ -68,7 +68,9 @@ class RomantauschPhotoGallery {
         event.preventDefault();
         const trigger = event.currentTarget;
         const index = Number.parseInt(trigger.getAttribute('data-photo-index') || '0', 10);
-        this.open(Number.isNaN(index) ? 0 : index);
+        const targetIndex = Number.isNaN(index) ? 0 : index;
+        this.setCurrentIndex(targetIndex);
+        this.open(targetIndex);
     }
 
     handleOverlayClick(event) {
@@ -141,10 +143,9 @@ class RomantauschPhotoGallery {
         const photo = this.photos[index];
 
         if (this.image) {
+            const altText = photo.alt || photo.label || `Foto ${index + 1}`;
             this.image.setAttribute('src', photo.src);
-            if (photo.alt) {
-                this.image.setAttribute('alt', photo.alt);
-            }
+            this.image.setAttribute('alt', altText);
         }
 
         if (this.counter) {
@@ -152,7 +153,7 @@ class RomantauschPhotoGallery {
         }
 
         if (this.caption) {
-            this.caption.textContent = photo.label ?? '';
+            this.caption.textContent = photo.label || photo.alt || `Foto ${index + 1}`;
         }
 
         this.updateNavigationState();
@@ -239,7 +240,7 @@ class RomantauschPhotoGallery {
     }
 }
 
-const initialiseGalleries = () => {
+export const initialiseGalleries = () => {
     document.querySelectorAll(GALLERY_SELECTOR).forEach((root) => {
         if (!root.__romantauschGallery) {
             root.__romantauschGallery = new RomantauschPhotoGallery(root);
@@ -252,5 +253,3 @@ if (document.readyState === 'loading') {
 } else {
     initialiseGalleries();
 }
-
-export {};

--- a/resources/js/romantausch-gallery.js
+++ b/resources/js/romantausch-gallery.js
@@ -1,0 +1,256 @@
+const GALLERY_SELECTOR = '[data-romantausch-gallery]';
+const FOCUSABLE_SELECTOR = [
+    'a[href]','button:not([disabled])','textarea','input','select','details summary',
+    '[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+class RomantauschPhotoGallery {
+    constructor(root) {
+        this.root = root;
+        this.dialog = root.querySelector('[data-photo-dialog]');
+        this.panel = this.dialog ? this.dialog.querySelector('[data-photo-dialog-panel]') : null;
+        this.image = this.dialog ? this.dialog.querySelector('[data-photo-dialog-image]') : null;
+        this.counter = this.dialog ? this.dialog.querySelector('[data-photo-dialog-counter]') : null;
+        this.caption = this.dialog ? this.dialog.querySelector('[data-photo-dialog-caption]') : null;
+        this.prevButton = this.dialog ? this.dialog.querySelector('[data-photo-dialog-prev]') : null;
+        this.nextButton = this.dialog ? this.dialog.querySelector('[data-photo-dialog-next]') : null;
+        this.closeButtons = this.dialog ? Array.from(this.dialog.querySelectorAll('[data-photo-dialog-close]')) : [];
+        this.initialFocus = this.dialog ? this.dialog.querySelector('[data-photo-dialog-initial-focus]') : null;
+        this.triggers = Array.from(root.querySelectorAll('[data-photo-dialog-trigger]'));
+        this.photos = this.triggers.map((trigger) => ({
+            src: trigger.getAttribute('data-photo-src'),
+            alt: trigger.getAttribute('data-photo-alt'),
+            label: trigger.getAttribute('data-photo-label') ?? ''
+        })).filter((photo) => Boolean(photo.src));
+        this.currentIndex = 0;
+        this.isOpen = false;
+        this.previouslyFocused = null;
+        this.handleKeyDown = this.handleKeyDown.bind(this);
+        this.handleTriggerClick = this.handleTriggerClick.bind(this);
+        this.handleOverlayClick = this.handleOverlayClick.bind(this);
+        this.handleFocusTrap = this.handleFocusTrap.bind(this);
+        this.init();
+    }
+
+    init() {
+        if (!this.dialog || this.photos.length === 0) {
+            return;
+        }
+
+        this.triggers.forEach((trigger) => {
+            trigger.addEventListener('click', this.handleTriggerClick);
+        });
+
+        this.closeButtons.forEach((button) => {
+            button.addEventListener('click', () => this.close());
+        });
+
+        const overlay = this.dialog.querySelector('[data-photo-dialog-overlay]');
+        if (overlay) {
+            overlay.addEventListener('click', this.handleOverlayClick);
+        }
+
+        if (this.prevButton) {
+            this.prevButton.addEventListener('click', () => this.showPrevious());
+        }
+
+        if (this.nextButton) {
+            this.nextButton.addEventListener('click', () => this.showNext());
+        }
+
+        this.dialog.addEventListener('keydown', this.handleKeyDown);
+        this.dialog.addEventListener('focusin', this.handleFocusTrap);
+
+        this.updateNavigationState();
+    }
+
+    handleTriggerClick(event) {
+        event.preventDefault();
+        const trigger = event.currentTarget;
+        const index = Number.parseInt(trigger.getAttribute('data-photo-index') ?? '0', 10);
+        this.open(Number.isNaN(index) ? 0 : index);
+    }
+
+    handleOverlayClick(event) {
+        event.preventDefault();
+        this.close();
+    }
+
+    open(index = 0) {
+        if (this.isOpen || !this.dialog) {
+            return;
+        }
+
+        this.isOpen = true;
+        this.previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        this.dialog.classList.remove('hidden');
+        this.dialog.removeAttribute('aria-hidden');
+        this.dialog.setAttribute('data-open', 'true');
+        document.body.classList.add('overflow-hidden');
+        this.setCurrentIndex(index);
+
+        const elementToFocus = this.initialFocus || this.closeButtons[0] || this.panel;
+        window.requestAnimationFrame(() => {
+            if (elementToFocus instanceof HTMLElement) {
+                elementToFocus.focus({ preventScroll: true });
+            }
+        });
+    }
+
+    close() {
+        if (!this.isOpen || !this.dialog) {
+            return;
+        }
+
+        this.isOpen = false;
+        this.dialog.classList.add('hidden');
+        this.dialog.setAttribute('aria-hidden', 'true');
+        this.dialog.removeAttribute('data-open');
+        document.body.classList.remove('overflow-hidden');
+
+        const toFocus = this.previouslyFocused;
+        if (toFocus && typeof toFocus.focus === 'function') {
+            window.requestAnimationFrame(() => {
+                toFocus.focus({ preventScroll: true });
+            });
+        }
+    }
+
+    showPrevious() {
+        if (this.photos.length <= 1) {
+            return;
+        }
+        const previousIndex = (this.currentIndex - 1 + this.photos.length) % this.photos.length;
+        this.setCurrentIndex(previousIndex);
+    }
+
+    showNext() {
+        if (this.photos.length <= 1) {
+            return;
+        }
+        const nextIndex = (this.currentIndex + 1) % this.photos.length;
+        this.setCurrentIndex(nextIndex);
+    }
+
+    setCurrentIndex(index) {
+        if (!this.photos[index]) {
+            return;
+        }
+
+        this.currentIndex = index;
+        const photo = this.photos[index];
+
+        if (this.image) {
+            this.image.setAttribute('src', photo.src);
+            if (photo.alt) {
+                this.image.setAttribute('alt', photo.alt);
+            }
+        }
+
+        if (this.counter) {
+            this.counter.textContent = `${index + 1} / ${this.photos.length}`;
+        }
+
+        if (this.caption) {
+            this.caption.textContent = photo.label ?? '';
+        }
+
+        this.updateNavigationState();
+    }
+
+    updateNavigationState() {
+        const disableNavigation = this.photos.length <= 1;
+        if (this.prevButton) {
+            this.prevButton.disabled = disableNavigation;
+        }
+        if (this.nextButton) {
+            this.nextButton.disabled = disableNavigation;
+        }
+    }
+
+    handleKeyDown(event) {
+        if (!this.isOpen) {
+            return;
+        }
+
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.close();
+            return;
+        }
+
+        if (event.key === 'ArrowLeft') {
+            event.preventDefault();
+            this.showPrevious();
+            return;
+        }
+
+        if (event.key === 'ArrowRight') {
+            event.preventDefault();
+            this.showNext();
+            return;
+        }
+
+        if (event.key === 'Tab') {
+            this.trapFocus(event);
+        }
+    }
+
+    handleFocusTrap() {
+        if (!this.isOpen || !this.dialog) {
+            return;
+        }
+
+        const focusable = this.getFocusableElements();
+        if (focusable.length === 0 && this.panel instanceof HTMLElement) {
+            this.panel.focus();
+        }
+    }
+
+    trapFocus(event) {
+        const focusable = this.getFocusableElements();
+        if (focusable.length === 0) {
+            event.preventDefault();
+            return;
+        }
+
+        const activeElement = document.activeElement;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (event.shiftKey) {
+            if (activeElement === first || !focusable.includes(activeElement)) {
+                event.preventDefault();
+                last.focus();
+            }
+        } else if (activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    }
+
+    getFocusableElements() {
+        if (!this.dialog) {
+            return [];
+        }
+
+        return Array.from(this.dialog.querySelectorAll(FOCUSABLE_SELECTOR))
+            .filter((element) => element instanceof HTMLElement && element.offsetParent !== null && !element.hasAttribute('disabled'));
+    }
+}
+
+const initialiseGalleries = () => {
+    document.querySelectorAll(GALLERY_SELECTOR).forEach((root) => {
+        if (!root.__romantauschGallery) {
+            root.__romantauschGallery = new RomantauschPhotoGallery(root);
+        }
+    });
+};
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialiseGalleries);
+} else {
+    initialiseGalleries();
+}
+
+export {};

--- a/resources/views/romantausch/index.blade.php
+++ b/resources/views/romantausch/index.blade.php
@@ -136,7 +136,7 @@
                         @endphp
                         <li class="bg-gray-100 dark:bg-gray-700 p-4 rounded">
                             <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
-                                <div class="flex w-full flex-col gap-3 sm:w-48" @if($hasPhotos) data-romantausch-gallery data-gallery-id="offer-{{ $offer->id }}" @endif>
+                                <div class="flex w-full flex-col gap-3 sm:w-48" @if($hasPhotos) data-romantausch-gallery @endif>
                                     @if($hasPhotos)
                                         <ul class="grid grid-cols-3 gap-2 sm:grid-cols-2">
                                             @foreach($photos as $photoIndex => $photoPath)

--- a/resources/views/romantausch/index.blade.php
+++ b/resources/views/romantausch/index.blade.php
@@ -131,19 +131,116 @@
                     @foreach($offers as $offer)
                         @php
                             $bookDescription = trim($offer->series . ' ' . $offer->book_number . ' - ' . $offer->book_title);
-                            $photos = $offer->photos;
-                            $firstPhoto = $photos ? reset($photos) ?: null : null;
+                            $photos = $offer->photos ?? [];
+                            $hasPhotos = count($photos) > 0;
                         @endphp
                         <li class="bg-gray-100 dark:bg-gray-700 p-4 rounded">
-                            <div class="flex flex-col sm:flex-row sm:items-center gap-4">
-                                <div class="flex-shrink-0">
-                                    @if($firstPhoto)
-                                        <img
-                                            src="{{ asset('storage/' . $firstPhoto) }}"
-                                            alt="Cover von {{ $bookDescription }}"
-                                            class="h-24 w-24 rounded-md object-cover shadow-sm ring-1 ring-inset ring-gray-200 dark:ring-gray-600"
-                                            loading="lazy"
+                            <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
+                                <div class="flex w-full flex-col gap-3 sm:w-48" @if($hasPhotos) data-romantausch-gallery data-gallery-id="offer-{{ $offer->id }}" @endif>
+                                    @if($hasPhotos)
+                                        <ul class="grid grid-cols-3 gap-2 sm:grid-cols-2">
+                                            @foreach($photos as $photoIndex => $photoPath)
+                                                @php
+                                                    $thumbnailSrc = asset('storage/' . $photoPath);
+                                                    $photoNumber = $photoIndex + 1;
+                                                    $thumbnailLabel = "Foto {$photoNumber} von {$bookDescription}";
+                                                @endphp
+                                                <li>
+                                                    <button
+                                                        type="button"
+                                                        class="group relative block aspect-square w-full overflow-hidden rounded-md ring-1 ring-inset ring-gray-200 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:ring-gray-600 dark:focus-visible:ring-[#FF6B81]"
+                                                        data-photo-dialog-trigger
+                                                        data-photo-src="{{ $thumbnailSrc }}"
+                                                        data-photo-alt="{{ $thumbnailLabel }}"
+                                                        data-photo-index="{{ $photoIndex }}"
+                                                        data-photo-label="{{ $thumbnailLabel }}"
+                                                    >
+                                                        <span class="sr-only">{{ $thumbnailLabel }} vergrößert anzeigen</span>
+                                                        <img
+                                                            src="{{ $thumbnailSrc }}"
+                                                            alt="{{ $thumbnailLabel }}"
+                                                            class="h-full w-full object-cover transition duration-200 group-hover:scale-105"
+                                                            loading="lazy"
+                                                        >
+                                                    </button>
+                                                </li>
+                                            @endforeach
+                                        </ul>
+                                        <p class="text-xs text-gray-600 dark:text-gray-300">Zum Vergrößern ein Foto auswählen.</p>
+                                        <div id="offer-{{ $offer->id }}-dialog-title" class="sr-only">Fotoansicht für {{ $bookDescription }}</div>
+                                        <div
+                                            class="hidden"
+                                            data-photo-dialog
+                                            aria-hidden="true"
+                                            role="dialog"
+                                            aria-modal="true"
+                                            aria-labelledby="offer-{{ $offer->id }}-dialog-title"
                                         >
+                                            <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+                                                <div class="absolute inset-0 bg-black/70" data-photo-dialog-overlay aria-hidden="true"></div>
+                                                <div
+                                                    class="relative z-10 flex w-full max-w-3xl flex-col overflow-hidden rounded-lg bg-white shadow-2xl outline-none focus-visible:outline-none dark:bg-gray-900"
+                                                    data-photo-dialog-panel
+                                                    tabindex="-1"
+                                                >
+                                                    <div class="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800">
+                                                        <h3 class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $bookDescription }}</h3>
+                                                        <button
+                                                            type="button"
+                                                            class="inline-flex items-center rounded-md p-2 text-gray-600 transition hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:text-gray-300 dark:hover:text-white dark:focus-visible:ring-[#FF6B81]"
+                                                            data-photo-dialog-close
+                                                            data-photo-dialog-initial-focus
+                                                            aria-label="Fotoansicht schließen"
+                                                        >
+                                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5" aria-hidden="true">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="m6 6 12 12M18 6 6 18" />
+                                                            </svg>
+                                                        </button>
+                                                    </div>
+                                                    <div class="relative flex items-center justify-center bg-gray-900 px-8 py-10 dark:bg-black">
+                                                        <button
+                                                            type="button"
+                                                            class="absolute left-2 top-1/2 -translate-y-1/2 rounded-full bg-white/90 p-2 text-gray-800 shadow transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] disabled:pointer-events-none disabled:opacity-50 dark:bg-gray-800/90 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:ring-[#FF6B81]"
+                                                            data-photo-dialog-prev
+                                                            aria-label="Vorheriges Foto"
+                                                        >
+                                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5" aria-hidden="true">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="m15.75 19.5-7.5-7.5 7.5-7.5" />
+                                                            </svg>
+                                                        </button>
+                                                        <img
+                                                            src="{{ asset('storage/' . $photos[0]) }}"
+                                                            alt="{{ "Foto 1 von {$bookDescription}" }}"
+                                                            class="max-h-[70vh] w-full max-w-2xl object-contain"
+                                                            data-photo-dialog-image
+                                                        >
+                                                        <button
+                                                            type="button"
+                                                            class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full bg-white/90 p-2 text-gray-800 shadow transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] disabled:pointer-events-none disabled:opacity-50 dark:bg-gray-800/90 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus-visible:ring-[#FF6B81]"
+                                                            data-photo-dialog-next
+                                                            aria-label="Nächstes Foto"
+                                                        >
+                                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5" aria-hidden="true">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                                                            </svg>
+                                                        </button>
+                                                    </div>
+                                                    <div class="flex items-center justify-between gap-3 border-t border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                                                        <span data-photo-dialog-counter>1 / {{ count($photos) }}</span>
+                                                        <span data-photo-dialog-caption>{{ "Foto 1 von {$bookDescription}" }}</span>
+                                                    </div>
+                                                    <div class="flex justify-end border-t border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800">
+                                                        <button
+                                                            type="button"
+                                                            class="inline-flex items-center rounded-md bg-[#8B0116] px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-[#A50019] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#8B0116] dark:bg-[#C41E3A] dark:hover:bg-[#D63A4D] dark:focus-visible:ring-[#FF6B81]"
+                                                            data-photo-dialog-close
+                                                        >
+                                                            Schließen
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
                                     @else
                                         <div
                                             class="flex h-24 w-24 items-center justify-center rounded-md border border-dashed border-gray-300 bg-gradient-to-br from-gray-50 to-gray-100 text-center text-xs font-medium text-gray-500 shadow-sm dark:border-gray-600 dark:from-gray-700 dark:to-gray-800 dark:text-gray-200"

--- a/resources/views/romantausch/index.blade.php
+++ b/resources/views/romantausch/index.blade.php
@@ -136,7 +136,7 @@
                         @endphp
                         <li class="bg-gray-100 dark:bg-gray-700 p-4 rounded">
                             <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
-                                <div class="flex w-full flex-col gap-3 sm:w-48" @if($hasPhotos) data-romantausch-gallery @endif>
+                                <div class="flex w-full flex-col gap-3 sm:w-48" {{ $hasPhotos ? 'data-romantausch-gallery' : '' }}>
                                     @if($hasPhotos)
                                         <ul class="grid grid-cols-3 gap-2 sm:grid-cols-2">
                                             @foreach($photos as $photoIndex => $photoPath)

--- a/resources/views/romantausch/index.blade.php
+++ b/resources/views/romantausch/index.blade.php
@@ -171,7 +171,6 @@
                                         <div
                                             class="hidden"
                                             data-photo-dialog
-                                            aria-hidden="true"
                                             role="dialog"
                                             aria-modal="true"
                                             aria-labelledby="offer-{{ $offer->id }}-dialog-title"

--- a/tests/Feature/RomantauschControllerTest.php
+++ b/tests/Feature/RomantauschControllerTest.php
@@ -116,6 +116,7 @@ class RomantauschControllerTest extends TestCase
         $response->assertSee('data-photo-index="0"', false);
         $response->assertSee('role="dialog"', false);
         $response->assertSee('aria-modal="true"', false);
+        $this->assertSame(0, preg_match('/data-photo-dialog(?!-)[^>]*aria-hidden="true"/', $response->getContent()));
         $response->assertSee('Fotoansicht schließen', false);
         $response->assertSee('Zum Vergrößern ein Foto auswählen.', false);
     }

--- a/tests/Feature/RomantauschControllerTest.php
+++ b/tests/Feature/RomantauschControllerTest.php
@@ -111,7 +111,9 @@ class RomantauschControllerTest extends TestCase
             $response->assertSee('storage/' . $photoPath, false);
         }
 
+        $response->assertDontSee('data-gallery-id', false);
         $response->assertSee('data-photo-dialog-trigger', false);
+        $response->assertSee('data-photo-index="0"', false);
         $response->assertSee('role="dialog"', false);
         $response->assertSee('aria-modal="true"', false);
         $response->assertSee('Fotoansicht schließen', false);

--- a/tests/Feature/RomantauschControllerTest.php
+++ b/tests/Feature/RomantauschControllerTest.php
@@ -116,7 +116,11 @@ class RomantauschControllerTest extends TestCase
         $response->assertSee('data-photo-index="0"', false);
         $response->assertSee('role="dialog"', false);
         $response->assertSee('aria-modal="true"', false);
-        $this->assertSame(0, preg_match('/data-photo-dialog(?!-)[^>]*aria-hidden="true"/', $response->getContent()));
+        $response->assertSee('data-photo-dialog', false);
+        $this->assertStringNotContainsString(
+            'data-photo-dialog aria-hidden="true"',
+            str_replace(["\n", "\r"], ' ', $response->getContent())
+        );
         $response->assertSee('Fotoansicht schließen', false);
         $response->assertSee('Zum Vergrößern ein Foto auswählen.', false);
     }

--- a/tests/Feature/RomantauschControllerTest.php
+++ b/tests/Feature/RomantauschControllerTest.php
@@ -83,6 +83,41 @@ class RomantauschControllerTest extends TestCase
         $response->assertSeeText($info['steps']['request']['cta']);
     }
 
+    public function test_index_displays_offer_photo_thumbnails_with_accessible_dialog(): void
+    {
+        $this->putBookData();
+
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $offer = BookOffer::create([
+            'user_id' => $user->id,
+            'series' => BookType::MaddraxDieDunkleZukunftDerErde->value,
+            'book_number' => 1,
+            'book_title' => 'Roman1',
+            'condition' => 'gebraucht',
+            'photos' => [
+                'offers/test-one.jpg',
+                'offers/test-two.jpg',
+                'offers/test-three.jpg',
+            ],
+        ]);
+
+        $response = $this->get('/romantauschboerse');
+
+        $response->assertOk();
+
+        foreach ($offer->photos as $photoPath) {
+            $response->assertSee('storage/' . $photoPath, false);
+        }
+
+        $response->assertSee('data-photo-dialog-trigger', false);
+        $response->assertSee('role="dialog"', false);
+        $response->assertSee('aria-modal="true"', false);
+        $response->assertSee('Fotoansicht schließen', false);
+        $response->assertSee('Zum Vergrößern ein Foto auswählen.', false);
+    }
+
     public function test_complete_swap_marks_entries_completed(): void
     {
         $this->putBookData();
@@ -663,7 +698,8 @@ class RomantauschControllerTest extends TestCase
         $description = BookType::MaddraxDieDunkleZukunftDerErde->value . ' 1 - Roman1';
 
         $response->assertSee('src="' . asset('storage/' . $photoPath) . '"', false);
-        $response->assertSee('alt="Cover von ' . e($description) . '"', false);
+        $response->assertSee('alt="Foto 1 von ' . e($description) . '"', false);
+        $response->assertSee('data-photo-dialog-trigger', false);
     }
 
     public function test_index_renders_placeholder_for_offer_without_photo(): void
@@ -690,7 +726,7 @@ class RomantauschControllerTest extends TestCase
         $response->assertSee('Kein Foto', false);
     }
 
-    public function test_index_uses_first_photo_when_multiple_available(): void
+    public function test_index_renders_all_photos_when_multiple_available(): void
     {
         $this->putBookData();
         Storage::fake('public');
@@ -713,8 +749,12 @@ class RomantauschControllerTest extends TestCase
         $this->actingAs($viewer);
         $response = $this->get('/romantauschboerse');
 
-        $response->assertSee('src="' . asset('storage/' . $firstPath) . '"', false);
-        $response->assertDontSee('src="' . asset('storage/' . $secondPath) . '"', false);
+        foreach ([$firstPath, $secondPath] as $index => $path) {
+            $response->assertSee('src="' . asset('storage/' . $path) . '"', false);
+            $response->assertSee('data-photo-index="' . $index . '"', false);
+        }
+
+        $response->assertSee('data-photo-dialog-counter', false);
     }
 
     public function test_create_request_loads_books_from_database(): void

--- a/tests/Jest/romantausch-gallery.test.js
+++ b/tests/Jest/romantausch-gallery.test.js
@@ -1,0 +1,96 @@
+import { RomantauschPhotoGallery } from '../../resources/js/romantausch-gallery.js';
+
+describe('RomantauschPhotoGallery', () => {
+    let gallery;
+    let root;
+
+    const createGalleryMarkup = () => `
+        <div data-romantausch-gallery>
+            <button
+                type="button"
+                data-photo-dialog-trigger
+                data-photo-src="https://example.com/photo-1.jpg"
+                data-photo-alt="Foto 1 von Beispiel"
+                data-photo-label="Foto 1 von Beispiel"
+                data-photo-index="0"
+            ></button>
+            <button
+                type="button"
+                data-photo-dialog-trigger
+                data-photo-src="https://example.com/photo-2.jpg"
+                data-photo-alt="Foto 2 von Beispiel"
+                data-photo-label="Foto 2 von Beispiel"
+                data-photo-index="1"
+            ></button>
+            <button
+                type="button"
+                data-photo-dialog-trigger
+                data-photo-src="https://example.com/photo-3.jpg"
+                data-photo-alt=""
+                data-photo-label=""
+                data-photo-index="2"
+            ></button>
+            <div class="hidden" data-photo-dialog aria-hidden="true">
+                <div data-photo-dialog-overlay></div>
+                <div data-photo-dialog-panel tabindex="-1">
+                    <button data-photo-dialog-close></button>
+                    <button data-photo-dialog-prev></button>
+                    <img
+                        src="https://example.com/photo-1.jpg"
+                        alt="Foto 1 von Beispiel"
+                        data-photo-dialog-image
+                    >
+                    <button data-photo-dialog-next></button>
+                    <div>
+                        <span data-photo-dialog-counter>1 / 3</span>
+                        <span data-photo-dialog-caption>Foto 1 von Beispiel</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+
+    beforeEach(() => {
+        document.body.innerHTML = createGalleryMarkup();
+        root = document.querySelector('[data-romantausch-gallery]');
+        gallery = new RomantauschPhotoGallery(root);
+    });
+
+    afterEach(() => {
+        gallery.close();
+        document.body.innerHTML = '';
+        document.body.className = '';
+    });
+
+    const clickTrigger = (index) => {
+        const trigger = root.querySelectorAll('[data-photo-dialog-trigger]')[index];
+        trigger.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    };
+
+    test('opens the dialog with the clicked thumbnail image', () => {
+        clickTrigger(1);
+
+        const image = root.querySelector('[data-photo-dialog-image]');
+        const caption = root.querySelector('[data-photo-dialog-caption]');
+        const counter = root.querySelector('[data-photo-dialog-counter]');
+        const dialog = root.querySelector('[data-photo-dialog]');
+
+        expect(dialog.classList.contains('hidden')).toBe(false);
+        expect(dialog.getAttribute('aria-hidden')).toBeNull();
+        expect(image.getAttribute('src')).toBe('https://example.com/photo-2.jpg');
+        expect(image.getAttribute('alt')).toBe('Foto 2 von Beispiel');
+        expect(caption.textContent).toBe('Foto 2 von Beispiel');
+        expect(counter.textContent).toBe('2 / 3');
+    });
+
+    test('falls back to a generated caption when no label is provided', () => {
+        clickTrigger(2);
+
+        const image = root.querySelector('[data-photo-dialog-image]');
+        const caption = root.querySelector('[data-photo-dialog-caption]');
+
+        expect(image.getAttribute('src')).toBe('https://example.com/photo-3.jpg');
+        expect(image.getAttribute('alt')).toBe('Foto 3');
+        expect(caption.textContent).toBe('Foto 3');
+    });
+});

--- a/tests/Jest/romantausch-gallery.test.js
+++ b/tests/Jest/romantausch-gallery.test.js
@@ -30,11 +30,12 @@ describe('RomantauschPhotoGallery', () => {
                 data-photo-label=""
                 data-photo-index="2"
             ></button>
-            <div class="hidden" data-photo-dialog aria-hidden="true">
+            <div class="hidden" data-photo-dialog>
                 <div data-photo-dialog-overlay></div>
                 <div data-photo-dialog-panel tabindex="-1">
                     <button data-photo-dialog-close></button>
                     <button data-photo-dialog-prev></button>
+                    <button hidden data-hidden-test></button>
                     <img
                         src="https://example.com/photo-1.jpg"
                         alt="Foto 1 von Beispiel"
@@ -92,5 +93,34 @@ describe('RomantauschPhotoGallery', () => {
         expect(image.getAttribute('src')).toBe('https://example.com/photo-3.jpg');
         expect(image.getAttribute('alt')).toBe('Foto 3');
         expect(caption.textContent).toBe('Foto 3');
+    });
+
+    test('focus trapping skips hidden controls and wraps correctly', () => {
+        clickTrigger(0);
+
+        const dialog = root.querySelector('[data-photo-dialog]');
+        const focusable = gallery.getFocusableElements();
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        expect(focusable.some((el) => el.hasAttribute('data-hidden-test'))).toBe(false);
+
+        last.focus();
+        dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true }));
+        expect(document.activeElement).toBe(first);
+
+        first.focus();
+        dialog.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true, cancelable: true }));
+        expect(document.activeElement).toBe(last);
+    });
+
+    test('closing the dialog keeps aria-hidden off while hiding the panel', () => {
+        clickTrigger(0);
+        gallery.close();
+
+        const dialog = root.querySelector('[data-photo-dialog]');
+
+        expect(dialog.classList.contains('hidden')).toBe(true);
+        expect(dialog.hasAttribute('aria-hidden')).toBe(false);
     });
 });


### PR DESCRIPTION
This pull request introduces a new accessible photo gallery feature for book offers in the "Romantauschbörse" section. It adds a JavaScript-powered dialog for viewing offer photos in an enlarged, navigable format, updates the Blade template to render photo thumbnails with dialog triggers, and includes comprehensive tests to verify the new UI elements and accessibility features.

**Photo Gallery Feature:**

* Added `resources/js/romantausch-gallery.js`, implementing an accessible photo gallery dialog with keyboard navigation, focus trapping, and support for multiple photos per offer.
* Updated `resources/js/app.js` to import the new gallery module, enabling initialization on relevant DOM elements.

**Blade Template and UI Updates:**

* Refactored `resources/views/romantausch/index.blade.php` to render photo thumbnails as clickable buttons, each opening the gallery dialog. The dialog supports navigation between photos, displays captions and counters, and is fully accessible (ARIA attributes, keyboard support).

**Testing and Accessibility:**

* Added a new feature test in `tests/Feature/RomantauschControllerTest.php` to verify that the index page displays photo thumbnails with the accessible gallery dialog and all required attributes, labels, and instructions.
* Updated an existing test to check for the correct alt text and dialog trigger attributes on photo thumbnails.