### PR TITLE
Fix: Main menu not centered

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -42,7 +42,7 @@
         @livewire('navigation-menu')
 
         {{-- Main Content --}}
-        <main class="w-full">
+        <main class="w-full pt-2">
             {{ $slot }}
         </main>
     </div>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -5,7 +5,7 @@
         </a>
 
         {{-- Desktop-Menü --}}
-        <div class="hidden xl:ml-10 xl:flex xl:items-center xl:gap-1">
+        <div class="hidden flex-1 justify-center xl:flex xl:items-center xl:gap-1">
             @auth
                 <x-button label="Dashboard" link="{{ route('dashboard') }}" class="btn-ghost btn-sm" />
                 <x-button label="Fantreffen 2026" link="{{ route('fantreffen.2026') }}" class="btn-ghost btn-sm" />


### PR DESCRIPTION
This pull request introduces minor layout improvements to the main content area and navigation menu for better visual spacing and alignment.

- Layout adjustments:
  * Added top padding to the `<main>` element in `app.blade.php` to improve spacing above the main content.

- Navigation menu improvements:
  * Updated the desktop navigation menu container in `navigation-menu.blade.php` to use `flex-1` and `justify-center` for better alignment and responsive layout.