### PR TITLE
Fix: Kompendium search does not work

### DIFF
--- a/resources/views/pages/kompendium.blade.php
+++ b/resources/views/pages/kompendium.blade.php
@@ -29,7 +29,7 @@
             {{-- Suchschlitz (ab 100 Baxx) -------------------------------- --}}
             @if($showSearch)
                 <div class="mb-4">
-                    <x-input id="search" placeholder="Suchbegriff eingeben … (Enter)" icon="o-magnifying-glass" />
+                    <x-input id="search" placeholder="Suchbegriff eingeben … (Enter)" icon="o-magnifying-glass" data-testid="kompendium-search" />
                 </div>
 
                 {{-- Serien-Filter (wird per JS befüllt) ----------------------- --}}
@@ -61,7 +61,7 @@
     </x-member-page>
 
     {{-- JavaScript nur, wenn Suche erlaubt ---------------------------------- --}}
-    @if($userPoints >= 100)
+    @if($showSearch)
         <script>
             (() => {
                 let page   = 1;
@@ -72,7 +72,7 @@
                 let lastPage = 1;
 
                 const perFetchOffset = 200;                       // px vor Seitenende
-                const $search  = document.getElementById('search');
+                const $search  = document.querySelector('[data-testid="kompendium-search"]');
                 const $results = document.getElementById('results');
                 const $loading = document.getElementById('loading');
                 const $serienFilter = document.getElementById('serien-filter');

--- a/tests/Feature/KompendiumSearchTest.php
+++ b/tests/Feature/KompendiumSearchTest.php
@@ -237,4 +237,276 @@ class KompendiumSearchTest extends TestCase
         $this->assertCount(1, $data);
         $this->assertEquals('001', $data[0]['romanNr']);
     }
+
+    /* --------------------------------------------------------------------- */
+    /*  Pagination */
+    /* --------------------------------------------------------------------- */
+
+    public function test_search_paginates_results_correctly(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+
+        Storage::fake('private');
+
+        // 7 Romane erstellen (5 pro Seite = 2 Seiten)
+        $ids = [];
+        for ($i = 1; $i <= 7; $i++) {
+            $nr = str_pad($i, 3, '0', STR_PAD_LEFT);
+            $path = "romane/maddrax/{$nr} - Roman{$i}.txt";
+            Storage::disk('private')->put($path, "Content roman{$i} with searchterm");
+            $ids[] = $path;
+        }
+
+        $this->mock(KompendiumSearchService::class, function ($mock) use ($ids) {
+            $mock->shouldReceive('search')
+                ->with('searchterm')
+                ->twice()
+                ->andReturn([
+                    'hits' => ['total_hits' => 7],
+                    'ids' => $ids,
+                ]);
+        });
+
+        // Seite 1: 5 Ergebnisse
+        $response = $this->getJson('/kompendium/suche?q=searchterm&page=1');
+        $response->assertOk();
+        $this->assertCount(5, $response->json('data'));
+        $this->assertEquals(1, $response->json('currentPage'));
+        $this->assertEquals(2, $response->json('lastPage'));
+
+        // Seite 2: 2 Ergebnisse
+        $response = $this->getJson('/kompendium/suche?q=searchterm&page=2');
+        $response->assertOk();
+        $this->assertCount(2, $response->json('data'));
+        $this->assertEquals(2, $response->json('currentPage'));
+    }
+
+    /* --------------------------------------------------------------------- */
+    /*  Snippet-Highlighting */
+    /* --------------------------------------------------------------------- */
+
+    public function test_search_generates_snippets_with_mark_highlighting(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+
+        Storage::fake('private');
+        Storage::disk('private')->put(
+            'romane/maddrax/001 - HighlightTest.txt',
+            'Vor dem Suchbegriff steht Text und hier kommt der Maddrax und danach mehr Text.'
+        );
+
+        $this->mock(KompendiumSearchService::class, function ($mock) {
+            $mock->shouldReceive('search')
+                ->with('maddrax')
+                ->once()
+                ->andReturn([
+                    'hits' => ['total_hits' => 1],
+                    'ids' => ['romane/maddrax/001 - HighlightTest.txt'],
+                ]);
+        });
+
+        $response = $this->getJson('/kompendium/suche?q=maddrax');
+
+        $response->assertOk();
+        $data = $response->json('data');
+        $this->assertNotEmpty($data[0]['snippets']);
+
+        // Snippet enthält <mark>-Tags um den Suchbegriff
+        $snippet = $data[0]['snippets'][0];
+        $this->assertStringContainsString('<mark>', $snippet);
+        $this->assertStringContainsString('</mark>', $snippet);
+    }
+
+    /* --------------------------------------------------------------------- */
+    /*  Fehlende Dateien überspringen */
+    /* --------------------------------------------------------------------- */
+
+    public function test_search_skips_files_that_no_longer_exist(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+
+        Storage::fake('private');
+        // Nur eine von zwei Dateien existiert
+        Storage::disk('private')->put('romane/maddrax/001 - Exists.txt', 'Existing content test');
+
+        $this->mock(KompendiumSearchService::class, function ($mock) {
+            $mock->shouldReceive('search')
+                ->with('content')
+                ->once()
+                ->andReturn([
+                    'hits' => ['total_hits' => 2],
+                    'ids' => [
+                        'romane/maddrax/001 - Exists.txt',
+                        'romane/maddrax/002 - Deleted.txt',  // existiert nicht
+                    ],
+                ]);
+        });
+
+        $response = $this->getJson('/kompendium/suche?q=content');
+
+        $response->assertOk();
+        $data = $response->json('data');
+        // Nur die existierende Datei wird zurückgegeben
+        $this->assertCount(1, $data);
+        $this->assertEquals('001', $data[0]['romanNr']);
+        $this->assertEquals('Exists', $data[0]['title']);
+    }
+
+    /* --------------------------------------------------------------------- */
+    /*  Mehrere Serien-Filter gleichzeitig */
+    /* --------------------------------------------------------------------- */
+
+    public function test_search_handles_multiple_serien_filters(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+
+        Storage::fake('private');
+        Storage::disk('private')->put('romane/maddrax/001 - MaddraxRoman.txt', 'Content testterm maddrax');
+        Storage::disk('private')->put('romane/missionmars/001 - MarsRoman.txt', 'Content testterm mars');
+        Storage::disk('private')->put('romane/hardcovers/001 - HCRoman.txt', 'Content testterm hardcover');
+
+        $this->mock(KompendiumSearchService::class, function ($mock) {
+            $mock->shouldReceive('search')
+                ->with('testterm')
+                ->once()
+                ->andReturn([
+                    'hits' => ['total_hits' => 3],
+                    'ids' => [
+                        'romane/maddrax/001 - MaddraxRoman.txt',
+                        'romane/missionmars/001 - MarsRoman.txt',
+                        'romane/hardcovers/001 - HCRoman.txt',
+                    ],
+                ]);
+        });
+
+        // Zwei von drei Serien filtern
+        $response = $this->getJson('/kompendium/suche?q=testterm&serien[]=maddrax&serien[]=missionmars');
+
+        $response->assertOk();
+        $data = $response->json('data');
+        $this->assertCount(2, $data);
+
+        $serien = array_column($data, 'serie');
+        $this->assertContains('maddrax', $serien);
+        $this->assertContains('missionmars', $serien);
+        $this->assertNotContains('hardcovers', $serien);
+
+        // serienCounts zeigt alle 3 (unabhängig vom Filter)
+        $this->assertEquals(3, count($response->json('serienCounts')));
+    }
+
+    /* --------------------------------------------------------------------- */
+    /*  Dateiname ohne Standardformat */
+    /* --------------------------------------------------------------------- */
+
+    public function test_search_handles_filename_without_separator(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+
+        Storage::fake('private');
+        Storage::disk('private')->put('romane/maddrax/BadFormat.txt', 'Some badformat content');
+
+        $this->mock(KompendiumSearchService::class, function ($mock) {
+            $mock->shouldReceive('search')
+                ->with('badformat')
+                ->once()
+                ->andReturn([
+                    'hits' => ['total_hits' => 1],
+                    'ids' => ['romane/maddrax/BadFormat.txt'],
+                ]);
+        });
+
+        $response = $this->getJson('/kompendium/suche?q=badformat');
+
+        $response->assertOk();
+        $data = $response->json('data');
+        $this->assertCount(1, $data);
+        // Fallback bei ungültigem Format
+        $this->assertEquals('???', $data[0]['romanNr']);
+        $this->assertEquals('BadFormat', $data[0]['title']);
+    }
+
+    /* --------------------------------------------------------------------- */
+    /*  JSON-Struktur der Antwort */
+    /* --------------------------------------------------------------------- */
+
+    public function test_search_response_contains_all_required_fields(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+
+        Storage::fake('private');
+        Storage::disk('private')->put('romane/maddrax/001 - TestRoman.txt', 'Content structtest');
+
+        $this->mock(KompendiumSearchService::class, function ($mock) {
+            $mock->shouldReceive('search')
+                ->with('structtest')
+                ->once()
+                ->andReturn([
+                    'hits' => ['total_hits' => 1],
+                    'ids' => ['romane/maddrax/001 - TestRoman.txt'],
+                ]);
+        });
+
+        $response = $this->getJson('/kompendium/suche?q=structtest');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => ['cycle', 'romanNr', 'title', 'serie', 'snippets'],
+                ],
+                'currentPage',
+                'lastPage',
+                'serienCounts',
+            ]);
+    }
+
+    /* --------------------------------------------------------------------- */
+    /*  Leere Seite jenseits der letzten Seite */
+    /* --------------------------------------------------------------------- */
+
+    public function test_search_returns_empty_data_beyond_last_page(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+
+        Storage::fake('private');
+        Storage::disk('private')->put('romane/maddrax/001 - OnlyOne.txt', 'Content pagetest');
+
+        $this->mock(KompendiumSearchService::class, function ($mock) {
+            $mock->shouldReceive('search')
+                ->with('pagetest')
+                ->once()
+                ->andReturn([
+                    'hits' => ['total_hits' => 1],
+                    'ids' => ['romane/maddrax/001 - OnlyOne.txt'],
+                ]);
+        });
+
+        // Seite 999 bei nur 1 Ergebnis
+        $response = $this->getJson('/kompendium/suche?q=pagetest&page=999');
+
+        $response->assertOk();
+        $this->assertEmpty($response->json('data'));
+    }
+
+    /* --------------------------------------------------------------------- */
+    /*  Zugang: Nicht-authentifizierter User */
+    /* --------------------------------------------------------------------- */
+
+    public function test_search_requires_authentication(): void
+    {
+        $this->getJson('/kompendium/suche?q=test')
+            ->assertUnauthorized();
+    }
+
+    public function test_serien_requires_authentication(): void
+    {
+        $this->getJson('/kompendium/serien')
+            ->assertUnauthorized();
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->get('/kompendium')
+            ->assertRedirect('/login');
+    }
 }

