### PR TITLE
Fix: Indexing of novel texts is not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /public/hot
 /public/storage
 /storage/*.key
+/storage/*.index
 /storage/pail
 /vendor
 .env

--- a/composer.lock
+++ b/composer.lock
@@ -63,16 +63,16 @@
         },
         {
             "name": "brick/math",
-            "version": "0.14.2",
+            "version": "0.14.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "55c950aa71a2cabc1d8f2bec1f8a7020bd244aa2"
+                "reference": "6af96b11de3f7d99730c118c200418c48274edb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/55c950aa71a2cabc1d8f2bec1f8a7020bd244aa2",
-                "reference": "55c950aa71a2cabc1d8f2bec1f8a7020bd244aa2",
+                "url": "https://api.github.com/repos/brick/math/zipball/6af96b11de3f7d99730c118c200418c48274edb4",
+                "reference": "6af96b11de3f7d99730c118c200418c48274edb4",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.14.2"
+                "source": "https://github.com/brick/math/tree/0.14.3"
             },
             "funding": [
                 {
@@ -119,7 +119,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-30T14:03:11+00:00"
+            "time": "2026-02-01T15:18:05+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",

--- a/storage/roman_excerpts.index
+++ b/storage/roman_excerpts.index
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f9b04a56828ae9f96a864f2f412ee7d6ae131a8c416cfd31b92052e3c2e12165
-size 124903424

--- a/storage/romane.index
+++ b/storage/romane.index
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55b41e3a7ab7faa748dc4b64dc134fd0cfa4202ffdf74bb2a62bd2a13b339c05
-size 40960


### PR DESCRIPTION
This pull request removes two large binary index files from the repository. This change will help reduce the repository size and prevent unnecessary storage of large files in version control.

Removed binary index files:

* Deleted `storage/roman_excerpts.index`, a large Git LFS-tracked file.
* Deleted `storage/romane.index`, a Git LFS-tracked file.