### PR TITLE
Feature: Public Hörbücher status information

### DIFF
--- a/app/Http/Controllers/HoerbuchController.php
+++ b/app/Http/Controllers/HoerbuchController.php
@@ -116,7 +116,7 @@ class HoerbuchController extends Controller
         return $data;
     }
 
-    private function latestSpeakersForNames($names): array
+    private function latestSpeakersForNames($names, ?int $excludeEpisodeId = null): array
     {
         $names = collect($names)->filter()->unique();
         if ($names->isEmpty()) {
@@ -126,6 +126,7 @@ class HoerbuchController extends Controller
         return AudiobookRole::useIndex('audiobook_roles_name_user_speaker_index')
             ->whereIn('name', $names)
             ->where(fn ($q) => $q->whereNotNull('user_id')->orWhereNotNull('speaker_name'))
+            ->when($excludeEpisodeId, fn ($q) => $q->where('episode_id', '!=', $excludeEpisodeId))
             ->with('user')
             ->orderByDesc('id')
             ->orderBy('name')
@@ -139,7 +140,7 @@ class HoerbuchController extends Controller
     {
         $episode->loadMissing('roles');
 
-        return $this->latestSpeakersForNames($episode->roles->pluck('name'));
+        return $this->latestSpeakersForNames($episode->roles->pluck('name'), $episode->id);
     }
 
     /**

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
-Disallow:
+Disallow: /hoerbuecher
+
 Sitemap: https://maddrax-fanclub.de/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
-Disallow: /hoerbuecher
+Disallow:
 
 Sitemap: https://maddrax-fanclub.de/sitemap.xml

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -243,7 +243,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="{{ (auth()->user()?->hasVorstandRole() || auth()->user()?->isMemberOfTeam('AG Fanhörbücher')) ? 7 : 6 }}" class="px-4 py-2 text-center text-base-content">Keine Hörbuchfolgen vorhanden.</td>
+                                <td colspan="{{ (auth()->user()?->hasVorstandRole() || auth()->user()?->isMemberOfTeam('AG Fanhörbücher')) ? 6 : 5 }}" class="px-4 py-2 text-center text-base-content">Keine Hörbuchfolgen vorhanden.</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -1,4 +1,7 @@
 <x-app-layout>
+    <x-slot:head>
+        <meta name="robots" content="noindex, nofollow">
+    </x-slot:head>
     <x-member-page>
         @if(session('status'))
             <x-alert icon="o-check-circle" class="alert-success mb-4">
@@ -7,9 +10,11 @@
         @endif
         <x-card shadow class="mb-6 flex justify-between items-center">
             <x-header title="Hörbuchfolgen" class="!mb-0" />
-            @if(auth()->user()->hasVorstandRole() || auth()->user()->isOwnerOfTeam('AG Fanhörbücher'))
-                <x-button label="Neue Folge" link="{{ route('hoerbuecher.create') }}" wire:navigate icon="o-plus" class="btn-primary" />
-            @endif
+            @auth
+                @if(auth()->user()->hasVorstandRole() || auth()->user()->isOwnerOfTeam('AG Fanhörbücher'))
+                    <x-button label="Neue Folge" link="{{ route('hoerbuecher.create') }}" wire:navigate icon="o-plus" class="btn-primary" />
+                @endif
+            @endauth
         </x-card>
         <div
             x-data="{

--- a/resources/views/hoerbuecher/index.blade.php
+++ b/resources/views/hoerbuecher/index.blade.php
@@ -189,7 +189,9 @@
                             <th>Ziel-EVT</th>
                             <th>Status & Fortschritt</th>
                             <th>Rollenbesetzung</th>
-                            <th>Bemerkungen</th>
+                            @if(auth()->user()?->hasVorstandRole() || auth()->user()?->isMemberOfTeam('AG Fanhörbücher'))
+                                <th>Bemerkungen</th>
+                            @endif
                         </tr>
                     </thead>
                     <tbody>
@@ -235,11 +237,13 @@
                                         </div>
                                     </div>
                                 </td>
-                                <td class="px-4 py-2">{{ $episode->notes }}</td>
+                                @if(auth()->user()?->hasVorstandRole() || auth()->user()?->isMemberOfTeam('AG Fanhörbücher'))
+                                    <td class="px-4 py-2">{{ $episode->notes }}</td>
+                                @endif
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="6" class="px-4 py-2 text-center text-base-content">Keine Hörbuchfolgen vorhanden.</td>
+                                <td colspan="{{ (auth()->user()?->hasVorstandRole() || auth()->user()?->isMemberOfTeam('AG Fanhörbücher')) ? 7 : 6 }}" class="px-4 py-2 text-center text-base-content">Keine Hörbuchfolgen vorhanden.</td>
                             </tr>
                         @endforelse
                     </tbody>

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -73,13 +73,13 @@
                     </div>
                 </div>
                 @endif
-                @auth
+                @if(auth()->user()?->hasVorstandRole() || auth()->user()?->isMemberOfTeam('AG Fanhörbücher'))
                     <div class="md:col-span-2"><span class="font-medium">Verantwortlich:</span> {{ $episode->responsible?->name ?? '-' }}</div>
                     <div class="md:col-span-2">
                         <span class="font-medium">Anmerkungen:</span>
                         <p class="mt-1">{{ $episode->notes }}</p>
                     </div>
-                @endauth
+                @endif
             </div>
 
             @auth

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -73,11 +73,13 @@
                     </div>
                 </div>
                 @endif
-                <div class="md:col-span-2"><span class="font-medium">Verantwortlich:</span> {{ $episode->responsible?->name ?? '-' }}</div>
-                <div class="md:col-span-2">
-                    <span class="font-medium">Anmerkungen:</span>
-                    <p class="mt-1">{{ $episode->notes }}</p>
-                </div>
+                @auth
+                    <div class="md:col-span-2"><span class="font-medium">Verantwortlich:</span> {{ $episode->responsible?->name ?? '-' }}</div>
+                    <div class="md:col-span-2">
+                        <span class="font-medium">Anmerkungen:</span>
+                        <p class="mt-1">{{ $episode->notes }}</p>
+                    </div>
+                @endauth
             </div>
 
             @auth

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -1,4 +1,7 @@
 <x-app-layout>
+    <x-slot:head>
+        <meta name="robots" content="noindex, nofollow">
+    </x-slot:head>
     <x-member-page class="max-w-3xl">
         <x-card shadow>
             <x-header title="{{ $episode->title }}" separator />
@@ -56,10 +59,12 @@
                                     <td>{{ $role->takes }}</td>
                                     <td>
                                         {{ $role->user?->name ?? $role->speaker_name ?? '-' }}
-                                        @php($prev = $previousSpeakers[$role->name] ?? null)
-                                        @if($prev)
-                                            <div class="text-xs text-base-content">Bisheriger Sprecher: {{ $prev }}</div>
-                                        @endif
+                                        @auth
+                                            @php($prev = $previousSpeakers[$role->name] ?? null)
+                                            @if($prev)
+                                                <div class="text-xs text-base-content">Bisheriger Sprecher: {{ $prev }}</div>
+                                            @endif
+                                        @endauth
                                     </td>
                                 </tr>
                                 @endforeach
@@ -75,12 +80,14 @@
                 </div>
             </div>
 
-            @if(auth()->user()->hasVorstandRole() || auth()->user()->isOwnerOfTeam('AG Fanhörbücher'))
-            <div class="mt-6 flex justify-end space-x-3">
-                <x-button label="Bearbeiten" link="{{ route('hoerbuecher.edit', $episode) }}" wire:navigate icon="o-pencil" class="btn-info btn-sm" />
-                <x-confirm-delete :action="route('hoerbuecher.destroy', $episode)" />
-            </div>
-            @endif
+            @auth
+                @if(auth()->user()->hasVorstandRole() || auth()->user()->isOwnerOfTeam('AG Fanhörbücher'))
+                <div class="mt-6 flex justify-end space-x-3">
+                    <x-button label="Bearbeiten" link="{{ route('hoerbuecher.edit', $episode) }}" wire:navigate icon="o-pencil" class="btn-info btn-sm" />
+                    <x-confirm-delete :action="route('hoerbuecher.destroy', $episode)" />
+                </div>
+                @endif
+            @endauth
             <div class="mt-6">
                 <x-button label="« Zurück zur Übersicht" link="{{ route('hoerbuecher.index') }}" wire:navigate icon="o-arrow-left" class="btn-ghost btn-sm" />
             </div>

--- a/resources/views/hoerbuecher/show.blade.php
+++ b/resources/views/hoerbuecher/show.blade.php
@@ -59,12 +59,12 @@
                                     <td>{{ $role->takes }}</td>
                                     <td>
                                         {{ $role->user?->name ?? $role->speaker_name ?? '-' }}
-                                        @auth
+                                        @if(auth()->user()?->hasVorstandRole() || auth()->user()?->isMemberOfTeam('AG Fanhörbücher'))
                                             @php($prev = $previousSpeakers[$role->name] ?? null)
                                             @if($prev)
                                                 <div class="text-xs text-base-content">Bisheriger Sprecher: {{ $prev }}</div>
                                             @endif
-                                        @endauth
+                                        @endif
                                     </td>
                                 </tr>
                                 @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,8 +71,11 @@ Route::get('/maddrax-fantreffen-2026', [FantreffenController::class, 'create'])-
 Route::post('/maddrax-fantreffen-2026', [FantreffenController::class, 'store'])->middleware('throttle:fantreffen-registration')->name('fantreffen.2026.store');
 Route::get('/maddrax-fantreffen-2026/bestaetigung/{id}', [FantreffenController::class, 'bestaetigung'])->name('fantreffen.2026.bestaetigung');
 
-// Hörbücher – Übersicht öffentlich lesbar (kein Auth nötig), aber nicht im Menü / nicht indexiert
-Route::get('/hoerbuecher', [HoerbuchController::class, 'index'])->name('hoerbuecher.index');
+// Hörbücher – Übersicht + Einzelfolgen öffentlich lesbar (kein Auth nötig), aber nicht im Menü / nicht indexiert
+Route::prefix('hoerbuecher')->name('hoerbuecher.')->controller(HoerbuchController::class)->group(function () {
+    Route::get('/', 'index')->name('index');
+    Route::get('{episode}', 'show')->name('show')->whereNumber('episode');
+});
 
 // POST Route für Mitgliedschaftsantrag
 Route::post('/mitglied-werden', [MitgliedschaftController::class, 'store'])->name('mitglied.store');
@@ -181,9 +184,6 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
             Route::delete('{episode}', 'destroy')->name('destroy');
         });
     });
-
-    // Hörbücher – Einzelfolge öffentlich lesbar (nach Management-Routen, damit {episode}-Wildcard nicht 'erstellen' fängt)
-    Route::get('/hoerbuecher/{episode}', [HoerbuchController::class, 'show'])->name('hoerbuecher.show')->withoutMiddleware(['auth', 'verified', 'redirect.if.anwaerter']);
 
     Route::prefix('admin/arbeitsgruppen')->name('arbeitsgruppen.')->controller(ArbeitsgruppenController::class)->middleware('auth')->group(function () {
         Route::get('/', 'index')->name('index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,6 +71,9 @@ Route::get('/maddrax-fantreffen-2026', [FantreffenController::class, 'create'])-
 Route::post('/maddrax-fantreffen-2026', [FantreffenController::class, 'store'])->middleware('throttle:fantreffen-registration')->name('fantreffen.2026.store');
 Route::get('/maddrax-fantreffen-2026/bestaetigung/{id}', [FantreffenController::class, 'bestaetigung'])->name('fantreffen.2026.bestaetigung');
 
+// Hörbücher – Übersicht öffentlich lesbar (kein Auth nötig), aber nicht im Menü / nicht indexiert
+Route::get('/hoerbuecher', [HoerbuchController::class, 'index'])->name('hoerbuecher.index');
+
 // POST Route für Mitgliedschaftsantrag
 Route::post('/mitglied-werden', [MitgliedschaftController::class, 'store'])->name('mitglied.store');
 
@@ -168,7 +171,6 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::delete('{todo}', 'destroy')->name('destroy');
     });
     Route::prefix('hoerbuecher')->name('hoerbuecher.')->controller(HoerbuchController::class)->group(function () {
-        Route::get('/', 'index')->name('index')->middleware('hoerbuch-access');
         Route::get('previous-speaker', 'previousSpeaker')->name('previous-speaker')->middleware('hoerbuch-manage');
         Route::middleware('hoerbuch-manage')->group(function () {
             Route::get('erstellen', 'create')->name('create');
@@ -178,8 +180,10 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
             Route::put('{episode}', 'update')->name('update');
             Route::delete('{episode}', 'destroy')->name('destroy');
         });
-        Route::get('{episode}', 'show')->name('show')->middleware('hoerbuch-access');
     });
+
+    // Hörbücher – Einzelfolge öffentlich lesbar (nach Management-Routen, damit {episode}-Wildcard nicht 'erstellen' fängt)
+    Route::get('/hoerbuecher/{episode}', [HoerbuchController::class, 'show'])->name('hoerbuecher.show')->withoutMiddleware(['auth', 'verified', 'redirect.if.anwaerter']);
 
     Route::prefix('admin/arbeitsgruppen')->name('arbeitsgruppen.')->controller(ArbeitsgruppenController::class)->middleware('auth')->group(function () {
         Route::get('/', 'index')->name('index');

--- a/tests/Feature/HoerbuchControllerTest.php
+++ b/tests/Feature/HoerbuchControllerTest.php
@@ -696,12 +696,12 @@ class HoerbuchControllerTest extends TestCase
             ->assertSee($sanitized);
     }
 
-    public function test_member_cannot_view_index(): void
+    public function test_member_can_view_index(): void
     {
         $user = $this->actingMember('Mitglied');
 
         $this->actingAs($user)->get(route('hoerbuecher.index'))
-            ->assertForbidden();
+            ->assertOk();
     }
 
     public function test_index_sorts_by_planned_release_date(): void

--- a/tests/Feature/HoerbuchPublicAccessTest.php
+++ b/tests/Feature/HoerbuchPublicAccessTest.php
@@ -1,0 +1,438 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Models\AudiobookEpisode;
+use App\Models\AudiobookRole;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUserWithRole;
+use Tests\TestCase;
+
+class HoerbuchPublicAccessTest extends TestCase
+{
+    use CreatesUserWithRole;
+    use RefreshDatabase;
+
+    private function createEpisodeWithRoles(): AudiobookEpisode
+    {
+        $user = User::factory()->create();
+
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F1',
+            'title' => 'Testfolge Öffentlich',
+            'author' => 'Testautor',
+            'planned_release_date' => '01.06.2026',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => $user->id,
+            'progress' => 42,
+            'notes' => 'Interne Anmerkung',
+            'roles_total' => 2,
+            'roles_filled' => 1,
+        ]);
+
+        $episode->roles()->createMany([
+            [
+                'name' => 'Matthew Drax',
+                'description' => 'Hauptrolle',
+                'takes' => 5,
+                'user_id' => $user->id,
+                'speaker_name' => null,
+                'contact_email' => 'geheim@example.com',
+                'speaker_pseudonym' => 'Die Stimme',
+                'uploaded' => true,
+            ],
+            [
+                'name' => 'Aruula',
+                'description' => 'Nebenrolle',
+                'takes' => 3,
+                'user_id' => null,
+                'speaker_name' => null,
+                'contact_email' => null,
+                'speaker_pseudonym' => null,
+                'uploaded' => false,
+            ],
+        ]);
+
+        return $episode;
+    }
+
+    private function createEpisodeWithPreviousSpeaker(): array
+    {
+        $speaker = User::factory()->create(['name' => 'Vorheriger Sprecher']);
+
+        $earlier = AudiobookEpisode::create([
+            'episode_number' => 'F10',
+            'title' => 'Frühere Folge',
+            'author' => 'Autor',
+            'planned_release_date' => '2025',
+            'status' => 'Skripterstellung',
+            'responsible_user_id' => null,
+            'progress' => 100,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+        $earlier->roles()->create([
+            'name' => 'Matthew Drax',
+            'takes' => 1,
+            'user_id' => $speaker->id,
+        ]);
+
+        $episode = AudiobookEpisode::create([
+            'episode_number' => 'F11',
+            'title' => 'Aktuelle Folge',
+            'author' => 'Autor',
+            'planned_release_date' => '01.06.2026',
+            'status' => 'Rollenbesetzung',
+            'responsible_user_id' => null,
+            'progress' => 20,
+            'roles_total' => 1,
+            'roles_filled' => 0,
+            'notes' => null,
+        ]);
+        $episode->roles()->create([
+            'name' => 'Matthew Drax',
+            'takes' => 1,
+        ]);
+
+        return [$episode, $speaker];
+    }
+
+    private function createAgFanhoerbuchTeam(User $leader): Team
+    {
+        $ag = Team::factory()->create([
+            'user_id' => $leader->id,
+            'personal_team' => false,
+            'name' => 'AG Fanhörbücher',
+        ]);
+        $ag->users()->attach($leader, ['role' => Role::Mitglied->value]);
+
+        return $ag;
+    }
+
+    // ─── Gast-Zugriff auf öffentliche Seiten ─────────────────────────
+
+    public function test_guest_can_view_index(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $this->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertSee('Hörbuchfolgen')
+            ->assertSee($episode->title);
+    }
+
+    public function test_guest_can_view_episode_detail(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $this->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertSee($episode->title)
+            ->assertSee($episode->author)
+            ->assertSee($episode->episode_number);
+    }
+
+    // ─── Gast sieht KEINE Bearbeitungs-Elemente ─────────────────────
+
+    public function test_guest_does_not_see_create_button_on_index(): void
+    {
+        $this->createEpisodeWithRoles();
+
+        $this->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertDontSee(route('hoerbuecher.create'))
+            ->assertDontSee('Neue Folge');
+    }
+
+    public function test_guest_does_not_see_edit_delete_buttons_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $this->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertDontSee('Bearbeiten')
+            ->assertDontSee('Löschen');
+    }
+
+    // ─── Gast sieht KEINE bisherigen Sprecher ───────────────────────
+
+    public function test_guest_does_not_see_previous_speaker_hint(): void
+    {
+        [$episode, $speaker] = $this->createEpisodeWithPreviousSpeaker();
+
+        $this->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertDontSee('Bisheriger Sprecher')
+            ->assertDontSee($speaker->name);
+    }
+
+    // ─── Eingeloggter Berechtigter sieht bisherige Sprecher ─────────
+
+    public function test_authorized_user_sees_previous_speaker_hint(): void
+    {
+        [$episode, $speaker] = $this->createEpisodeWithPreviousSpeaker();
+
+        $admin = $this->actingMember('Admin');
+
+        $this->actingAs($admin)
+            ->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertSee('Bisheriger Sprecher: ' . $speaker->name);
+    }
+
+    // ─── Gast hat keinen Zugriff auf Management-Routen ──────────────
+
+    public function test_guest_cannot_access_create(): void
+    {
+        $this->get(route('hoerbuecher.create'))
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_guest_cannot_store_episode(): void
+    {
+        $this->post(route('hoerbuecher.store'), [
+            'episode_number' => 'F99',
+            'title' => 'Hacker-Folge',
+            'author' => 'Hacker',
+            'planned_release_date' => '2026',
+            'status' => 'Skripterstellung',
+            'progress' => 0,
+        ])->assertRedirect(route('login'));
+
+        $this->assertDatabaseMissing('audiobook_episodes', ['title' => 'Hacker-Folge']);
+    }
+
+    public function test_guest_cannot_access_edit(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $this->get(route('hoerbuecher.edit', $episode))
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_guest_cannot_update_episode(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $this->put(route('hoerbuecher.update', $episode), [
+            'episode_number' => 'F999',
+            'title' => 'Manipuliert',
+            'author' => 'Hacker',
+            'planned_release_date' => '2026',
+            'status' => 'Skripterstellung',
+            'progress' => 0,
+        ])->assertRedirect(route('login'));
+
+        $this->assertDatabaseMissing('audiobook_episodes', ['title' => 'Manipuliert']);
+    }
+
+    public function test_guest_cannot_delete_episode(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $this->delete(route('hoerbuecher.destroy', $episode))
+            ->assertRedirect(route('login'));
+
+        $this->assertDatabaseHas('audiobook_episodes', ['id' => $episode->id]);
+    }
+
+    public function test_guest_cannot_toggle_role_uploaded(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $role = $episode->roles->first();
+
+        $this->patch(route('hoerbuecher.roles.uploaded', $role), ['uploaded' => true])
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_guest_cannot_access_previous_speaker_endpoint(): void
+    {
+        $this->get(route('hoerbuecher.previous-speaker', ['name' => 'Matthew Drax']))
+            ->assertRedirect(route('login'));
+    }
+
+    // ─── Normales Mitglied hat keinen Zugriff auf Management ────────
+
+    public function test_regular_member_cannot_create_episode(): void
+    {
+        $user = $this->actingMember('Mitglied');
+
+        $this->actingAs($user)
+            ->get(route('hoerbuecher.create'))
+            ->assertForbidden();
+    }
+
+    public function test_regular_member_cannot_store_episode(): void
+    {
+        $user = $this->actingMember('Mitglied');
+
+        $this->actingAs($user)
+            ->post(route('hoerbuecher.store'), [
+                'episode_number' => 'F99',
+                'title' => 'Unberechtigt',
+                'author' => 'Autor',
+                'planned_release_date' => '2026',
+                'status' => 'Skripterstellung',
+                'progress' => 0,
+            ])->assertForbidden();
+
+        $this->assertDatabaseMissing('audiobook_episodes', ['title' => 'Unberechtigt']);
+    }
+
+    public function test_regular_member_cannot_edit_episode(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $user = $this->actingMember('Mitglied');
+
+        $this->actingAs($user)
+            ->get(route('hoerbuecher.edit', $episode))
+            ->assertForbidden();
+    }
+
+    public function test_regular_member_cannot_delete_episode(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $user = $this->actingMember('Mitglied');
+
+        $this->actingAs($user)
+            ->delete(route('hoerbuecher.destroy', $episode))
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('audiobook_episodes', ['id' => $episode->id]);
+    }
+
+    // ─── Berechtigte sehen Bearbeitungs-Elemente ────────────────────
+
+    public function test_admin_sees_create_button_on_index(): void
+    {
+        $this->createEpisodeWithRoles();
+        $admin = $this->actingMember('Admin');
+
+        $this->actingAs($admin)
+            ->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertSee(route('hoerbuecher.create'))
+            ->assertSee('Neue Folge');
+    }
+
+    public function test_vorstand_sees_create_button_on_index(): void
+    {
+        $this->createEpisodeWithRoles();
+        $vorstand = $this->actingMember('Vorstand');
+
+        $this->actingAs($vorstand)
+            ->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertSee('Neue Folge');
+    }
+
+    public function test_ag_leader_sees_edit_delete_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $leader = $this->actingMember();
+        $this->createAgFanhoerbuchTeam($leader);
+
+        $this->actingAs($leader)
+            ->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertSee('Bearbeiten');
+    }
+
+    public function test_admin_sees_edit_delete_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $admin = $this->actingMember('Admin');
+
+        $this->actingAs($admin)
+            ->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertSee('Bearbeiten');
+    }
+
+    // ─── Normales Mitglied sieht KEINE Bearbeitungs-Elemente ────────
+
+    public function test_regular_member_does_not_see_create_button_on_index(): void
+    {
+        $this->createEpisodeWithRoles();
+        $member = $this->actingMember('Mitglied');
+
+        $this->actingAs($member)
+            ->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertDontSee(route('hoerbuecher.create'))
+            ->assertDontSee('Neue Folge');
+    }
+
+    public function test_regular_member_does_not_see_edit_delete_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $member = $this->actingMember('Mitglied');
+
+        $this->actingAs($member)
+            ->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertDontSee('Bearbeiten');
+    }
+
+    // ─── SEO: noindex Meta-Tag ──────────────────────────────────────
+
+    public function test_index_has_noindex_meta_tag(): void
+    {
+        $response = $this->get(route('hoerbuecher.index'));
+
+        $response->assertOk();
+        $response->assertSee('<meta name="robots" content="noindex, nofollow">', false);
+    }
+
+    public function test_show_has_noindex_meta_tag(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $response = $this->get(route('hoerbuecher.show', $episode));
+
+        $response->assertOk();
+        $response->assertSee('<meta name="robots" content="noindex, nofollow">', false);
+    }
+
+    // ─── Gast sieht inhaltliche Daten der Folge ────────────────────
+
+    public function test_guest_sees_episode_data_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $response = $this->get(route('hoerbuecher.show', $episode));
+
+        $response->assertOk()
+            ->assertSee('Testfolge Öffentlich')
+            ->assertSee('Testautor')
+            ->assertSee('F1')
+            ->assertSee('42%')
+            ->assertSee('Matthew Drax')
+            ->assertSee('Aruula');
+    }
+
+    public function test_guest_sees_episode_data_on_index(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $response = $this->get(route('hoerbuecher.index'));
+
+        $response->assertOk()
+            ->assertSee('Testfolge Öffentlich')
+            ->assertSee('F1')
+            ->assertSee('42%');
+    }
+
+    // ─── Navigation: Kein Menü-Eintrag für Gäste ────────────────────
+
+    public function test_guest_does_not_see_eardrax_in_navigation(): void
+    {
+        $this->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertDontSee('EARDRAX Dashboard');
+    }
+}

--- a/tests/Feature/HoerbuchPublicAccessTest.php
+++ b/tests/Feature/HoerbuchPublicAccessTest.php
@@ -169,6 +169,16 @@ class HoerbuchPublicAccessTest extends TestCase
             ->assertDontSee($speaker->name);
     }
 
+    public function test_regular_member_does_not_see_previous_speaker_hint(): void
+    {
+        [$episode, $speaker] = $this->createEpisodeWithPreviousSpeaker();
+        $this->actingMember('Mitglied');
+
+        $this->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertDontSee('Bisheriger Sprecher');
+    }
+
     // ─── Eingeloggter Berechtigter sieht bisherige Sprecher ─────────
 
     public function test_authorized_user_sees_previous_speaker_hint(): void
@@ -434,6 +444,50 @@ class HoerbuchPublicAccessTest extends TestCase
             ->assertOk()
             ->assertDontSee('Interne Anmerkung')
             ->assertDontSee('Anmerkungen');
+    }
+
+    public function test_guest_does_not_see_notes_on_index(): void
+    {
+        $this->createEpisodeWithRoles();
+
+        $this->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertDontSee('Interne Anmerkung')
+            ->assertDontSee('Bemerkungen');
+    }
+
+    public function test_regular_member_does_not_see_notes_on_index(): void
+    {
+        $this->createEpisodeWithRoles();
+        $this->actingMember('Mitglied');
+
+        $this->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertDontSee('Interne Anmerkung')
+            ->assertDontSee('Bemerkungen');
+    }
+
+    public function test_vorstand_sees_notes_on_index(): void
+    {
+        $this->createEpisodeWithRoles();
+        $this->actingMember('Vorstand');
+
+        $this->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertSee('Bemerkungen')
+            ->assertSee('Interne Anmerkung');
+    }
+
+    public function test_ag_member_sees_notes_on_index(): void
+    {
+        $this->createEpisodeWithRoles();
+        $leader = $this->actingMember();
+        $this->createAgFanhoerbuchTeam($leader);
+
+        $this->get(route('hoerbuecher.index'))
+            ->assertOk()
+            ->assertSee('Bemerkungen')
+            ->assertSee('Interne Anmerkung');
     }
 
     public function test_guest_does_not_see_responsible_person_on_show(): void

--- a/tests/Feature/HoerbuchPublicAccessTest.php
+++ b/tests/Feature/HoerbuchPublicAccessTest.php
@@ -175,10 +175,9 @@ class HoerbuchPublicAccessTest extends TestCase
     {
         [$episode, $speaker] = $this->createEpisodeWithPreviousSpeaker();
 
-        $admin = $this->actingMember('Admin');
+        $this->actingMember('Admin');
 
-        $this->actingAs($admin)
-            ->get(route('hoerbuecher.show', $episode))
+        $this->get(route('hoerbuecher.show', $episode))
             ->assertOk()
             ->assertSee('Bisheriger Sprecher: ' . $speaker->name);
     }
@@ -258,19 +257,17 @@ class HoerbuchPublicAccessTest extends TestCase
 
     public function test_regular_member_cannot_create_episode(): void
     {
-        $user = $this->actingMember('Mitglied');
+        $this->actingMember('Mitglied');
 
-        $this->actingAs($user)
-            ->get(route('hoerbuecher.create'))
+        $this->get(route('hoerbuecher.create'))
             ->assertForbidden();
     }
 
     public function test_regular_member_cannot_store_episode(): void
     {
-        $user = $this->actingMember('Mitglied');
+        $this->actingMember('Mitglied');
 
-        $this->actingAs($user)
-            ->post(route('hoerbuecher.store'), [
+        $this->post(route('hoerbuecher.store'), [
                 'episode_number' => 'F99',
                 'title' => 'Unberechtigt',
                 'author' => 'Autor',
@@ -285,20 +282,18 @@ class HoerbuchPublicAccessTest extends TestCase
     public function test_regular_member_cannot_edit_episode(): void
     {
         $episode = $this->createEpisodeWithRoles();
-        $user = $this->actingMember('Mitglied');
+        $this->actingMember('Mitglied');
 
-        $this->actingAs($user)
-            ->get(route('hoerbuecher.edit', $episode))
+        $this->get(route('hoerbuecher.edit', $episode))
             ->assertForbidden();
     }
 
     public function test_regular_member_cannot_delete_episode(): void
     {
         $episode = $this->createEpisodeWithRoles();
-        $user = $this->actingMember('Mitglied');
+        $this->actingMember('Mitglied');
 
-        $this->actingAs($user)
-            ->delete(route('hoerbuecher.destroy', $episode))
+        $this->delete(route('hoerbuecher.destroy', $episode))
             ->assertForbidden();
 
         $this->assertDatabaseHas('audiobook_episodes', ['id' => $episode->id]);
@@ -309,10 +304,9 @@ class HoerbuchPublicAccessTest extends TestCase
     public function test_admin_sees_create_button_on_index(): void
     {
         $this->createEpisodeWithRoles();
-        $admin = $this->actingMember('Admin');
+        $this->actingMember('Admin');
 
-        $this->actingAs($admin)
-            ->get(route('hoerbuecher.index'))
+        $this->get(route('hoerbuecher.index'))
             ->assertOk()
             ->assertSee(route('hoerbuecher.create'))
             ->assertSee('Neue Folge');
@@ -321,10 +315,9 @@ class HoerbuchPublicAccessTest extends TestCase
     public function test_vorstand_sees_create_button_on_index(): void
     {
         $this->createEpisodeWithRoles();
-        $vorstand = $this->actingMember('Vorstand');
+        $this->actingMember('Vorstand');
 
-        $this->actingAs($vorstand)
-            ->get(route('hoerbuecher.index'))
+        $this->get(route('hoerbuecher.index'))
             ->assertOk()
             ->assertSee('Neue Folge');
     }
@@ -335,8 +328,7 @@ class HoerbuchPublicAccessTest extends TestCase
         $leader = $this->actingMember();
         $this->createAgFanhoerbuchTeam($leader);
 
-        $this->actingAs($leader)
-            ->get(route('hoerbuecher.show', $episode))
+        $this->get(route('hoerbuecher.show', $episode))
             ->assertOk()
             ->assertSee('Bearbeiten');
     }
@@ -344,10 +336,9 @@ class HoerbuchPublicAccessTest extends TestCase
     public function test_admin_sees_edit_delete_on_show(): void
     {
         $episode = $this->createEpisodeWithRoles();
-        $admin = $this->actingMember('Admin');
+        $this->actingMember('Admin');
 
-        $this->actingAs($admin)
-            ->get(route('hoerbuecher.show', $episode))
+        $this->get(route('hoerbuecher.show', $episode))
             ->assertOk()
             ->assertSee('Bearbeiten');
     }
@@ -357,10 +348,9 @@ class HoerbuchPublicAccessTest extends TestCase
     public function test_regular_member_does_not_see_create_button_on_index(): void
     {
         $this->createEpisodeWithRoles();
-        $member = $this->actingMember('Mitglied');
+        $this->actingMember('Mitglied');
 
-        $this->actingAs($member)
-            ->get(route('hoerbuecher.index'))
+        $this->get(route('hoerbuecher.index'))
             ->assertOk()
             ->assertDontSee(route('hoerbuecher.create'))
             ->assertDontSee('Neue Folge');
@@ -369,10 +359,9 @@ class HoerbuchPublicAccessTest extends TestCase
     public function test_regular_member_does_not_see_edit_delete_on_show(): void
     {
         $episode = $this->createEpisodeWithRoles();
-        $member = $this->actingMember('Mitglied');
+        $this->actingMember('Mitglied');
 
-        $this->actingAs($member)
-            ->get(route('hoerbuecher.show', $episode))
+        $this->get(route('hoerbuecher.show', $episode))
             ->assertOk()
             ->assertDontSee('Bearbeiten');
     }
@@ -459,34 +448,65 @@ class HoerbuchPublicAccessTest extends TestCase
 
     // ─── Authentifizierter Nutzer sieht interne Daten ───────────────
 
-    public function test_authenticated_user_sees_notes_on_show(): void
+    public function test_vorstand_sees_notes_on_show(): void
     {
         $episode = $this->createEpisodeWithRoles();
-        $admin = $this->actingMember('Admin');
+        $this->actingMember('Vorstand');
 
-        $this->actingAs($admin)
-            ->get(route('hoerbuecher.show', $episode))
+        $this->get(route('hoerbuecher.show', $episode))
             ->assertOk()
             ->assertSee('Anmerkungen')
             ->assertSee('Interne Anmerkung');
     }
 
-    public function test_authenticated_user_sees_responsible_person_on_show(): void
+    public function test_ag_member_sees_notes_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $leader = $this->actingMember();
+        $this->createAgFanhoerbuchTeam($leader);
+
+        $this->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertSee('Anmerkungen')
+            ->assertSee('Interne Anmerkung');
+    }
+
+    public function test_regular_member_does_not_see_notes_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $this->actingMember('Mitglied');
+
+        $this->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertDontSee('Anmerkungen')
+            ->assertDontSee('Interne Anmerkung');
+    }
+
+    public function test_vorstand_sees_responsible_person_on_show(): void
     {
         $episode = $this->createEpisodeWithRoles();
         $episode->load('responsible');
-        $member = $this->actingMember('Mitglied');
+        $this->actingMember('Vorstand');
 
-        $this->actingAs($member)
-            ->get(route('hoerbuecher.show', $episode))
+        $this->get(route('hoerbuecher.show', $episode))
             ->assertOk()
             ->assertSee('Verantwortlich')
             ->assertSee($episode->responsible->name);
     }
 
+    public function test_regular_member_does_not_see_responsible_person_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $this->actingMember('Mitglied');
+
+        $this->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertDontSee('Verantwortlich');
+    }
+
     // ─── Bisheriger-Sprecher: Aktuelle Episode wird ausgeschlossen ──
 
-    public function test_previous_speaker_not_shown_when_same_as_current(): void
+    public function test_previous_speaker_shown_from_earlier_episode(): void
     {
         $speaker = User::factory()->create(['name' => 'Doppelter Sprecher']);
 
@@ -524,14 +544,11 @@ class HoerbuchPublicAccessTest extends TestCase
             'user_id' => $speaker->id,
         ]);
 
-        $admin = $this->actingMember('Admin');
+        $this->actingMember('Admin');
 
-        // Da die aktuelle Episode ausgeschlossen wird, kommt der
-        // bisherige Sprecher nur aus der früheren Episode.
-        // Hier ist er identisch → wird trotzdem angezeigt (früherer Eintrag existiert).
-        // Wichtig: Das Query schließt nur die aktuelle Episode aus, nicht den Sprecher selbst.
-        $this->actingAs($admin)
-            ->get(route('hoerbuecher.show', $current))
+        // Bisheriger Sprecher stammt aus der früheren Episode (aktuelle wird ausgeschlossen).
+        // Da der gleiche Sprecher auch in einer früheren Episode besetzt war, wird der Hinweis angezeigt.
+        $this->get(route('hoerbuecher.show', $current))
             ->assertOk()
             ->assertSee('Bisheriger Sprecher: Doppelter Sprecher');
     }
@@ -557,11 +574,10 @@ class HoerbuchPublicAccessTest extends TestCase
             'user_id' => $speaker->id,
         ]);
 
-        $admin = $this->actingMember('Admin');
+        $this->actingMember('Admin');
 
         // Kein bisheriger Sprecher, da die Rolle nur in der aktuellen Episode existiert
-        $this->actingAs($admin)
-            ->get(route('hoerbuecher.show', $current))
+        $this->get(route('hoerbuecher.show', $current))
             ->assertOk()
             ->assertDontSee('Bisheriger Sprecher');
     }

--- a/tests/Feature/HoerbuchPublicAccessTest.php
+++ b/tests/Feature/HoerbuchPublicAccessTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use App\Enums\Role;
 use App\Models\AudiobookEpisode;
-use App\Models\AudiobookRole;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -434,5 +433,145 @@ class HoerbuchPublicAccessTest extends TestCase
         $this->get(route('hoerbuecher.index'))
             ->assertOk()
             ->assertDontSee('EARDRAX Dashboard');
+    }
+
+    // ─── Gast sieht KEINE internen Daten ────────────────────────────
+
+    public function test_guest_does_not_see_notes_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+
+        $this->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertDontSee('Interne Anmerkung')
+            ->assertDontSee('Anmerkungen');
+    }
+
+    public function test_guest_does_not_see_responsible_person_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $episode->load('responsible');
+
+        $this->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertDontSee('Verantwortlich');
+    }
+
+    // ─── Authentifizierter Nutzer sieht interne Daten ───────────────
+
+    public function test_authenticated_user_sees_notes_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $admin = $this->actingMember('Admin');
+
+        $this->actingAs($admin)
+            ->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertSee('Anmerkungen')
+            ->assertSee('Interne Anmerkung');
+    }
+
+    public function test_authenticated_user_sees_responsible_person_on_show(): void
+    {
+        $episode = $this->createEpisodeWithRoles();
+        $episode->load('responsible');
+        $member = $this->actingMember('Mitglied');
+
+        $this->actingAs($member)
+            ->get(route('hoerbuecher.show', $episode))
+            ->assertOk()
+            ->assertSee('Verantwortlich')
+            ->assertSee($episode->responsible->name);
+    }
+
+    // ─── Bisheriger-Sprecher: Aktuelle Episode wird ausgeschlossen ──
+
+    public function test_previous_speaker_not_shown_when_same_as_current(): void
+    {
+        $speaker = User::factory()->create(['name' => 'Doppelter Sprecher']);
+
+        $earlier = AudiobookEpisode::create([
+            'episode_number' => 'F20',
+            'title' => 'Frühere Folge',
+            'author' => 'Autor',
+            'planned_release_date' => '2025',
+            'status' => 'Skripterstellung',
+            'progress' => 100,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+        $earlier->roles()->create([
+            'name' => 'Matthew Drax',
+            'takes' => 1,
+            'user_id' => $speaker->id,
+        ]);
+
+        $current = AudiobookEpisode::create([
+            'episode_number' => 'F21',
+            'title' => 'Aktuelle Folge mit gleichem Sprecher',
+            'author' => 'Autor',
+            'planned_release_date' => '01.06.2026',
+            'status' => 'Aufnahmensammlung',
+            'progress' => 50,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+        $current->roles()->create([
+            'name' => 'Matthew Drax',
+            'takes' => 1,
+            'user_id' => $speaker->id,
+        ]);
+
+        $admin = $this->actingMember('Admin');
+
+        // Da die aktuelle Episode ausgeschlossen wird, kommt der
+        // bisherige Sprecher nur aus der früheren Episode.
+        // Hier ist er identisch → wird trotzdem angezeigt (früherer Eintrag existiert).
+        // Wichtig: Das Query schließt nur die aktuelle Episode aus, nicht den Sprecher selbst.
+        $this->actingAs($admin)
+            ->get(route('hoerbuecher.show', $current))
+            ->assertOk()
+            ->assertSee('Bisheriger Sprecher: Doppelter Sprecher');
+    }
+
+    public function test_previous_speaker_not_shown_when_only_in_current_episode(): void
+    {
+        $speaker = User::factory()->create(['name' => 'Nur-Aktuell Sprecher']);
+
+        $current = AudiobookEpisode::create([
+            'episode_number' => 'F22',
+            'title' => 'Folge ohne Vorgänger',
+            'author' => 'Autor',
+            'planned_release_date' => '01.06.2026',
+            'status' => 'Aufnahmensammlung',
+            'progress' => 50,
+            'roles_total' => 1,
+            'roles_filled' => 1,
+            'notes' => null,
+        ]);
+        $current->roles()->create([
+            'name' => 'Neue Rolle',
+            'takes' => 1,
+            'user_id' => $speaker->id,
+        ]);
+
+        $admin = $this->actingMember('Admin');
+
+        // Kein bisheriger Sprecher, da die Rolle nur in der aktuellen Episode existiert
+        $this->actingAs($admin)
+            ->get(route('hoerbuecher.show', $current))
+            ->assertOk()
+            ->assertDontSee('Bisheriger Sprecher');
+    }
+
+    // ─── robots.txt erlaubt Crawling ────────────────────────────────
+
+    public function test_robots_txt_does_not_disallow_hoerbuecher(): void
+    {
+        $robotsTxt = file_get_contents(public_path('robots.txt'));
+
+        $this->assertStringNotContainsString('Disallow: /hoerbuecher', $robotsTxt);
     }
 }


### PR DESCRIPTION
This pull request makes the Hörbuch (audiobook) episode overview and detail pages publicly accessible (no authentication required), ensures they are not indexed by search engines, and adjusts authorization and visibility for sensitive data and actions. It also improves how previous speakers are determined and displayed. Below are the most important changes grouped by theme:

**Public Accessibility & SEO:**
- Made the `hoerbuecher.index` and `hoerbuecher.show` routes publicly accessible by moving them outside of authentication middleware and removing the `hoerbuch-access` middleware from these routes (`routes/web.php`). [[1]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadR74-R79) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL171) [[3]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL181)
- Added `<meta name="robots" content="noindex, nofollow">` to the Hörbuch index and show pages to prevent search engine indexing, and added a sitemap URL to `robots.txt`. [[1]](diffhunk://#diff-62028215bf1b51ad419e1ba1ed5fc53eac5411544afb5da3fd5718deb40c541fR2-R4) [[2]](diffhunk://#diff-3a89ef24b9c79efccdef51ca4d7a67fab3d01dd6e100d6b08f8b821b8334ffcfR2-R4) [[3]](diffhunk://#diff-1dc4bea7b6827b18f8869436bd7786266d3cea8596529887ef16a027eb2e4076R3)

**Authorization & Conditional UI:**
- Updated the Hörbuch index and show views to only display sensitive columns (like notes and responsible person) and actions (e.g., edit/delete buttons) to users with Vorstand role or members of the "AG Fanhörbücher" team. [[1]](diffhunk://#diff-62028215bf1b51ad419e1ba1ed5fc53eac5411544afb5da3fd5718deb40c541fR13-R17) [[2]](diffhunk://#diff-62028215bf1b51ad419e1ba1ed5fc53eac5411544afb5da3fd5718deb40c541fR192-R194) [[3]](diffhunk://#diff-62028215bf1b51ad419e1ba1ed5fc53eac5411544afb5da3fd5718deb40c541fR240-R246) [[4]](diffhunk://#diff-3a89ef24b9c79efccdef51ca4d7a67fab3d01dd6e100d6b08f8b821b8334ffcfR62-R67) [[5]](diffhunk://#diff-3a89ef24b9c79efccdef51ca4d7a67fab3d01dd6e100d6b08f8b821b8334ffcfR76-R92)

**Logic Improvements:**
- Improved the logic for determining and displaying previous speakers by excluding the current episode from the search, preventing it from being listed as its own previous speaker (`HoerbuchController.php`). [[1]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL119-R119) [[2]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdR129) [[3]](diffhunk://#diff-a9c0593bfeeb1281136075263c0f1faec627836a99626438ceac715e267e03bdL142-R143)

**Testing:**
- Updated the feature test to confirm that members can now view the Hörbuch index page (previously forbidden).