--- a/tests/Vitest/kompendium-search.test.js
+++ b/tests/Vitest/kompendium-search.test.js
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+/**
+ * Vitest für die Kompendium-Suche: DOM-Selektor-Verhalten.
+ *
+ * Die maryUI <x-input>-Komponente generiert eine UUID statt der übergebenen id
+ * auf dem <input>-Element. Deshalb muss data-testid statt getElementById verwendet werden.
+ *
+ * Diese Tests stellen sicher, dass das korrekte Selektor-Pattern funktioniert.
+ */
+describe('Kompendium Suche – DOM Selektoren', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('findet das Suchfeld per data-testid Selektor', () => {
+        // Simuliere die maryUI-Ausgabe: das <input> hat eine UUID als id,
+        // aber data-testid wird korrekt durchgereicht
+        document.body.innerHTML = `
+            <fieldset class="fieldset py-0">
+                <label>
+                    <label class="input w-full">
+                        <input id="mary4a5b6c7dsearch" placeholder="Suchbegriff eingeben … (Enter)"
+                               data-testid="kompendium-search" type="text" />
+                    </label>
+                </label>
+            </fieldset>
+        `;
+
+        const el = document.querySelector('[data-testid="kompendium-search"]');
+        expect(el).not.toBeNull();
+        expect(el.tagName).toBe('INPUT');
+        expect(el.getAttribute('placeholder')).toContain('Suchbegriff');
+    });
+
+    it('getElementById("search") findet das maryUI-Input NICHT', () => {
+        // Dies war der Bug: maryUI setzt id="mary<hash>search", nicht id="search"
+        document.body.innerHTML = `
+            <fieldset class="fieldset py-0">
+                <label>
+                    <label class="input w-full">
+                        <input id="mary4a5b6c7dsearch" placeholder="Suchbegriff eingeben … (Enter)"
+                               data-testid="kompendium-search" type="text" />
+                    </label>
+                </label>
+            </fieldset>
+        `;
+
+        const el = document.getElementById('search');
+        expect(el).toBeNull();
+    });
+
+    it('andere DOM-Elemente (results, loading) werden per id korrekt gefunden', () => {
+        document.body.innerHTML = `
+            <div id="results" class="space-y-6"></div>
+            <div id="loading" class="hidden text-center py-4"></div>
+            <div id="serien-filter" class="mb-4 hidden"></div>
+            <div id="serien-checkboxes" class="flex flex-wrap"></div>
+        `;
+
+        expect(document.getElementById('results')).not.toBeNull();
+        expect(document.getElementById('loading')).not.toBeNull();
+        expect(document.getElementById('serien-filter')).not.toBeNull();
+        expect(document.getElementById('serien-checkboxes')).not.toBeNull();
+    });
+});
+
+describe('Kompendium Suche – escapeHtml', () => {
+    // Die escapeHtml-Funktion aus kompendium.blade.php (inline JS)
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    it('escaped HTML-Sonderzeichen korrekt', () => {
+        expect(escapeHtml('<script>alert("xss")</script>')).toBe(
+            '&lt;script&gt;alert("xss")&lt;/script&gt;'
+        );
+    });
+
+    it('escaped Ampersand korrekt', () => {
+        expect(escapeHtml('Tom & Jerry')).toBe('Tom &amp; Jerry');
+    });
+
+    it('lässt normalen Text unverändert', () => {
+        expect(escapeHtml('Maddrax - Die dunkle Zukunft der Erde')).toBe(
+            'Maddrax - Die dunkle Zukunft der Erde'
+        );
+    });
+
+    it('behandelt leeren String', () => {
+        expect(escapeHtml('')).toBe('');
+    });
+
+    it('escaped Anführungszeichen im Kontext', () => {
+        const result = escapeHtml('Er sagte "Hallo" & ging');
+        expect(result).toContain('&amp;');
+        expect(result).toContain('"');
+    });
+});
+
+describe('Kompendium Suche – Serien-Checkboxen', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `
+            <div id="serien-filter" class="mb-4 hidden">
+                <fieldset role="group">
+                    <legend id="serien-filter-legend">Serien filtern:</legend>
+                    <div id="serien-checkboxes" class="flex flex-wrap gap-x-4 gap-y-2" role="group"></div>
+                </fieldset>
+            </div>
+        `;
+    });
+
+    it('verhindert Abwählen der letzten Checkbox', () => {
+        const container = document.getElementById('serien-checkboxes');
+
+        // Eine einzige Checkbox erstellen (bereits gecheckt)
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.name = 'serien';
+        checkbox.value = 'maddrax';
+        checkbox.checked = true;
+        container.appendChild(checkbox);
+
+        // Funktion aus dem Blade-Template nachgebaut
+        function hasCheckedSerie() {
+            return container.querySelectorAll('input[name="serien"]:checked').length > 0;
+        }
+
+        // Simuliere Abwählen
+        checkbox.checked = false;
+
+        // Prüfe: keine Checkbox mehr ausgewählt
+        expect(hasCheckedSerie()).toBe(false);
+
+        // Die Guard-Logik sollte dies verhindern:
+        if (!checkbox.checked && !hasCheckedSerie()) {
+            checkbox.checked = true;
+        }
+
+        expect(checkbox.checked).toBe(true);
+        expect(hasCheckedSerie()).toBe(true);
+    });
+
+    it('erlaubt Abwählen wenn andere Checkboxen noch aktiv', () => {
+        const container = document.getElementById('serien-checkboxes');
+
+        const cb1 = document.createElement('input');
+        cb1.type = 'checkbox';
+        cb1.name = 'serien';
+        cb1.value = 'maddrax';
+        cb1.checked = true;
+
+        const cb2 = document.createElement('input');
+        cb2.type = 'checkbox';
+        cb2.name = 'serien';
+        cb2.value = 'missionmars';
+        cb2.checked = true;
+
+        container.appendChild(cb1);
+        container.appendChild(cb2);
+
+        function hasCheckedSerie() {
+            return container.querySelectorAll('input[name="serien"]:checked').length > 0;
+        }
+
+        // Erste Checkbox abwählen – sollte erlaubt sein, weil cb2 noch aktiv
+        cb1.checked = false;
+        expect(hasCheckedSerie()).toBe(true);
+    });
+
+    it('getSelectedSerien gibt nur ausgewählte Serien zurück', () => {
+        const container = document.getElementById('serien-checkboxes');
+
+        ['maddrax', 'missionmars', 'hardcovers'].forEach((serie, i) => {
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.name = 'serien';
+            cb.value = serie;
+            cb.checked = i < 2; // nur maddrax und missionmars
+            container.appendChild(cb);
+        });
+
+        // Funktion aus dem Blade-Template nachgebaut
+        function getSelectedSerien() {
+            const checkboxes = container.querySelectorAll('input[name="serien"]:checked');
+            return Array.from(checkboxes).map(cb => cb.value);
+        }
+
+        const selected = getSelectedSerien();
+        expect(selected).toEqual(['maddrax', 'missionmars']);
+        expect(selected).not.toContain('hardcovers');
+    });
+});
+
+describe('Kompendium Suche – URL-Parameter-Aufbau', () => {
+    it('baut korrekte Suchparameter mit Serien-Filter auf', () => {
+        const query = 'maddrax';
+        const page = 1;
+        const selectedSerien = ['maddrax', 'missionmars'];
+
+        const params = new URLSearchParams();
+        params.append('q', query);
+        params.append('page', page);
+        selectedSerien.forEach(s => params.append('serien[]', s));
+
+        const url = `/kompendium/suche?${params.toString()}`;
+
+        expect(url).toContain('q=maddrax');
+        expect(url).toContain('page=1');
+        expect(url).toContain('serien%5B%5D=maddrax');
+        expect(url).toContain('serien%5B%5D=missionmars');
+    });
+
+    it('baut korrekte URL ohne Serien-Filter auf', () => {
+        const params = new URLSearchParams();
+        params.append('q', 'test');
+        params.append('page', 1);
+
+        const url = `/kompendium/suche?${params.toString()}`;
+
+        expect(url).toBe('/kompendium/suche?q=test&page=1');
+        expect(url).not.toContain('serien');
+    });
+});
+
+describe('Kompendium Suche – Treffer-Template', () => {
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    const tpl = (roman) => `
+        <div class="border border-base-content/10 rounded p-4">
+            <h2 class="font-semibold text-primary mb-2">
+                ${escapeHtml(roman.cycle)} – ${escapeHtml(roman.romanNr)}: ${escapeHtml(roman.title)}
+            </h2>
+            ${roman.snippets.map(s => `<p class="mb-2 text-sm leading-relaxed">${s}</p>`).join('')}
+        </div>`;
+
+    it('rendert Roman-Treffer korrekt', () => {
+        const roman = {
+            cycle: 'Maddrax - Die dunkle Zukunft der Erde',
+            romanNr: '001',
+            title: 'Der Gott aus dem Eis',
+            snippets: ['…hier kommt der <mark>Suchbegriff</mark> im Text…'],
+        };
+
+        const html = tpl(roman);
+        expect(html).toContain('Maddrax - Die dunkle Zukunft der Erde');
+        expect(html).toContain('001');
+        expect(html).toContain('Der Gott aus dem Eis');
+        expect(html).toContain('<mark>Suchbegriff</mark>');
+    });
+
+    it('escaped XSS in Roman-Metadaten', () => {
+        const roman = {
+            cycle: '<script>alert("xss")</script>',
+            romanNr: '001',
+            title: 'Normal',
+            snippets: [],
+        };
+
+        const html = tpl(roman);
+        expect(html).not.toContain('<script>');
+        expect(html).toContain('&lt;script&gt;');
+    });
+
+    it('rendert mehrere Snippets', () => {
+        const roman = {
+            cycle: 'Test',
+            romanNr: '001',
+            title: 'Test',
+            snippets: ['Snippet 1', 'Snippet 2', 'Snippet 3'],
+        };
+
+        const html = tpl(roman);
+        expect(html).toContain('Snippet 1');
+        expect(html).toContain('Snippet 2');
+        expect(html).toContain('Snippet 3');
+        // Jeder Snippet in eigenem <p>-Tag
+        expect((html.match(/<p class/g) || []).length).toBe(3);
+    });
+
+    it('rendert leere Snippet-Liste', () => {
+        const roman = {
+            cycle: 'Test',
+            romanNr: '001',
+            title: 'Test',
+            snippets: [],
+        };
+
+        const html = tpl(roman);
+        expect(html).not.toContain('<p class="mb-2');
+    });
+});


