### PR TITLE
Add Satzung navigation link for authenticated members

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -51,6 +51,7 @@
                                 <x-dropdown-link href="{{ route('mitglieder.index') }}">Mitgliederliste</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('mitglieder.karte') }}">Mitgliederkarte</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('protokolle') }}">Protokolle</x-dropdown-link>
+                                <x-dropdown-link href="{{ route('satzung') }}">Satzung</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('kassenbuch.index') }}">Kassenbuch</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('reviews.index') }}">Rezensionen</x-dropdown-link>
                                 <x-dropdown-link href="{{ route('romantausch.index') }}">Tauschbörse</x-dropdown-link>
@@ -187,6 +188,7 @@
                 <x-responsive-nav-link href="{{ route('mitglieder.index') }}">Mitgliederliste</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('mitglieder.karte') }}">Mitgliederkarte</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('protokolle') }}">Protokolle</x-responsive-nav-link>
+                <x-responsive-nav-link href="{{ route('satzung') }}">Satzung</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('kassenbuch.index') }}">Kassenbuch</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('reviews.index') }}">Rezensionen</x-responsive-nav-link>
                 <x-responsive-nav-link href="{{ route('romantausch.index') }}">Tauschbörse</x-responsive-nav-link>

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -20,6 +20,19 @@ class NavigationMenuTest extends TestCase
         $response->assertSee(route('termine'));
     }
 
+    public function test_authenticated_users_see_satzung_between_protokolle_and_kassenbuch(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertSeeInOrder([
+            '>Protokolle<',
+            '>Satzung<',
+            '>Kassenbuch<',
+        ], false);
+    }
+
     public function test_guests_see_termine_link_in_navigation(): void
     {
         $response = $this->get('/');


### PR DESCRIPTION
This pull request adds a new "Satzung" (statutes) navigation link to both the desktop and mobile navigation menus, and introduces a feature test to ensure it appears in the correct position between "Protokolle" and "Kassenbuch" for authenticated users.

Navigation menu updates:

* Added a `Satzung` link to the desktop navigation menu in `resources/views/navigation-menu.blade.php`, placed between the `Protokolle` and `Kassenbuch` links.
* Added a `Satzung` link to the mobile (responsive) navigation menu in `resources/views/navigation-menu.blade.php`, also positioned between `Protokolle` and `Kassenbuch`.

Testing improvements:

* Added a feature test in `tests/Feature/NavigationMenuTest.php` to verify that authenticated users see the `Satzung` link in the correct order in the navigation menu.