### PR TITLE
Allow Vorstand and Admin to delete challenges

### DIFF
--- a/app/Policies/TodoPolicy.php
+++ b/app/Policies/TodoPolicy.php
@@ -26,7 +26,9 @@ class TodoPolicy
 
     public function delete(User $user, Todo $todo): bool
     {
-        return $this->update($user, $todo);
+        $role = $this->role($user);
+
+        return $role && in_array($role, [Role::Vorstand, Role::Admin], true);
     }
 
     public function assign(User $user, Todo $todo): bool

--- a/resources/views/todos/show.blade.php
+++ b/resources/views/todos/show.blade.php
@@ -110,23 +110,25 @@
                 </div>
 
                 <!-- Aktionen -->
-                <div class="flex justify-between mt-8">
-                    <a href="{{ route('todos.index') }}"
-                        class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-700 border border-transparent rounded-md font-semibold text-gray-800 dark:text-white hover:bg-gray-300 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
-                        <svg class="h-5 w-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
-                        </svg>
-                        Zurück zur Übersicht
-                    </a>
-                    @if($canEdit)
-                        <a href="{{ route('todos.edit', $todo) }}"
-                            class="ml-2 inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                            Bearbeiten
+                <div class="mt-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <a href="{{ route('todos.index') }}"
+                            class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-700 border border-transparent rounded-md font-semibold text-gray-800 dark:text-white hover:bg-gray-300 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                            <svg class="h-5 w-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+                            </svg>
+                            Zurück zur Übersicht
                         </a>
-                    @endif
-                    <div>
+                        @if($canEdit)
+                            <a href="{{ route('todos.edit', $todo) }}"
+                                class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                                Bearbeiten
+                            </a>
+                        @endif
+                    </div>
+                    <div class="flex flex-wrap items-center gap-2 md:justify-end">
                         @if($canAssign)
                             <form action="{{ route('todos.assign', $todo) }}" method="POST" class="inline">
                                 @csrf
@@ -162,6 +164,22 @@
                                 <button type="submit"
                                     class="inline-flex items-center px-4 py-2 bg-gray-500 border border-transparent rounded-md font-semibold text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
                                     Challenge freigeben
+                                </button>
+                            </form>
+                        @endif
+                        @if($canDelete)
+                            <form action="{{ route('todos.destroy', $todo) }}" method="POST" class="inline"
+                                onsubmit="return confirm('Möchtest du diese Challenge wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.');">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit"
+                                    class="inline-flex items-center px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">
+                                    <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5-4h4m-4 0a1 1 0 00-1 1v1h6V4a1 1 0 00-1-1m-4 0h4"></path>
+                                    </svg>
+                                    Challenge löschen
                                 </button>
                             </form>
                         @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -111,6 +111,7 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::post('{todo}/abschliessen', 'complete')->name('complete');
         Route::post('{todo}/pruefen', 'verify')->name('verify');
         Route::post('{todo}/freigeben', 'release')->name('release');
+        Route::delete('{todo}', 'destroy')->name('destroy');
     });
     Route::prefix('hoerbuecher')->name('hoerbuecher.')->controller(HoerbuchController::class)->group(function () {
         Route::get('/', 'index')->name('index')->middleware('hoerbuch-access');

--- a/tests/Feature/TodoControllerTest.php
+++ b/tests/Feature/TodoControllerTest.php
@@ -323,6 +323,47 @@ class TodoControllerTest extends TestCase
         $response->assertViewIs('todos.show');
         $response->assertViewHas('canAssign', true);
         $response->assertViewHas('canEdit', true);
+        $response->assertViewHas('canDelete', false);
+    }
+
+    public function test_vorstand_can_delete_todo(): void
+    {
+        $vorstand = $this->actingMember('Vorstand');
+        $todo = $this->createTodo($vorstand);
+        $this->actingAs($vorstand);
+
+        $response = $this->delete(route('todos.destroy', $todo));
+
+        $response->assertRedirect(route('todos.index', [], false));
+        $response->assertSessionHas('status', 'Challenge wurde erfolgreich gelöscht.');
+        $this->assertDatabaseMissing('todos', ['id' => $todo->id]);
+    }
+
+    public function test_admin_can_delete_todo(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $creator = $this->actingMember('Vorstand');
+        $todo = $this->createTodo($creator);
+        $this->actingAs($admin);
+
+        $response = $this->delete(route('todos.destroy', $todo));
+
+        $response->assertRedirect(route('todos.index', [], false));
+        $response->assertSessionHas('status', 'Challenge wurde erfolgreich gelöscht.');
+        $this->assertDatabaseMissing('todos', ['id' => $todo->id]);
+    }
+
+    public function test_member_cannot_delete_todo(): void
+    {
+        $creator = $this->actingMember('Vorstand');
+        $todo = $this->createTodo($creator);
+        $member = $this->actingMember();
+        $this->actingAs($member);
+
+        $response = $this->delete(route('todos.destroy', $todo));
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('todos', ['id' => $todo->id]);
     }
 
     public function test_edit_page_loads_for_creator(): void


### PR DESCRIPTION
This pull request adds the ability to permanently delete a "Challenge" (Todo) from the system, restricting this action to users with the "Vorstand" or "Admin" roles. It introduces backend logic, updates authorization policies, enhances the UI to show a delete option where appropriate, and adds comprehensive tests to verify correct permissions and behavior.

**Feature: Todo Deletion**

* Added a new `destroy` method to `TodoController` to handle permanent deletion of a Todo, including authorization and feedback messages.
* Registered a new DELETE route for destroying Todos in `routes/web.php`.

**Authorization & Policy Updates**

* Updated the `delete` method in `TodoPolicy` to allow only "Vorstand" and "Admin" roles to delete Todos.
* Controller now passes `canDelete` to the view, based on the user's permissions.

**UI Enhancements**

* Updated the `todos/show.blade.php` view to display a "Challenge löschen" (Delete Challenge) button for authorized users, with a confirmation prompt. Improved button layout for better usability. [[1]](diffhunk://#diff-b8a567b21d24c339f30a38551740cb99aee9ba87c59070afc97afdbbf07aa255L113-R114) [[2]](diffhunk://#diff-b8a567b21d24c339f30a38551740cb99aee9ba87c59070afc97afdbbf07aa255L125-R131) [[3]](diffhunk://#diff-b8a567b21d24c339f30a38551740cb99aee9ba87c59070afc97afdbbf07aa255R170-R185)

**Testing**

* Added feature tests to verify that only "Vorstand" and "Admin" users can delete Todos, and that regular members cannot. Also checks correct UI permissions.