### PR TITLE
Modernize dashboard activity feed

### DIFF
--- a/app/Support/PreviewText.php
+++ b/app/Support/PreviewText.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
+
+class PreviewText
+{
+    public static function make(mixed $content, int $limit): Stringable
+    {
+        return Str::of((string) strip_tags($content ?? ''))
+            ->squish()
+            ->limit($limit);
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -143,13 +143,6 @@
                     </div>
                     <span class="inline-flex items-center gap-1 rounded-full bg-[#8B0116]/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[#8B0116] dark:bg-[#FCA5A5]/10 dark:text-[#FCA5A5]">Live-Feed</span>
                 </div>
-                @php
-                    $previewText = static function ($content, int $limit) {
-                        return \Illuminate\Support\Str::of((string) strip_tags($content ?? ''))
-                            ->squish()
-                            ->limit($limit);
-                    };
-                @endphp
                 <ul class="space-y-3" role="list">
                     @forelse($activities as $activity)
                         @php
@@ -220,7 +213,7 @@
                                     <span>{{ $registrantName }} hat sich zum Fantreffen in Coellen angemeldet</span>
                                 @elseif($activity->subject_type === \App\Models\Review::class)
                                     @php
-                                        $reviewPreview = $previewText($subject->content ?? '', 160);
+                                        $reviewPreview = \App\Support\PreviewText::make($subject->content ?? '', 160);
                                     @endphp
                                     <div class="space-y-1">
                                         <a href="{{ route('reviews.show', $subject->book_id) }}" class="font-semibold text-blue-600 dark:text-blue-400 hover:underline">Neue Rezension: {{ $subject->title }}</a>
@@ -241,7 +234,7 @@
                                 @elseif($activity->subject_type === \App\Models\ReviewComment::class)
                                     @php
                                         $review = $subject?->review;
-                                        $commentPreview = $previewText($subject?->content ?? '', 140);
+                                        $commentPreview = \App\Support\PreviewText::make($subject?->content ?? '', 140);
                                     @endphp
                                     @if($review)
                                         <div class="space-y-1">

--- a/tests/Feature/ActivityFeedTest.php
+++ b/tests/Feature/ActivityFeedTest.php
@@ -18,10 +18,10 @@ use App\Models\AdminMessage;
 use App\Models\FantreffenAnmeldung;
 use App\Enums\BookType;
 use App\Enums\TodoStatus;
+use App\Support\PreviewText;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Database\QueryException;
 use App\Enums\Role;
-use Illuminate\Support\Str;
 
 class ActivityFeedTest extends TestCase
 {
@@ -165,7 +165,7 @@ class ActivityFeedTest extends TestCase
         $response = $this->get('/dashboard');
         $response->assertOk();
         $response->assertSeeText('Neue Rezension: ' . $review->title);
-        $response->assertSeeText(Str::of((string) strip_tags($reviewContent))->squish()->limit(160));
+        $response->assertSeeText(PreviewText::make($reviewContent, 160));
     }
 
     public function test_dashboard_limits_comment_preview_excerpt(): void
@@ -196,7 +196,7 @@ class ActivityFeedTest extends TestCase
 
         $response = $this->get('/dashboard');
         $response->assertOk();
-        $expectedPreview = Str::of((string) strip_tags($longComment))->squish()->limit(140);
+        $expectedPreview = PreviewText::make($longComment, 140);
         $response->assertSeeText('Kommentar zu ' . $review->title . ' von ' . $user->name);
         $response->assertSeeText($expectedPreview);
     }

--- a/tests/Unit/PreviewTextTest.php
+++ b/tests/Unit/PreviewTextTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\PreviewText;
+use Illuminate\Support\Stringable;
+use PHPUnit\Framework\TestCase;
+
+class PreviewTextTest extends TestCase
+{
+    public function test_trims_strips_and_limits_content(): void
+    {
+        $content = '   <p>Dieses Preview wird ordentlich begrenzt und bereinigt.</p>   ';
+
+        $preview = PreviewText::make($content, 20);
+
+        $this->assertInstanceOf(Stringable::class, $preview);
+        $this->assertSame('Dieses Preview wird...', $preview->toString());
+    }
+
+    public function test_returns_empty_stringable_for_blank_content(): void
+    {
+        $preview = PreviewText::make('<div>   </div>', 50);
+
+        $this->assertTrue($preview->isEmpty());
+        $this->assertSame('', $preview->toString());
+    }
+
+    public function test_preserves_unicode_and_squishes_whitespace(): void
+    {
+        $content = "<span>Hallo\n  zusammen   –   viel Spaß! </span>";
+
+        $preview = PreviewText::make($content, 80);
+
+        $this->assertSame('Hallo zusammen – viel Spaß!', $preview->toString());
+    }
+}


### PR DESCRIPTION
This pull request enhances the activity feed on the dashboard by improving the display and handling of review and comment previews, introducing a reusable `PreviewText` utility, and updating related tests. The main focus is on providing concise, well-formatted excerpts for reviews and comments, improving the UI for activity entries, and ensuring robust test coverage for these changes.

**Activity Feed UI and Preview Improvements:**

* Refactored the dashboard activity feed to display more detailed and visually improved activity entries, including type labels, user badges, and better grouping of information. Added concise, squished, and limited-length previews for reviews and comments, shown only when content is present. [[1]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324L139-R146) [[2]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324R158-R203) [[3]](diffhunk://#diff-e720f286fb3c46871afbdac94bfe0293e346e36a23d16d636485431ddefe8324L175-R272)

**Reusable PreviewText Utility:**

* Introduced the `App\Support\PreviewText` class, providing a static `make` method to create clean, whitespace-squished, HTML-free, and length-limited string previews for any content.

**Test Coverage Enhancements:**

* Updated and expanded feature tests in `ActivityFeedTest` to verify the correct display, truncation, and omission of review and comment previews in the dashboard activity feed. [[1]](diffhunk://#diff-6bdef5cc698fedef22d34b4142491edf9dc7f2b6465ee3f45901c1800706c8bbR21) [[2]](diffhunk://#diff-6bdef5cc698fedef22d34b4142491edf9dc7f2b6465ee3f45901c1800706c8bbL140-R260)
* Added a dedicated unit test `PreviewTextTest` to ensure the `PreviewText` utility behaves correctly with various input scenarios, including trimming, stripping HTML, handling blank content, and preserving Unicode.