### PR DESCRIPTION
This pull request introduces several improvements and new tests for the Kompendium search feature. The main focus is on enhancing the frontend search selector logic, ensuring correct script rendering based on permissions, and significantly expanding test coverage for the search endpoint. The tests now cover pagination, snippet highlighting, file existence checks, filtering, response structure, and authentication requirements.

**Frontend improvements:**

* Changed the search input selector in `kompendium.blade.php` to use a `data-testid="kompendium-search"` attribute instead of an ID, and updated the JavaScript to select the input using `querySelector` for better testability and robustness. [[1]](diffhunk://#diff-5175fa063768ad35dd06de86cf7c1b68b4103c1e8752f820b503f9392bf36d47L32-R32) [[2]](diffhunk://#diff-5175fa063768ad35dd06de86cf7c1b68b4103c1e8752f820b503f9392bf36d47L75-R75)
* Updated the condition for rendering the search script block to use `$showSearch` instead of a hardcoded points check, ensuring the script is only included when search is actually available.

**Test coverage enhancements:**

* Added comprehensive feature tests in `KompendiumControllerTest.php` to verify correct rendering of the search input, script blocks, admin button visibility, points warnings, and various search states (e.g., empty index, indexed summary).
* Added extensive tests in `KompendiumSearchTest.php` for search endpoint behaviors, including pagination, snippet highlighting, skipping missing files, handling multiple series filters, fallback for malformed filenames, response structure, empty page handling, and authentication requirements.