### PR TITLE
Fix: Modal background not displayed

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -78,6 +78,14 @@ details.dropdown:has(> summary.btn-sm) > ul.menu {
     font-weight: 600;
 }
 
+/* DaisyUI-Modal-Hintergrund: Die Backdrop-Regel (.modal.modal-open) liegt in
+   @layer daisyui.l1.l2 – layered Styles haben niedrigere Priorität als
+   un-layered Styles. Hier un-layered setzen, damit der halbtransparente
+   Overlay zuverlässig angezeigt wird. */
+dialog.modal:is(.modal-open, [open], :target) {
+    background-color: oklch(0% 0 0 / 40%);
+}
+
 @layer base {
     /* Hintergrund wird jetzt vom daisyUI-Theme gesteuert (caramellatte/coffee) */
 


### PR DESCRIPTION
This pull request addresses an issue with the modal backdrop styling to ensure that the semi-transparent overlay is reliably displayed, regardless of DaisyUI's layered style priorities.

**Modal/Backdrop Styling Fix:**

* Added an un-layered CSS rule for `dialog.modal` elements in the `modal-open`, `[open]`, or `:target` state to set the `background-color` with appropriate opacity, ensuring the modal overlay is always visible above DaisyUI's layered styles.