### PR TITLE
Fix: Dropdown width in main menu to small

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -14,7 +14,7 @@
                 @endif
 
                 {{-- Dropdown Verein --}}
-                <x-dropdown label="Verein" class="btn-ghost btn-sm" no-x-anchor>
+                <x-dropdown label="Verein" class="btn-ghost btn-sm">
                     <x-menu-item title="Fanfiction" link="{{ route('fanfiction.index') }}" />
                     <x-menu-item title="Mitgliederliste" link="{{ route('mitglieder.index') }}" />
                     <x-menu-item title="Mitgliederkarte" link="{{ route('mitglieder.karte') }}" />
@@ -26,20 +26,20 @@
                 </x-dropdown>
 
                 {{-- Dropdown Veranstaltungen --}}
-                <x-dropdown label="Veranstaltungen" class="btn-ghost btn-sm" no-x-anchor>
+                <x-dropdown label="Veranstaltungen" class="btn-ghost btn-sm">
                     <x-menu-item title="Fotos" link="{{ route('fotogalerie') }}" />
                     <x-menu-item title="Meetings" link="{{ route('meetings') }}" />
                     <x-menu-item title="Termine" link="{{ route('termine') }}" />
                 </x-dropdown>
 
                 {{-- Dropdown Baxx --}}
-                <x-dropdown label="Baxx" class="btn-ghost btn-sm" no-x-anchor>
+                <x-dropdown label="Baxx" class="btn-ghost btn-sm">
                     <x-menu-item title="Challenges" link="{{ route('todos.index') }}" />
                     <x-menu-item title="Belohnungen" link="{{ route('rewards.index') }}" />
                 </x-dropdown>
 
                 {{-- Dropdown Belohnungen --}}
-                <x-dropdown label="Belohnungen" class="btn-ghost btn-sm" no-x-anchor>
+                <x-dropdown label="Belohnungen" class="btn-ghost btn-sm">
                     <x-menu-item title="Maddraxiversum" link="{{ route('maddraxiversum.index') }}" />
                     <x-menu-item title="Downloads" link="{{ route('downloads') }}" />
                     <x-menu-item title="Kompendium" link="{{ route('kompendium.index') }}" />
@@ -48,7 +48,7 @@
 
                 {{-- Dropdown AG (nur wenn Mitglied einer AG oder Vorstand) --}}
                 @if(Auth::user()->teams()->where('personal_team', false)->exists() || Auth::user()->hasVorstandRole())
-                    <x-dropdown label="AG" class="btn-ghost btn-sm" no-x-anchor>
+                    <x-dropdown label="AG" class="btn-ghost btn-sm">
                         @if(Auth::user()->hasVorstandRole() || Auth::user()->isMemberOfTeam('AG Fanhörbücher'))
                             <x-menu-item title="EARDRAX Dashboard" link="{{ route('hoerbuecher.index') }}" />
                         @endif
@@ -63,7 +63,7 @@
 
                 {{-- Dropdown Vorstand (nur Vorstand/Kassenwart/Admin) --}}
                 @if(Auth::user()->hasAnyRole(\App\Enums\Role::Admin, \App\Enums\Role::Vorstand, \App\Enums\Role::Kassenwart))
-                    <x-dropdown label="Vorstand" class="btn-ghost btn-sm" no-x-anchor>
+                    <x-dropdown label="Vorstand" class="btn-ghost btn-sm">
                         <x-menu-item title="Statistik" link="{{ route('admin.statistiken.index') }}" />
                         <x-menu-item title="Anmeldungen FT" link="{{ route('admin.fantreffen.2026') }}" />
                         <x-menu-item title="Fanfiction" link="{{ route('admin.fanfiction.index') }}" />
@@ -75,7 +75,7 @@
 
                 {{-- Dropdown Admin (nur Admin) --}}
                 @if(Auth::user()->hasRole(\App\Enums\Role::Admin))
-                    <x-dropdown label="Admin" class="btn-ghost btn-sm" no-x-anchor>
+                    <x-dropdown label="Admin" class="btn-ghost btn-sm">
                         <x-menu-item title="Newsletter versenden" link="{{ route('newsletter.create') }}" />
                         <x-menu-item title="Kurznachrichten" link="{{ route('admin.messages.index') }}" />
                         <x-menu-item title="Charakter-Editor" link="{{ route('rpg.char-editor') }}" />
@@ -108,7 +108,7 @@
         {{-- Profil-Dropdown / Login (Desktop) --}}
         <div class="hidden xl:flex xl:items-center">
             @auth
-                <x-dropdown no-x-anchor class="dropdown-end">
+                <x-dropdown right>
                     <x-slot:trigger>
                         <button class="flex items-center">
                             <img class="h-8 w-8 rounded-full object-cover" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />


### PR DESCRIPTION
This pull request simplifies the usage of the `x-dropdown` component throughout the `navigation-menu.blade.php` view. The main change is the removal of the `no-x-anchor` attribute from all dropdowns, and in one case, replacing it with the `right` attribute for the profile dropdown. This likely standardizes dropdown alignment and behavior across the navigation menu.

**Navigation dropdown updates:**

* Removed the `no-x-anchor` attribute from all dropdowns in the navigation menu, which affects dropdowns for "Verein," "Veranstaltungen," "Baxx," "Belohnungen," "AG," "Vorstand," and "Admin" (`resources/views/navigation-menu.blade.php`). [[1]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL17-R17) [[2]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL29-R42) [[3]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL51-R51) [[4]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL66-R66) [[5]](diffhunk://#diff-b5ab7079dd7e1e7893fd7b228061417c4c44efb18213c0d3efd422b32579af9dL78-R78)

**Profile dropdown alignment:**

* Replaced `no-x-anchor` with the `right` attribute on the profile dropdown, likely to ensure it aligns to the right edge of the navigation bar (`resources/views/navigation-menu.blade.php`).