### PR TITLE
Fix: Tailwind config

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -30,6 +30,12 @@
         );
     }
 
+    input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='file']):not([type='button']):not([type='submit']):not([type='reset']),
+    select,
+    textarea {
+        @apply px-3 py-2;
+    }
+
     .dark body {
         background-image: url('/images/design/dark/concrete_dark.webp');
         background-image: image-set(

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ import typography from '@tailwindcss/typography';
 export default {
     darkMode: 'class',
     content: [
+        './config/**/*.php',
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './vendor/laravel/jetstream/**/*.blade.php',
         './storage/framework/views/*.php',


### PR DESCRIPTION
This pull request introduces a small but useful CSS change to improve the default styling of form elements. Padding is now consistently applied to most input fields, `select`, and `textarea` elements, which will enhance the overall appearance and usability of forms across the application.

* Added default horizontal and vertical padding to most `input` elements (excluding checkboxes, radios, ranges, files, and buttons), as well as `select` and `textarea` elements, using Tailwind's `px-3 py-2` utility classes.