### PR TITLE
Run Volk der Tiefe crawler from crawlnovels

### DIFF
--- a/app/Console/Commands/CrawlNovels.php
+++ b/app/Console/Commands/CrawlNovels.php
@@ -54,6 +54,7 @@ class CrawlNovels extends Command
             $this->info('maddrax.json updated.');
 
             $this->call(CrawlMissionMars::class);
+            $this->call(CrawlVolkDerTiefe::class);
 
             return $this->call(CrawlHardcovers::class);
         }
@@ -63,12 +64,12 @@ class CrawlNovels extends Command
         return self::FAILURE;
     }
 
-    private function getUrlContent(string $url): string|false
+    protected function getUrlContent(string $url): string|false
     {
         return @file_get_contents($url);
     }
 
-    private function getArticleUrls(string $categoryUrl): array
+    protected function getArticleUrls(string $categoryUrl): array
     {
         $html = $this->getUrlContent($categoryUrl);
         if ($html === false) {
@@ -93,7 +94,7 @@ class CrawlNovels extends Command
         return $urls;
     }
 
-    private function getHeftromanInfo(string $url): ?array
+    protected function getHeftromanInfo(string $url): ?array
     {
         $html = $this->getUrlContent($url);
         if ($html === false) {
@@ -158,7 +159,7 @@ class CrawlNovels extends Command
         return null;
     }
 
-    private function writeHeftromane(array $data, string $filename): bool
+    protected function writeHeftromane(array $data, string $filename): bool
     {
         $jsonData = [];
         foreach ($data as $row) {


### PR DESCRIPTION
This pull request enhances the `CrawlNovels` command by adding a new crawler trigger, improves code testability by changing method visibility, and introduces a comprehensive test to ensure all related crawlers are executed. The most important changes are:

**Command enhancements:**

* The `CrawlNovels` command now triggers the `CrawlVolkDerTiefe` crawler in addition to the existing related crawlers, ensuring all relevant data sources are processed.

**Code maintainability and testability:**

* Several methods in `CrawlNovels` (`getUrlContent`, `getArticleUrls`, `getHeftromanInfo`, and `writeHeftromane`) have been changed from `private` to `protected`, allowing them to be mocked or overridden in tests and subclasses. [[1]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5L66-R72) [[2]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5L96-R97) [[3]](diffhunk://#diff-2b9150d86e4cb140d2352381e0b1cbbc10aa27b88a0a95f166ed64bcb2de67f5L161-R162)

**Testing improvements:**

* A new test, `test_handle_triggers_all_related_crawlers`, was added to verify that the `handle` method of `CrawlNovels` triggers all expected crawler commands, increasing test coverage and reliability.
* Test setup and teardown were improved by ensuring Mockery is closed after each test, preventing potential test pollution.
* Additional imports and minor refactoring were made in the test file to support mocking and improve test structure.