### PR TITLE
Add PHP 8.5 compatibility workflow

### DIFF
--- a/.github/workflows/php-8-5-compatibility.yml
+++ b/.github/workflows/php-8-5-compatibility.yml
@@ -1,0 +1,115 @@
+name: PHP 8.5 Compatibility Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  pest:
+    runs-on: ubuntu-latest
+    name: Pest under PHP 8.5
+    env:
+      APP_KEY: ${{ secrets.APP_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
+        with:
+          php-version: '8.5'
+      - name: Copy .env
+        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.5-composer-
+            ${{ runner.os }}-php-8.5-
+            ${{ runner.os }}-
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-php-8.5-composer-cache-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.5-composer-cache-
+            ${{ runner.os }}-php-8.5-
+            ${{ runner.os }}-
+      - name: Install PHP dependencies
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist --ignore-platform-req=php
+      - name: Directory Permissions
+        run: chmod -R 777 storage bootstrap/cache
+      - name: Create Database
+        run: |
+          mkdir -p database
+          touch database/database.sqlite
+      - name: Setup Node.js and build assets
+        uses: ./.github/actions/build-assets
+      - name: Execute Pest suite
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: database/database.sqlite
+        run: php artisan test
+
+  vitest:
+    runs-on: ubuntu-latest
+    name: Vitest under PHP 8.5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
+        with:
+          php-version: '8.5'
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, pdo_mysql, xdebug
+          tools: composer:v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Run Vitest unit tests
+        run: npm run test:vitest
+        env:
+          LARAVEL_BYPASS_ENV_CHECK: 1
+
+  playwright:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser: [chromium, firefox, webkit]
+    name: Playwright ${{ matrix.browser }} under PHP 8.5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
+        with:
+          php-version: '8.5'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --ignore-platform-req=php
+      - run: cp .env.example .env
+      - run: php artisan key:generate
+      - name: Configure SQLite
+        run: |
+          sed -i 's/^DB_CONNECTION=.*/DB_CONNECTION=sqlite/' .env
+          sed -i 's/^DB_DATABASE=.*/DB_DATABASE=database\/database.sqlite/' .env
+          touch database/database.sqlite
+      - run: php artisan migrate --force
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npx playwright install-deps ${{ matrix.browser }}
+      - run: npx playwright install ${{ matrix.browser }}
+      - run: npx playwright test --browser=${{ matrix.browser }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to ensure compatibility with PHP 8.5 by running automated tests across multiple test suites and browsers. The workflow is designed to catch any issues early when upgrading to or supporting PHP 8.5.

The most important changes are:

**CI/CD: PHP 8.5 Compatibility Workflow**
* Added a new workflow file, `.github/workflows/php-8-5-compatibility.yml`, to run automated tests using PHP 8.5 for the following test suites: Pest, Vitest, and Playwright.

**Test Coverage:**
* The workflow runs backend tests with Pest, including environment setup, Composer caching, and database creation.
* The workflow runs frontend unit tests with Vitest, ensuring Node.js and PHP 8.5 compatibility.
* The workflow runs Playwright end-to-end tests across Chromium, Firefox, and WebKit browsers, validating cross-browser compatibility under PHP 8.5.