### PR TITLE
Fix: Force HTTPS and honor X-Forwarded-Proto

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,13 +38,14 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         // Force HTTPS in production – URL::forceScheme() erzwingt https:// bei der URL-Generierung.
-        // Zusätzlich muss X-Forwarded-Proto gesetzt werden, damit request()->isSecure()
-        // ebenfalls true liefert. Ohne diesen Header schlägt die Signaturprüfung bei
-        // Livewire File-Uploads fehl (401), weil die signierte URL https:// nutzt,
-        // aber request()->url() http:// zurückgibt.
+        // Zusätzlich müssen X-Forwarded-Proto und X-Forwarded-Port gesetzt werden, damit
+        // request()->isSecure() und request()->getPort() die korrekten Werte liefern.
+        // Ohne diese Header schlägt die Signaturprüfung bei Livewire File-Uploads fehl (401),
+        // weil die signierte URL https:// nutzt, aber request()->url() http://:80 zurückgibt.
         if ($this->app->environment('production')) {
             URL::forceScheme('https');
             $this->app['request']->headers->set('X-Forwarded-Proto', 'https');
+            $this->app['request']->headers->set('X-Forwarded-Port', '443');
         }
 
         // Rate Limiter für Fantreffen-Anmeldung (deaktivierbar via Config für Tests)

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -37,10 +37,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // Force HTTPS in production
+        // Force HTTPS in production – URL::forceScheme() erzwingt https:// bei der URL-Generierung.
+        // Zusätzlich muss X-Forwarded-Proto gesetzt werden, damit request()->isSecure()
+        // ebenfalls true liefert. Ohne diesen Header schlägt die Signaturprüfung bei
+        // Livewire File-Uploads fehl (401), weil die signierte URL https:// nutzt,
+        // aber request()->url() http:// zurückgibt.
         if ($this->app->environment('production')) {
             URL::forceScheme('https');
-            $this->app['request']->server->set('HTTPS', true);
+            $this->app['request']->headers->set('X-Forwarded-Proto', 'https');
         }
 
         // Rate Limiter für Fantreffen-Anmeldung (deaktivierbar via Config für Tests)

--- a/deploy/nginx/laravel.conf
+++ b/deploy/nginx/laravel.conf
@@ -5,6 +5,15 @@ map $scheme $fcgi_https {
     default "";
 }
 
+# X-Forwarded-Proto: Wenn ein vorgelagerter Reverse Proxy (z.B. Traefik, Caddy, nginx)
+# den Header bereits setzt, diesen übernehmen. Ansonsten $scheme verwenden.
+# Nur explizite Werte (https/http) werden durchgelassen, um Header-Injection zu verhindern.
+map $http_x_forwarded_proto $forwarded_proto {
+    default $scheme;
+    https   "https";
+    http    "http";
+}
+
 server {
     listen 80 default_server;
     server_name _;
@@ -73,11 +82,12 @@ server {
         fastcgi_param PATH_INFO $fastcgi_path_info;
         # HTTPS-Erkennung: "on" bei HTTPS, leer bei HTTP
         fastcgi_param HTTPS $fcgi_https if_not_empty;
-        # Proxy-Header: Nginx ist der Edge-Proxy, daher eigene Werte setzen
-        # (keine Client-gelieferten Header propagieren → verhindert Spoofing).
-        # Falls ein vorgelagerter LB/Proxy existiert, set_real_ip_from + real_ip_header konfigurieren.
+        # Proxy-Header: X-Forwarded-Proto wird vom vorgelagerten Reverse Proxy
+        # übernommen (via $forwarded_proto map). Die übrigen Header setzen wir selbst,
+        # um Spoofing zu verhindern. Falls ein vorgelagerter LB/Proxy existiert,
+        # ggf. set_real_ip_from + real_ip_header konfigurieren.
         fastcgi_param HTTP_X_FORWARDED_FOR $remote_addr;
-        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $forwarded_proto;
         fastcgi_param HTTP_X_FORWARDED_HOST $host;
         fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
         fastcgi_buffer_size 16k;

--- a/deploy/nginx/laravel.conf
+++ b/deploy/nginx/laravel.conf
@@ -5,15 +5,6 @@ map $scheme $fcgi_https {
     default "";
 }
 
-# X-Forwarded-Proto: Wenn ein vorgelagerter Reverse Proxy (z.B. Traefik, Caddy, nginx)
-# den Header bereits setzt, diesen übernehmen. Ansonsten $scheme verwenden.
-# Nur explizite Werte (https/http) werden durchgelassen, um Header-Injection zu verhindern.
-map $http_x_forwarded_proto $forwarded_proto {
-    default $scheme;
-    https   "https";
-    http    "http";
-}
-
 server {
     listen 80 default_server;
     server_name _;
@@ -82,12 +73,12 @@ server {
         fastcgi_param PATH_INFO $fastcgi_path_info;
         # HTTPS-Erkennung: "on" bei HTTPS, leer bei HTTP
         fastcgi_param HTTPS $fcgi_https if_not_empty;
-        # Proxy-Header: X-Forwarded-Proto wird vom vorgelagerten Reverse Proxy
-        # übernommen (via $forwarded_proto map). Die übrigen Header setzen wir selbst,
-        # um Spoofing zu verhindern. Falls ein vorgelagerter LB/Proxy existiert,
-        # ggf. set_real_ip_from + real_ip_header konfigurieren.
+        # Proxy-Header: Nginx ist der Edge-Proxy, daher eigene Werte setzen
+        # (keine Client-gelieferten Header propagieren → verhindert Spoofing).
+        # Die HTTPS-/Port-Korrektur für Production (TLS-Termination) erfolgt in
+        # AppServiceProvider::boot(), da nur die App den Deployment-Kontext kennt.
         fastcgi_param HTTP_X_FORWARDED_FOR $remote_addr;
-        fastcgi_param HTTP_X_FORWARDED_PROTO $forwarded_proto;
+        fastcgi_param HTTP_X_FORWARDED_PROTO $scheme;
         fastcgi_param HTTP_X_FORWARDED_HOST $host;
         fastcgi_param HTTP_X_FORWARDED_PORT $server_port;
         fastcgi_buffer_size 16k;


### PR DESCRIPTION
This pull request improves HTTPS handling in production by ensuring correct header values are set for secure URL generation and signature validation, particularly for Livewire file uploads. It also clarifies where HTTPS and port correction should occur in the deployment stack.

HTTPS handling improvements:

* In `AppServiceProvider.php`, the code now sets the `X-Forwarded-Proto` and `X-Forwarded-Port` headers instead of just forcing the `HTTPS` server variable. This ensures `request()->isSecure()` and `request()->getPort()` return correct values, preventing signature verification issues for Livewire file uploads.

Documentation and deployment clarification:

* In `nginx/laravel.conf`, the comment now explains that HTTPS and port correction for production (TLS termination) is handled in `AppServiceProvider::boot()`, since only the application knows the deployment context.