### PR TITLE
Add PHP 8.5 to PHPUnit workflow

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -46,7 +46,11 @@ jobs:
             ${{ runner.os }}-php-${{ matrix.php-version }}-
             ${{ runner.os }}-
       - name: Install Dependencies
+        if: matrix.php-version != '8.5'
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+      - name: Install Dependencies (ignore platform for PHP 8.5)
+        if: matrix.php-version == '8.5'
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --ignore-platform-req=php
       - name: Directory Permissions
         run: chmod -R 777 storage bootstrap/cache
       - name: Create Database


### PR DESCRIPTION
This pull request updates the PHPUnit GitHub Actions workflow to add support for PHP 8.4 and 8.5, and adjusts dependency installation to handle PHP 8.5 compatibility issues. The main changes are:

**PHP Version Support:**
* Expanded the test matrix in `.github/workflows/phpunit.yml` to include PHP 8.4 and 8.5, ensuring the test suite runs against upcoming PHP versions.

**Dependency Installation Adjustments:**
* Modified the dependency installation step to use the `--ignore-platform-req=php` flag for PHP 8.5, allowing Composer to install dependencies even if some packages are not yet compatible with PHP 8.5.