### PR TITLE
Fix: Make export buttons responsive on mobile

### DIFF
--- a/resources/views/mitglieder/index.blade.php
+++ b/resources/views/mitglieder/index.blade.php
@@ -78,15 +78,15 @@
             <div class="flex flex-wrap gap-4 items-center justify-between">
                 <h3 class="text-lg font-medium text-base-content">Datenexport & Funktionen</h3>
 
-                <div class="flex space-x-2">
+                <div class="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
                     <!-- CSV Export Button -->
-                    <x-button icon="o-arrow-down-tray" label="CSV Export" @click="showExportOptions = !showExportOptions" class="btn-primary" data-testid="mitglieder-csv-export-btn" />
+                    <x-button icon="o-arrow-down-tray" label="CSV Export" @click="showExportOptions = !showExportOptions" class="btn-primary w-full sm:w-auto" data-testid="mitglieder-csv-export-btn" />
 
                     <!-- E-Mail-Adressen kopieren -->
                     <x-button
                         icon="o-clipboard-document"
                         label="E-Mail-Adressen kopieren"
-                        class="btn-info"
+                        class="btn-info w-full sm:w-auto"
                         @click="
                             fetch('{{ route('mitglieder.all-emails') }}')
                                 .then(response => response.json())


### PR DESCRIPTION
This pull request updates the layout of the action buttons in the "Datenexport & Funktionen" section on the `mitglieder/index.blade.php` view. The main improvement is making the buttons responsive so they stack vertically on small screens and display in a row on larger screens.

**UI/UX improvements:**

* Changed the button container from a horizontal flex layout with `space-x-2` to a responsive column layout with `flex-col sm:flex-row gap-2`, ensuring better usability on mobile devices.
* Added `w-full sm:w-auto` classes to the buttons to make them full width on small screens and auto width on larger screens, improving touch targets and alignment in mobile view.