### PR TITLE
Feature: Rule-based Baxx for reviews and new notifications mail

### DIFF
--- a/app/Console/Commands/ImportOldReviews.php
+++ b/app/Console/Commands/ImportOldReviews.php
@@ -143,7 +143,12 @@ class ImportOldReviews extends Command
             $reviewCount = Review::where('team_id', $teamId)
                 ->where('user_id', $user->id)
                 ->count();
-            app(ReviewBaxxService::class)->awardPointsForReview($user, $reviewCount, Carbon::parse($dt, config('app.timezone')));
+            app(ReviewBaxxService::class)->awardPointsForReview(
+                $user,
+                $reviewCount,
+                $teamId,
+                Carbon::parse($dt, config('app.timezone'))
+            );
 
             $bar->advance();
         }

--- a/app/Console/Commands/ImportOldReviews.php
+++ b/app/Console/Commands/ImportOldReviews.php
@@ -7,6 +7,7 @@ use App\Models\Review;
 use App\Models\Team;
 use App\Models\User;
 use App\Models\UserPoint;
+use App\Services\ReviewBaxxService;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 
@@ -138,19 +139,11 @@ class ImportOldReviews extends Command
                 'updated_at' => $dt,
             ]);
 
-            // Award one Baxx for every tenth imported review of the member
+            // Award Baxx using the same rule resolution as the live review flow
             $reviewCount = Review::where('team_id', $teamId)
                 ->where('user_id', $user->id)
                 ->count();
-            if ($reviewCount % 10 === 0) {
-                UserPoint::create([
-                    'user_id' => $user->id,
-                    'team_id' => $teamId,
-                    'points' => 1,
-                    'created_at' => $dt,
-                    'updated_at' => $dt,
-                ]);
-            }
+            app(ReviewBaxxService::class)->awardPointsForReview($user, $reviewCount, Carbon::parse($dt, config('app.timezone')));
 
             $bar->advance();
         }

--- a/app/Http/Controllers/Auth/CustomEmailVerificationController.php
+++ b/app/Http/Controllers/Auth/CustomEmailVerificationController.php
@@ -28,9 +28,12 @@ class CustomEmailVerificationController extends Controller
 
         event(new Verified($user));
 
-        // Versenden der Mails an Admin und Vorstand
-        Mail::to('vorstand@maddrax-fanclub.de')->queue(new AntragAnVorstand($user));
-        Mail::to('holgerehrmann@gmail.com')->queue(new AntragAnAdmin($user));
+        // Versenden der Mails an Vorstand, Kassenwart und Admin
+        Mail::to([
+            'vorstand@maddrax-fanclub.de',
+            'kassenwart@maddrax-fanclub.de',
+        ])->queue(new AntragAnVorstand($user));
+        Mail::to('info@maddraxikon.com')->queue(new AntragAnAdmin($user));
 
         return redirect()->route('mitglied.werden.bestaetigt')->with('status', 'Deine E-Mail-Adresse wurde erfolgreich bestätigt.');
     }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -15,6 +15,7 @@ use App\Models\Todo;
 use App\Models\User;
 use App\Models\UserPoint;
 use App\Services\MembersTeamProvider;
+use App\Services\ReviewBaxxService;
 use App\Services\UserRoleService;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Auth;
@@ -26,7 +27,8 @@ class DashboardController extends Controller
 {
     public function __construct(
         private UserRoleService $userRoleService,
-        private MembersTeamProvider $membersTeamProvider
+        private MembersTeamProvider $membersTeamProvider,
+        private ReviewBaxxService $reviewBaxxService,
     ) {}
 
     public function index()
@@ -185,6 +187,8 @@ class DashboardController extends Controller
             ->limit(10)
             ->get();
 
+        $prominentReviewSpecialOffer = $this->reviewBaxxService->getProminentSpecialOffer();
+
         return view('dashboard', compact(
             'anwaerter',
             'openTodos',
@@ -198,7 +202,8 @@ class DashboardController extends Controller
             'romantauschMatches',
             'romantauschOffers',
             'fanfictionCount',
-            'activities'
+            'activities',
+            'prominentReviewSpecialOffer'
         ));
     }
 

--- a/app/Http/Controllers/RezensionController.php
+++ b/app/Http/Controllers/RezensionController.php
@@ -275,11 +275,11 @@ class RezensionController extends Controller
             'content' => $data['content'],
         ]);
 
-        // Award Baxx for every tenth review of the member
+        // Award Baxx using the currently effective review rule.
         $reviewCount = Review::where('team_id', $teamId)
             ->where('user_id', $user->id)
             ->count();
-        $this->reviewBaxxService->awardPointsForReview($user, $reviewCount);
+        $this->reviewBaxxService->awardPointsForReview($user, $reviewCount, $teamId);
 
         // Autoren des Romans über neue Rezension informieren
         $authorNames = array_map('trim', explode(',', $book->author));

--- a/app/Http/Controllers/RezensionController.php
+++ b/app/Http/Controllers/RezensionController.php
@@ -8,11 +8,11 @@ use App\Http\Controllers\Concerns\MembersTeamAware;
 use App\Http\Requests\ReviewRequest;
 use App\Mail\NewReviewNotification;
 use App\Models\Activity;
-use App\Models\BaxxEarningRule;
 use App\Models\Book;
 use App\Models\Review;
 use App\Models\User;
 use App\Services\MaddraxDataService;
+use App\Services\ReviewBaxxService;
 use App\Services\UserRoleService;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
@@ -27,6 +27,7 @@ class RezensionController extends Controller
     public function __construct(
         private UserRoleService $userRoleService,
         private MaddraxDataService $maddraxDataService,
+        private ReviewBaxxService $reviewBaxxService,
     ) {}
 
     protected function getUserRoleService(): UserRoleService
@@ -278,12 +279,7 @@ class RezensionController extends Controller
         $reviewCount = Review::where('team_id', $teamId)
             ->where('user_id', $user->id)
             ->count();
-        if ($reviewCount % 10 === 0) {
-            $points = BaxxEarningRule::getPointsFor('rezension');
-            if ($points > 0) {
-                $user->incrementTeamPoints($points);
-            }
-        }
+        $this->reviewBaxxService->awardPointsForReview($user, $reviewCount);
 
         // Autoren des Romans über neue Rezension informieren
         $authorNames = array_map('trim', explode(',', $book->author));

--- a/app/Livewire/BelohnungenAdmin.php
+++ b/app/Livewire/BelohnungenAdmin.php
@@ -2,10 +2,13 @@
 
 namespace App\Livewire;
 
+use Carbon\Carbon;
 use App\Models\BaxxEarningRule;
 use App\Models\Download;
 use App\Models\Reward;
 use App\Models\RewardPurchase;
+use App\Models\ReviewBaxxSpecialOffer;
+use App\Services\ReviewBaxxService;
 use App\Services\RewardService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
@@ -58,7 +61,22 @@ class BelohnungenAdmin extends Component
 
     public int $rulePoints = 1;
 
+    public int $ruleEveryCount = 1;
+
     public bool $ruleIsActive = true;
+
+    // --- Review special offers ---
+    public bool $showReviewSpecialOfferModal = false;
+
+    public ?int $editingReviewSpecialOfferId = null;
+
+    public int $reviewSpecialOfferPoints = 1;
+
+    public int $reviewSpecialOfferEveryCount = 1;
+
+    public string $reviewSpecialOfferEndsAt = '';
+
+    public bool $reviewSpecialOfferIsActive = true;
 
     // --- Download management ---
     public bool $showDownloadModal = false;
@@ -94,6 +112,27 @@ class BelohnungenAdmin extends Component
     public function earningRules(): \Illuminate\Database\Eloquent\Collection
     {
         return BaxxEarningRule::orderBy('action_key')->get();
+    }
+
+    #[Computed]
+    public function reviewSpecialOffers(): \Illuminate\Database\Eloquent\Collection
+    {
+        return ReviewBaxxSpecialOffer::query()
+            ->orderByDesc('is_active')
+            ->orderByDesc('ends_at')
+            ->get();
+    }
+
+    #[Computed]
+    public function reviewRewardConfiguration(): array
+    {
+        $service = app(ReviewBaxxService::class);
+
+        return [
+            'base_rule' => $service->getBaseRuleData(),
+            'effective_rule' => $service->getEffectiveRule(),
+            'prominent_special_offer' => $service->getProminentSpecialOffer(),
+        ];
     }
 
     #[Computed]
@@ -267,6 +306,7 @@ class BelohnungenAdmin extends Component
         $this->ruleLabel = $rule->label;
         $this->ruleDescription = $rule->description ?? '';
         $this->rulePoints = $rule->points;
+        $this->ruleEveryCount = $rule->every_count;
         $this->ruleIsActive = $rule->is_active;
         $this->showRuleModal = true;
     }
@@ -276,6 +316,7 @@ class BelohnungenAdmin extends Component
         $this->validate([
             'ruleLabel' => 'required|string|max:255',
             'rulePoints' => 'required|integer|min:0',
+            'ruleEveryCount' => 'required|integer|min:1',
         ]);
 
         if ($this->editingRuleId) {
@@ -284,6 +325,7 @@ class BelohnungenAdmin extends Component
                 'label' => $this->ruleLabel,
                 'description' => $this->ruleDescription ?: null,
                 'points' => $this->rulePoints,
+                'every_count' => $this->ruleEveryCount,
                 'is_active' => $this->ruleIsActive,
             ]);
             $this->dispatch('toast', type: 'success', title: 'Vergaberegel aktualisiert');
@@ -291,7 +333,8 @@ class BelohnungenAdmin extends Component
 
         $this->showRuleModal = false;
         $this->editingRuleId = null;
-        unset($this->earningRules);
+        $this->ruleEveryCount = 1;
+        unset($this->earningRules, $this->reviewRewardConfiguration);
     }
 
     public function toggleRuleActive(int $ruleId): void
@@ -300,7 +343,103 @@ class BelohnungenAdmin extends Component
         $rule->update(['is_active' => ! $rule->is_active]);
         $status = $rule->is_active ? 'aktiviert' : 'deaktiviert';
         $this->dispatch('toast', type: 'success', title: "Vergaberegel {$status}");
-        unset($this->earningRules);
+        unset($this->earningRules, $this->reviewRewardConfiguration);
+    }
+
+    public function openCreateReviewSpecialOffer(): void
+    {
+        $this->resetReviewSpecialOfferForm();
+        $this->showReviewSpecialOfferModal = true;
+    }
+
+    public function openEditReviewSpecialOffer(int $offerId): void
+    {
+        $offer = ReviewBaxxSpecialOffer::findOrFail($offerId);
+        $this->editingReviewSpecialOfferId = $offer->id;
+        $this->reviewSpecialOfferPoints = $offer->points;
+        $this->reviewSpecialOfferEveryCount = $offer->every_count;
+        $this->reviewSpecialOfferEndsAt = $offer->ends_at->copy()->timezone(config('app.timezone'))->format('Y-m-d\TH:i');
+        $this->reviewSpecialOfferIsActive = $offer->is_active;
+        $this->showReviewSpecialOfferModal = true;
+    }
+
+    public function saveReviewSpecialOffer(): void
+    {
+        $this->validate([
+            'reviewSpecialOfferPoints' => 'required|integer|min:1',
+            'reviewSpecialOfferEveryCount' => 'required|integer|min:1',
+            'reviewSpecialOfferEndsAt' => 'required|date',
+        ]);
+
+        $endsAt = Carbon::parse($this->reviewSpecialOfferEndsAt, config('app.timezone'));
+
+        if ($this->reviewSpecialOfferIsActive && $endsAt->lte(now())) {
+            throw ValidationException::withMessages([
+                'reviewSpecialOfferEndsAt' => 'Das Enddatum einer aktiven Sonderaktion muss in der Zukunft liegen.',
+            ]);
+        }
+
+        $hasConflictingOffer = ReviewBaxxSpecialOffer::query()
+            ->currentlyActive()
+            ->when($this->editingReviewSpecialOfferId, fn ($query) => $query->whereKeyNot($this->editingReviewSpecialOfferId))
+            ->exists();
+
+        if ($this->reviewSpecialOfferIsActive && $hasConflictingOffer) {
+            throw ValidationException::withMessages([
+                'reviewSpecialOfferIsActive' => 'Es kann immer nur eine aktive Review-Sonderaktion gleichzeitig geben.',
+            ]);
+        }
+
+        $data = [
+            'points' => $this->reviewSpecialOfferPoints,
+            'every_count' => $this->reviewSpecialOfferEveryCount,
+            'ends_at' => $endsAt,
+            'is_active' => $this->reviewSpecialOfferIsActive,
+        ];
+
+        if ($this->editingReviewSpecialOfferId) {
+            ReviewBaxxSpecialOffer::findOrFail($this->editingReviewSpecialOfferId)->update($data);
+            $this->dispatch('toast', type: 'success', title: 'Review-Sonderaktion aktualisiert');
+        } else {
+            ReviewBaxxSpecialOffer::create($data);
+            $this->dispatch('toast', type: 'success', title: 'Review-Sonderaktion erstellt');
+        }
+
+        $this->showReviewSpecialOfferModal = false;
+        $this->resetReviewSpecialOfferForm();
+        unset($this->reviewSpecialOffers, $this->reviewRewardConfiguration);
+    }
+
+    public function toggleReviewSpecialOfferActive(int $offerId): void
+    {
+        $offer = ReviewBaxxSpecialOffer::findOrFail($offerId);
+        $nextActiveState = ! $offer->is_active;
+
+        if ($nextActiveState && $offer->ends_at->lte(now())) {
+            $this->dispatch('toast', type: 'error', title: 'Aktivierung nicht möglich', description: 'Abgelaufene Sonderaktionen können nicht erneut aktiviert werden.');
+
+            return;
+        }
+
+        if ($nextActiveState && ReviewBaxxSpecialOffer::query()->currentlyActive()->whereKeyNot($offer->id)->exists()) {
+            $this->dispatch('toast', type: 'error', title: 'Aktivierung nicht möglich', description: 'Es gibt bereits eine andere aktive Review-Sonderaktion.');
+
+            return;
+        }
+
+        $offer->update(['is_active' => $nextActiveState]);
+        $status = $offer->is_active ? 'aktiviert' : 'deaktiviert';
+        $this->dispatch('toast', type: 'success', title: "Review-Sonderaktion {$status}");
+        unset($this->reviewSpecialOffers, $this->reviewRewardConfiguration);
+    }
+
+    private function resetReviewSpecialOfferForm(): void
+    {
+        $this->editingReviewSpecialOfferId = null;
+        $this->reviewSpecialOfferPoints = 1;
+        $this->reviewSpecialOfferEveryCount = 1;
+        $this->reviewSpecialOfferEndsAt = now()->addDay()->format('Y-m-d\TH:i');
+        $this->reviewSpecialOfferIsActive = true;
     }
 
     // =====================================================

--- a/app/Livewire/BelohnungenAdmin.php
+++ b/app/Livewire/BelohnungenAdmin.php
@@ -379,17 +379,6 @@ class BelohnungenAdmin extends Component
             ]);
         }
 
-        $hasConflictingOffer = ReviewBaxxSpecialOffer::query()
-            ->currentlyActive()
-            ->when($this->editingReviewSpecialOfferId, fn ($query) => $query->whereKeyNot($this->editingReviewSpecialOfferId))
-            ->exists();
-
-        if ($this->reviewSpecialOfferIsActive && $hasConflictingOffer) {
-            throw ValidationException::withMessages([
-                'reviewSpecialOfferIsActive' => 'Es kann immer nur eine aktive Review-Sonderaktion gleichzeitig geben.',
-            ]);
-        }
-
         $data = [
             'points' => $this->reviewSpecialOfferPoints,
             'every_count' => $this->reviewSpecialOfferEveryCount,
@@ -397,13 +386,36 @@ class BelohnungenAdmin extends Component
             'is_active' => $this->reviewSpecialOfferIsActive,
         ];
 
-        if ($this->editingReviewSpecialOfferId) {
-            ReviewBaxxSpecialOffer::findOrFail($this->editingReviewSpecialOfferId)->update($data);
-            $this->dispatch('toast', type: 'success', title: 'Review-Sonderaktion aktualisiert');
-        } else {
+        DB::transaction(function () use ($data) {
+            BaxxEarningRule::query()
+                ->where('action_key', 'rezension')
+                ->lockForUpdate()
+                ->first();
+
+            $hasConflictingOffer = ReviewBaxxSpecialOffer::query()
+                ->currentlyActive()
+                ->when($this->editingReviewSpecialOfferId, fn ($query) => $query->whereKeyNot($this->editingReviewSpecialOfferId))
+                ->exists();
+
+            if ($this->reviewSpecialOfferIsActive && $hasConflictingOffer) {
+                throw ValidationException::withMessages([
+                    'reviewSpecialOfferIsActive' => 'Es kann immer nur eine aktive Review-Sonderaktion gleichzeitig geben.',
+                ]);
+            }
+
+            if ($this->editingReviewSpecialOfferId) {
+                ReviewBaxxSpecialOffer::findOrFail($this->editingReviewSpecialOfferId)->update($data);
+
+                return;
+            }
+
             ReviewBaxxSpecialOffer::create($data);
-            $this->dispatch('toast', type: 'success', title: 'Review-Sonderaktion erstellt');
-        }
+        });
+
+        $title = $this->editingReviewSpecialOfferId
+            ? 'Review-Sonderaktion aktualisiert'
+            : 'Review-Sonderaktion erstellt';
+        $this->dispatch('toast', type: 'success', title: $title);
 
         $this->showReviewSpecialOfferModal = false;
         $this->resetReviewSpecialOfferForm();
@@ -412,23 +424,32 @@ class BelohnungenAdmin extends Component
 
     public function toggleReviewSpecialOfferActive(int $offerId): void
     {
-        $offer = ReviewBaxxSpecialOffer::findOrFail($offerId);
-        $nextActiveState = ! $offer->is_active;
+        $status = DB::transaction(function () use ($offerId) {
+            BaxxEarningRule::query()
+                ->where('action_key', 'rezension')
+                ->lockForUpdate()
+                ->first();
 
-        if ($nextActiveState && $offer->ends_at->lte(now())) {
-            $this->dispatch('toast', type: 'error', title: 'Aktivierung nicht möglich', description: 'Abgelaufene Sonderaktionen können nicht erneut aktiviert werden.');
+            $offer = ReviewBaxxSpecialOffer::findOrFail($offerId);
+            $nextActiveState = ! $offer->is_active;
 
-            return;
-        }
+            if ($nextActiveState && $offer->ends_at->lte(now())) {
+                throw ValidationException::withMessages([
+                    'reviewSpecialOfferIsActive' => 'Abgelaufene Sonderaktionen können nicht erneut aktiviert werden.',
+                ]);
+            }
 
-        if ($nextActiveState && ReviewBaxxSpecialOffer::query()->currentlyActive()->whereKeyNot($offer->id)->exists()) {
-            $this->dispatch('toast', type: 'error', title: 'Aktivierung nicht möglich', description: 'Es gibt bereits eine andere aktive Review-Sonderaktion.');
+            if ($nextActiveState && ReviewBaxxSpecialOffer::query()->currentlyActive()->whereKeyNot($offer->id)->exists()) {
+                throw ValidationException::withMessages([
+                    'reviewSpecialOfferIsActive' => 'Es gibt bereits eine andere aktive Review-Sonderaktion.',
+                ]);
+            }
 
-            return;
-        }
+            $offer->update(['is_active' => $nextActiveState]);
 
-        $offer->update(['is_active' => $nextActiveState]);
-        $status = $offer->is_active ? 'aktiviert' : 'deaktiviert';
+            return $offer->is_active ? 'aktiviert' : 'deaktiviert';
+        });
+
         $this->dispatch('toast', type: 'success', title: "Review-Sonderaktion {$status}");
         unset($this->reviewSpecialOffers, $this->reviewRewardConfiguration);
     }

--- a/app/Livewire/BelohnungenIndex.php
+++ b/app/Livewire/BelohnungenIndex.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use App\Models\Reward;
 use App\Models\RewardPurchase;
+use App\Services\ReviewBaxxService;
 use App\Services\RewardService;
 use App\Services\TeamPointService;
 use Illuminate\Support\Facades\Auth;
@@ -94,6 +95,18 @@ class BelohnungenIndex extends Component
             ->orderBy('category')
             ->pluck('category')
             ->toArray();
+    }
+
+    #[Computed]
+    public function reviewRewardConfiguration(): array
+    {
+        return app(ReviewBaxxService::class)->getEffectiveRule();
+    }
+
+    #[Computed]
+    public function prominentReviewSpecialOffer(): ?array
+    {
+        return app(ReviewBaxxService::class)->getProminentSpecialOffer();
     }
 
     public function purchase(int $rewardId): void

--- a/app/Livewire/BelohnungenIndex.php
+++ b/app/Livewire/BelohnungenIndex.php
@@ -100,13 +100,7 @@ class BelohnungenIndex extends Component
     #[Computed]
     public function reviewRewardConfiguration(): array
     {
-        return app(ReviewBaxxService::class)->getEffectiveRule();
-    }
-
-    #[Computed]
-    public function prominentReviewSpecialOffer(): ?array
-    {
-        return app(ReviewBaxxService::class)->getProminentSpecialOffer();
+        return app(ReviewBaxxService::class)->getMemberConfiguration();
     }
 
     public function purchase(int $rewardId): void

--- a/app/Livewire/RezensionForm.php
+++ b/app/Livewire/RezensionForm.php
@@ -123,7 +123,7 @@ class RezensionForm extends Component
             $reviewCount = Review::where('team_id', $teamId)
                 ->where('user_id', $user->id)
                 ->count();
-            app(ReviewBaxxService::class)->awardPointsForReview($user, $reviewCount);
+            app(ReviewBaxxService::class)->awardPointsForReview($user, $reviewCount, $teamId);
 
             $authorNames = array_map('trim', explode(',', $book->author));
             $authors = User::whereIn('name', $authorNames)->get();

--- a/app/Livewire/RezensionForm.php
+++ b/app/Livewire/RezensionForm.php
@@ -5,11 +5,11 @@ namespace App\Livewire;
 use App\Enums\Role;
 use App\Mail\NewReviewNotification;
 use App\Models\Activity;
-use App\Models\BaxxEarningRule;
 use App\Models\Book;
 use App\Models\Review;
 use App\Models\User;
 use App\Services\MembersTeamProvider;
+use App\Services\ReviewBaxxService;
 use App\Services\UserRoleService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Mail;
@@ -123,12 +123,7 @@ class RezensionForm extends Component
             $reviewCount = Review::where('team_id', $teamId)
                 ->where('user_id', $user->id)
                 ->count();
-            if ($reviewCount % 10 === 0) {
-                $points = BaxxEarningRule::getPointsFor('rezension');
-                if ($points > 0) {
-                    $user->incrementTeamPoints($points);
-                }
-            }
+            app(ReviewBaxxService::class)->awardPointsForReview($user, $reviewCount);
 
             $authorNames = array_map('trim', explode(',', $book->author));
             $authors = User::whereIn('name', $authorNames)->get();

--- a/app/Livewire/RezensionIndex.php
+++ b/app/Livewire/RezensionIndex.php
@@ -8,6 +8,7 @@ use App\Models\Book;
 use App\Models\User;
 use App\Services\MaddraxDataService;
 use App\Services\MembersTeamProvider;
+use App\Services\ReviewBaxxService;
 use App\Services\UserRoleService;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -55,6 +56,18 @@ class RezensionIndex extends Component
     public function filtersApplied(): bool
     {
         return $this->roman_number || $this->title_filter !== '' || $this->author !== '' || $this->review_status !== '';
+    }
+
+    #[Computed]
+    public function reviewRewardConfiguration(): array
+    {
+        return app(ReviewBaxxService::class)->getEffectiveRule();
+    }
+
+    #[Computed]
+    public function prominentReviewSpecialOffer(): ?array
+    {
+        return app(ReviewBaxxService::class)->getProminentSpecialOffer();
     }
 
     protected function applyFilters(Builder $query): Builder

--- a/app/Livewire/RezensionIndex.php
+++ b/app/Livewire/RezensionIndex.php
@@ -61,13 +61,7 @@ class RezensionIndex extends Component
     #[Computed]
     public function reviewRewardConfiguration(): array
     {
-        return app(ReviewBaxxService::class)->getEffectiveRule();
-    }
-
-    #[Computed]
-    public function prominentReviewSpecialOffer(): ?array
-    {
-        return app(ReviewBaxxService::class)->getProminentSpecialOffer();
+        return app(ReviewBaxxService::class)->getMemberConfiguration();
     }
 
     protected function applyFilters(Builder $query): Builder

--- a/app/Models/BaxxEarningRule.php
+++ b/app/Models/BaxxEarningRule.php
@@ -70,12 +70,10 @@ class BaxxEarningRule extends Model
     public static function clearCache(?string $actionKey = null): void
     {
         if ($actionKey) {
-            Cache::forget("baxx_earning_rule_{$actionKey}");
             Cache::forget("baxx_earning_rule_model_{$actionKey}");
         } else {
             $rules = static::all();
             foreach ($rules as $rule) {
-                Cache::forget("baxx_earning_rule_{$rule->action_key}");
                 Cache::forget("baxx_earning_rule_model_{$rule->action_key}");
             }
         }

--- a/app/Models/BaxxEarningRule.php
+++ b/app/Models/BaxxEarningRule.php
@@ -16,6 +16,7 @@ class BaxxEarningRule extends Model
         'label',
         'description',
         'points',
+        'every_count',
         'is_active',
     ];
 
@@ -23,8 +24,21 @@ class BaxxEarningRule extends Model
     {
         return [
             'points' => 'integer',
+            'every_count' => 'integer',
             'is_active' => 'boolean',
         ];
+    }
+
+    public static function getActiveRuleFor(string $actionKey): ?self
+    {
+        return Cache::remember(
+            "baxx_earning_rule_model_{$actionKey}",
+            3600,
+            fn () => static::query()
+                ->where('action_key', $actionKey)
+                ->where('is_active', true)
+                ->first()
+        );
     }
 
     /**
@@ -42,17 +56,12 @@ class BaxxEarningRule extends Model
      */
     public static function getPointsFor(string $actionKey): int
     {
-        return Cache::remember(
-            "baxx_earning_rule_{$actionKey}",
-            3600,
-            function () use ($actionKey) {
-                $rule = static::where('action_key', $actionKey)
-                    ->where('is_active', true)
-                    ->first();
+        return static::getActiveRuleFor($actionKey)?->points ?? 0;
+    }
 
-                return $rule?->points ?? 0;
-            }
-        );
+    public static function getEveryCountFor(string $actionKey): int
+    {
+        return static::getActiveRuleFor($actionKey)?->every_count ?? 1;
     }
 
     /**
@@ -62,10 +71,12 @@ class BaxxEarningRule extends Model
     {
         if ($actionKey) {
             Cache::forget("baxx_earning_rule_{$actionKey}");
+            Cache::forget("baxx_earning_rule_model_{$actionKey}");
         } else {
             $rules = static::all();
             foreach ($rules as $rule) {
                 Cache::forget("baxx_earning_rule_{$rule->action_key}");
+                Cache::forget("baxx_earning_rule_model_{$rule->action_key}");
             }
         }
     }

--- a/app/Models/ReviewBaxxSpecialOffer.php
+++ b/app/Models/ReviewBaxxSpecialOffer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ReviewBaxxSpecialOffer extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'points',
+        'every_count',
+        'ends_at',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'points' => 'integer',
+            'every_count' => 'integer',
+            'ends_at' => 'datetime',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function scopeCurrentlyActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true)
+            ->where('ends_at', '>', now());
+    }
+}

--- a/app/Services/ReviewBaxxService.php
+++ b/app/Services/ReviewBaxxService.php
@@ -63,6 +63,34 @@ class ReviewBaxxService
      *     ends_at_formatted:?string,
      *     banner_text:?string,
      *     banner_end_text:?string
+     * }
+     */
+    public function getBaseRuleData(): array
+    {
+        $baseRule = $this->getBaseRule();
+
+        return $this->makeRuleData(
+            points: $baseRule->points,
+            everyCount: $baseRule->every_count,
+            isActive: $baseRule->is_active,
+            isSpecialOffer: false,
+            endsAt: null
+        );
+    }
+
+    /**
+     * @return array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_review:float,
+     *     points_per_review_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
      * }|null
      */
     public function getProminentSpecialOffer(): ?array

--- a/app/Services/ReviewBaxxService.php
+++ b/app/Services/ReviewBaxxService.php
@@ -10,6 +10,12 @@ use Carbon\CarbonInterface;
 
 class ReviewBaxxService
 {
+    private ?BaxxEarningRule $baseRule = null;
+
+    private bool $activeSpecialOfferLoaded = false;
+
+    private ?ReviewBaxxSpecialOffer $activeSpecialOffer = null;
+
     /**
      * @return array{
      *     points:int,
@@ -95,21 +101,47 @@ class ReviewBaxxService
      */
     public function getProminentSpecialOffer(): ?array
     {
-        $specialOffer = $this->getActiveSpecialOffer();
+        return $this->extractProminentSpecialOffer($this->getEffectiveRule());
+    }
 
-        if (! $specialOffer) {
-            return null;
-        }
+    /**
+     * @return array{
+     *     effective_rule: array{
+     *         points:int,
+     *         every_count:int,
+     *         is_active:bool,
+     *         is_special_offer:bool,
+     *         points_per_review:float,
+     *         points_per_review_label:string,
+     *         rule_label:string,
+     *         ends_at:?CarbonInterface,
+     *         ends_at_formatted:?string,
+     *         banner_text:?string,
+     *         banner_end_text:?string
+     *     },
+     *     prominent_special_offer: array{
+     *         points:int,
+     *         every_count:int,
+     *         is_active:bool,
+     *         is_special_offer:bool,
+     *         points_per_review:float,
+     *         points_per_review_label:string,
+     *         rule_label:string,
+     *         ends_at:?CarbonInterface,
+     *         ends_at_formatted:?string,
+     *         banner_text:?string,
+     *         banner_end_text:?string
+     *     }|null
+     * }
+     */
+    public function getMemberConfiguration(): array
+    {
+        $effectiveRule = $this->getEffectiveRule();
 
-        $rule = $this->makeRuleData(
-            points: $specialOffer->points,
-            everyCount: $specialOffer->every_count,
-            isActive: true,
-            isSpecialOffer: true,
-            endsAt: $specialOffer->ends_at
-        );
-
-        return $rule['points_per_review'] >= 1 ? $rule : null;
+        return [
+            'effective_rule' => $effectiveRule,
+            'prominent_special_offer' => $this->extractProminentSpecialOffer($effectiveRule),
+        ];
     }
 
     public function awardPointsForReview(User $user, int $reviewCount, ?int $teamId = null, ?CarbonInterface $awardedAt = null): int
@@ -148,7 +180,11 @@ class ReviewBaxxService
 
     public function getBaseRule(): BaxxEarningRule
     {
-        return BaxxEarningRule::query()->firstOrCreate(
+        if ($this->baseRule) {
+            return $this->baseRule;
+        }
+
+        return $this->baseRule = BaxxEarningRule::query()->firstOrCreate(
             ['action_key' => 'rezension'],
             [
                 'label' => 'Rezension-Meilenstein',
@@ -162,10 +198,53 @@ class ReviewBaxxService
 
     public function getActiveSpecialOffer(): ?ReviewBaxxSpecialOffer
     {
-        return ReviewBaxxSpecialOffer::query()
+        if ($this->activeSpecialOfferLoaded) {
+            return $this->activeSpecialOffer;
+        }
+
+        $this->activeSpecialOfferLoaded = true;
+
+        return $this->activeSpecialOffer = ReviewBaxxSpecialOffer::query()
             ->currentlyActive()
             ->orderByDesc('ends_at')
             ->first();
+    }
+
+    /**
+     * @param  array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_review:float,
+     *     points_per_review_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }  $effectiveRule
+     * @return array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_review:float,
+     *     points_per_review_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }|null
+     */
+    private function extractProminentSpecialOffer(array $effectiveRule): ?array
+    {
+        if (! $effectiveRule['is_special_offer']) {
+            return null;
+        }
+
+        return $effectiveRule['points_per_review'] >= 1 ? $effectiveRule : null;
     }
 
     private function makeRuleData(

--- a/app/Services/ReviewBaxxService.php
+++ b/app/Services/ReviewBaxxService.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\BaxxEarningRule;
+use App\Models\ReviewBaxxSpecialOffer;
+use App\Models\User;
+use App\Models\UserPoint;
+use Carbon\CarbonInterface;
+
+class ReviewBaxxService
+{
+    /**
+     * @return array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_review:float,
+     *     points_per_review_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }
+     */
+    public function getEffectiveRule(): array
+    {
+        $specialOffer = $this->getActiveSpecialOffer();
+
+        if ($specialOffer) {
+            return $this->makeRuleData(
+                points: $specialOffer->points,
+                everyCount: $specialOffer->every_count,
+                isActive: true,
+                isSpecialOffer: true,
+                endsAt: $specialOffer->ends_at
+            );
+        }
+
+        $baseRule = $this->getBaseRule();
+
+        return $this->makeRuleData(
+            points: $baseRule->points,
+            everyCount: $baseRule->every_count,
+            isActive: $baseRule->is_active,
+            isSpecialOffer: false,
+            endsAt: null
+        );
+    }
+
+    /**
+     * @return array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_review:float,
+     *     points_per_review_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }|null
+     */
+    public function getProminentSpecialOffer(): ?array
+    {
+        $specialOffer = $this->getActiveSpecialOffer();
+
+        if (! $specialOffer) {
+            return null;
+        }
+
+        $rule = $this->makeRuleData(
+            points: $specialOffer->points,
+            everyCount: $specialOffer->every_count,
+            isActive: true,
+            isSpecialOffer: true,
+            endsAt: $specialOffer->ends_at
+        );
+
+        return $rule['points_per_review'] >= 1 ? $rule : null;
+    }
+
+    public function awardPointsForReview(User $user, int $reviewCount, ?CarbonInterface $awardedAt = null): int
+    {
+        $effectiveRule = $this->getEffectiveRule();
+
+        if (! $effectiveRule['is_active'] || $effectiveRule['points'] <= 0) {
+            return 0;
+        }
+
+        if ($reviewCount <= 0 || $reviewCount % $effectiveRule['every_count'] !== 0) {
+            return 0;
+        }
+
+        if (! $user->currentTeam) {
+            return 0;
+        }
+
+        $userPoint = new UserPoint([
+            'user_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'points' => $effectiveRule['points'],
+        ]);
+
+        if ($awardedAt) {
+            $userPoint->created_at = $awardedAt;
+            $userPoint->updated_at = $awardedAt;
+        }
+
+        $userPoint->save();
+
+        return $effectiveRule['points'];
+    }
+
+    public function getBaseRule(): BaxxEarningRule
+    {
+        return BaxxEarningRule::query()->firstOrCreate(
+            ['action_key' => 'rezension'],
+            [
+                'label' => 'Rezension-Meilenstein',
+                'description' => '1 Baxx für jede 10. Rezension eines Mitglieds.',
+                'points' => 1,
+                'every_count' => 10,
+                'is_active' => true,
+            ]
+        );
+    }
+
+    public function getActiveSpecialOffer(): ?ReviewBaxxSpecialOffer
+    {
+        return ReviewBaxxSpecialOffer::query()
+            ->currentlyActive()
+            ->orderByDesc('ends_at')
+            ->first();
+    }
+
+    private function makeRuleData(
+        int $points,
+        int $everyCount,
+        bool $isActive,
+        bool $isSpecialOffer,
+        ?CarbonInterface $endsAt,
+    ): array {
+        $everyCount = max(1, $everyCount);
+        $pointsPerReview = $points / $everyCount;
+        $pointsPerReviewLabel = $this->formatNumber($pointsPerReview);
+
+        return [
+            'points' => $points,
+            'every_count' => $everyCount,
+            'is_active' => $isActive,
+            'is_special_offer' => $isSpecialOffer,
+            'points_per_review' => $pointsPerReview,
+            'points_per_review_label' => $pointsPerReviewLabel,
+            'rule_label' => $this->formatRuleLabel($points, $everyCount),
+            'ends_at' => $endsAt,
+            'ends_at_formatted' => $endsAt?->copy()->timezone(config('app.timezone'))->format('d.m.Y, H:i'),
+            'banner_text' => $isSpecialOffer
+                ? 'Special Offer: Jetzt für einen begrenzten Zeitraum '.$pointsPerReviewLabel.' Baxx pro Rezension!'
+                : null,
+            'banner_end_text' => $endsAt
+                ? 'Die Aktion endet am '.$endsAt->copy()->timezone(config('app.timezone'))->format('d.m.Y').' um '.$endsAt->copy()->timezone(config('app.timezone'))->format('H:i').' Uhr.'
+                : null,
+        ];
+    }
+
+    private function formatRuleLabel(int $points, int $everyCount): string
+    {
+        if ($everyCount === 1) {
+            return $points.' Baxx pro Rezension';
+        }
+
+        return $points.' Baxx pro '.$everyCount.' Rezensionen';
+    }
+
+    private function formatNumber(float $value): string
+    {
+        if ((float) (int) $value === $value) {
+            return (string) (int) $value;
+        }
+
+        $formatted = number_format($value, 2, ',', '');
+
+        return rtrim(rtrim($formatted, '0'), ',');
+    }
+}

--- a/app/Services/ReviewBaxxService.php
+++ b/app/Services/ReviewBaxxService.php
@@ -112,7 +112,7 @@ class ReviewBaxxService
         return $rule['points_per_review'] >= 1 ? $rule : null;
     }
 
-    public function awardPointsForReview(User $user, int $reviewCount, ?CarbonInterface $awardedAt = null): int
+    public function awardPointsForReview(User $user, int $reviewCount, ?int $teamId = null, ?CarbonInterface $awardedAt = null): int
     {
         $effectiveRule = $this->getEffectiveRule();
 
@@ -124,13 +124,15 @@ class ReviewBaxxService
             return 0;
         }
 
-        if (! $user->currentTeam) {
+        $resolvedTeamId = $teamId ?? $user->currentTeam?->id;
+
+        if (! $resolvedTeamId) {
             return 0;
         }
 
         $userPoint = new UserPoint([
             'user_id' => $user->id,
-            'team_id' => $user->currentTeam->id,
+            'team_id' => $resolvedTeamId,
             'points' => $effectiveRule['points'],
         ]);
 
@@ -188,7 +190,7 @@ class ReviewBaxxService
             'ends_at' => $endsAt,
             'ends_at_formatted' => $endsAt?->copy()->timezone(config('app.timezone'))->format('d.m.Y, H:i'),
             'banner_text' => $isSpecialOffer
-                ? 'Special Offer: Jetzt für einen begrenzten Zeitraum '.$pointsPerReviewLabel.' Baxx pro Rezension!'
+                ? 'Sonderaktion: Jetzt für einen begrenzten Zeitraum '.$pointsPerReviewLabel.' Baxx pro Rezension!'
                 : null,
             'banner_end_text' => $endsAt
                 ? 'Die Aktion endet am '.$endsAt->copy()->timezone(config('app.timezone'))->format('d.m.Y').' um '.$endsAt->copy()->timezone(config('app.timezone'))->format('H:i').' Uhr.'

--- a/database/migrations/2026_04_25_130000_add_every_count_to_baxx_earning_rules_table.php
+++ b/database/migrations/2026_04_25_130000_add_every_count_to_baxx_earning_rules_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('baxx_earning_rules', function (Blueprint $table) {
+            $table->unsignedInteger('every_count')->default(1)->after('points');
+        });
+
+        DB::table('baxx_earning_rules')
+            ->whereIn('action_key', ['rezension', 'romantausch_offer'])
+            ->update(['every_count' => 10]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('baxx_earning_rules', function (Blueprint $table) {
+            $table->dropColumn('every_count');
+        });
+    }
+};

--- a/database/migrations/2026_04_25_131000_create_review_baxx_special_offers_table.php
+++ b/database/migrations/2026_04_25_131000_create_review_baxx_special_offers_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('review_baxx_special_offers', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('points');
+            $table->unsignedInteger('every_count')->default(1);
+            $table->timestamp('ends_at');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('review_baxx_special_offers');
+    }
+};

--- a/database/migrations/2026_04_25_131000_create_review_baxx_special_offers_table.php
+++ b/database/migrations/2026_04_25_131000_create_review_baxx_special_offers_table.php
@@ -15,6 +15,8 @@ return new class extends Migration
             $table->timestamp('ends_at');
             $table->boolean('is_active')->default(true);
             $table->timestamps();
+
+            $table->index(['is_active', 'ends_at']);
         });
     }
 

--- a/database/seeders/BaxxEarningRuleSeeder.php
+++ b/database/seeders/BaxxEarningRuleSeeder.php
@@ -19,30 +19,35 @@ class BaxxEarningRuleSeeder extends Seeder
                 'label' => 'Rezension-Meilenstein',
                 'description' => '1 Baxx für jede 10. Rezension eines Mitglieds.',
                 'points' => 1,
+                'every_count' => 10,
             ],
             [
                 'action_key' => 'fanfiction_publish',
                 'label' => 'Fanfiction veröffentlichen',
                 'description' => 'Baxx für die Veröffentlichung einer Fanfiction.',
                 'points' => 5,
+                'every_count' => 1,
             ],
             [
                 'action_key' => 'romantausch_offer',
                 'label' => 'Romantausch-Meilenstein',
                 'description' => '1 Baxx für jedes 10. Romantausch-Angebot eines Mitglieds.',
                 'points' => 1,
+                'every_count' => 10,
             ],
             [
                 'action_key' => 'maddraxiversum_mission',
                 'label' => 'Maddraxiversum-Mission',
                 'description' => 'Standard-Baxx für eine abgeschlossene Maddraxiversum-Mission (kann pro Mission überschrieben werden).',
                 'points' => 5,
+                'every_count' => 1,
             ],
             [
                 'action_key' => 'todo_complete',
                 'label' => 'Aufgabe abschließen',
                 'description' => 'Standard-Baxx für das Abschließen einer Aufgabe (kann pro Aufgabe überschrieben werden).',
                 'points' => 1,
+                'every_count' => 1,
             ],
         ];
 

--- a/resources/views/components/review-baxx-special-offer.blade.php
+++ b/resources/views/components/review-baxx-special-offer.blade.php
@@ -1,0 +1,11 @@
+@props(['offer'])
+
+<x-alert icon="o-megaphone" class="mb-6 border-2 border-warning/60 bg-warning/10 shadow-lg alert-warning">
+    <div class="space-y-1">
+        <p class="text-lg font-black leading-tight">{{ $offer['banner_text'] }}</p>
+        @if(!empty($offer['banner_end_text']))
+            <p class="text-sm font-semibold">{{ $offer['banner_end_text'] }}</p>
+        @endif
+        <p class="text-sm opacity-90">Aktuelle Aktionsregel: {{ $offer['rule_label'] }}</p>
+    </div>
+</x-alert>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,6 +7,10 @@
             </x-alert>
         @endif
 
+        @if($prominentReviewSpecialOffer)
+            <x-review-baxx-special-offer :offer="$prominentReviewSpecialOffer" />
+        @endif
+
         {{-- Dashboard Cards Grid --}}
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 mb-8 grid-flow-row-dense" aria-label="Überblick wichtiger Community-Kennzahlen">
             {{-- Persönliche offene Challenges Card --}}

--- a/resources/views/livewire/belohnungen-admin.blade.php
+++ b/resources/views/livewire/belohnungen-admin.blade.php
@@ -62,14 +62,43 @@
                     Hier kannst du festlegen, wie viele Baxx Mitglieder für bestimmte Aktionen erhalten.
                 </x-alert>
 
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+                    <x-stat
+                        title="Basisregel Rezensionen"
+                        :value="$this->reviewRewardConfiguration['base_rule']['rule_label']"
+                        icon="o-book-open"
+                        class="shadow"
+                    />
+                    <x-stat
+                        title="Aktuell wirksam"
+                        :value="$this->reviewRewardConfiguration['effective_rule']['rule_label']"
+                        icon="o-bolt"
+                        class="shadow"
+                    />
+                    <x-stat
+                        title="Sonderaktion"
+                        :value="$this->reviewRewardConfiguration['prominent_special_offer'] ? 'Prominent sichtbar' : 'Keine prominente Aktion'"
+                        icon="o-megaphone"
+                        class="shadow"
+                    />
+                </div>
+
                 <x-table :headers="[
                     ['key' => 'action_key', 'label' => 'Aktion'],
                     ['key' => 'label', 'label' => 'Bezeichnung'],
                     ['key' => 'description', 'label' => 'Beschreibung'],
-                    ['key' => 'points', 'label' => 'Baxx'],
+                    ['key' => 'rule_pattern', 'label' => 'Regel'],
                     ['key' => 'is_active', 'label' => 'Status'],
                     ['key' => 'actions', 'label' => 'Aktionen'],
                 ]" :rows="$this->earningRules" striped>
+
+                    @scope('cell_rule_pattern', $rule)
+                        @if($rule->every_count === 1)
+                            {{ $rule->points }} Baxx pro Auslöser
+                        @else
+                            {{ $rule->points }} Baxx pro {{ $rule->every_count }} Auslöser
+                        @endif
+                    @endscope
 
                     @scope('cell_is_active', $rule)
                         @if($rule->is_active)
@@ -87,6 +116,56 @@
                                 class="btn-ghost btn-xs"
                                 wire:click="toggleRuleActive({{ $rule->id }})"
                                 tooltip="{{ $rule->is_active ? 'Deaktivieren' : 'Aktivieren' }}"
+                            />
+                        </div>
+                    @endscope
+                </x-table>
+
+                <div class="flex items-center justify-between mt-8 mb-4 gap-4">
+                    <div>
+                        <h3 class="text-lg font-bold text-primary">Rezensions-Sonderaktionen</h3>
+                        <p class="text-sm text-base-content">Zeitlich begrenzte Aktionen überschreiben die Basisregel automatisch bis zum Endzeitpunkt.</p>
+                    </div>
+                    <x-button label="Neue Sonderaktion" icon="o-plus" class="btn-primary" wire:click="openCreateReviewSpecialOffer" />
+                </div>
+
+                <x-table :headers="[
+                    ['key' => 'rule_pattern', 'label' => 'Aktionsregel'],
+                    ['key' => 'ends_at', 'label' => 'Endet'],
+                    ['key' => 'status', 'label' => 'Status'],
+                    ['key' => 'actions', 'label' => 'Aktionen'],
+                ]" :rows="$this->reviewSpecialOffers" striped>
+
+                    @scope('cell_rule_pattern', $offer)
+                        @if($offer->every_count === 1)
+                            {{ $offer->points }} Baxx pro Rezension
+                        @else
+                            {{ $offer->points }} Baxx pro {{ $offer->every_count }} Rezensionen
+                        @endif
+                    @endscope
+
+                    @scope('cell_ends_at', $offer)
+                        {{ $offer->ends_at->format('d.m.Y H:i') }}
+                    @endscope
+
+                    @scope('cell_status', $offer)
+                        @if($offer->is_active && $offer->ends_at->isFuture())
+                            <x-badge value="Aktiv" class="badge-success" icon="o-bolt" />
+                        @elseif($offer->ends_at->isPast())
+                            <x-badge value="Abgelaufen" class="badge-warning" icon="o-clock" />
+                        @else
+                            <x-badge value="Inaktiv" class="badge-ghost" icon="o-pause" />
+                        @endif
+                    @endscope
+
+                    @scope('cell_actions', $offer)
+                        <div class="flex gap-2">
+                            <x-button icon="o-pencil" class="btn-ghost btn-xs" wire:click="openEditReviewSpecialOffer({{ $offer->id }})" tooltip="Bearbeiten" />
+                            <x-button
+                                icon="{{ $offer->is_active && $offer->ends_at->isFuture() ? 'o-eye-slash' : 'o-eye' }}"
+                                class="btn-ghost btn-xs"
+                                wire:click="toggleReviewSpecialOfferActive({{ $offer->id }})"
+                                tooltip="{{ $offer->is_active && $offer->ends_at->isFuture() ? 'Deaktivieren' : 'Aktivieren' }}"
                             />
                         </div>
                     @endscope
@@ -316,12 +395,27 @@
                 <x-input wire:model="ruleLabel" label="Bezeichnung" />
                 <x-textarea wire:model="ruleDescription" label="Beschreibung" />
                 <x-input wire:model="rulePoints" label="Baxx-Betrag" type="number" min="0" />
+                <x-input wire:model="ruleEveryCount" label="Pro Anzahl Auslöser" type="number" min="1" />
                 <x-toggle wire:model="ruleIsActive" label="Aktiv" />
             </div>
 
             <x-slot:actions>
                 <x-button label="Abbrechen" wire:click="$set('showRuleModal', false)" />
                 <x-button label="Speichern" class="btn-primary" wire:click="saveRule" />
+            </x-slot:actions>
+        </x-modal>
+
+        <x-modal wire:model="showReviewSpecialOfferModal" title="{{ $editingReviewSpecialOfferId ? 'Review-Sonderaktion bearbeiten' : 'Neue Review-Sonderaktion' }}">
+            <div class="space-y-4">
+                <x-input wire:model="reviewSpecialOfferPoints" label="Baxx" type="number" min="1" />
+                <x-input wire:model="reviewSpecialOfferEveryCount" label="Pro Anzahl Rezensionen" type="number" min="1" />
+                <x-input wire:model="reviewSpecialOfferEndsAt" label="Endet am" type="datetime-local" />
+                <x-toggle wire:model="reviewSpecialOfferIsActive" label="Aktiv" />
+            </div>
+
+            <x-slot:actions>
+                <x-button label="Abbrechen" wire:click="$set('showReviewSpecialOfferModal', false)" />
+                <x-button label="Speichern" class="btn-primary" wire:click="saveReviewSpecialOffer" />
             </x-slot:actions>
         </x-modal>
 

--- a/resources/views/livewire/belohnungen-index.blade.php
+++ b/resources/views/livewire/belohnungen-index.blade.php
@@ -8,6 +8,10 @@
             </x-slot:subtitle>
         </x-header>
 
+        @if($this->prominentReviewSpecialOffer)
+            <x-review-baxx-special-offer :offer="$this->prominentReviewSpecialOffer" />
+        @endif
+
         {{-- Hilfetext --}}
         <x-alert icon="o-information-circle" class="mb-6 alert-info" dismissible>
             <p>
@@ -15,6 +19,11 @@
                 Mit deinen verdienten Baxx kannst du hier Features freischalten. Wähle aus, welche Features du
                 nutzen möchtest, und kaufe sie mit deinen Baxx. Einmal freigeschaltete Features bleiben dauerhaft aktiv.
                 Baxx verdienst du z.&nbsp;B. durch das Erledigen von Aufgaben, Rezensionen oder Romantausch-Angebote.
+                @if($this->reviewRewardConfiguration['is_active'])
+                    Aktuell gilt für Rezensionen: <strong>{{ $this->reviewRewardConfiguration['rule_label'] }}</strong>.
+                @else
+                    Aktuell gibt es keine Baxx für neue Rezensionen.
+                @endif
             </p>
         </x-alert>
 

--- a/resources/views/livewire/belohnungen-index.blade.php
+++ b/resources/views/livewire/belohnungen-index.blade.php
@@ -8,8 +8,8 @@
             </x-slot:subtitle>
         </x-header>
 
-        @if($this->prominentReviewSpecialOffer)
-            <x-review-baxx-special-offer :offer="$this->prominentReviewSpecialOffer" />
+        @if($this->reviewRewardConfiguration['prominent_special_offer'])
+            <x-review-baxx-special-offer :offer="$this->reviewRewardConfiguration['prominent_special_offer']" />
         @endif
 
         {{-- Hilfetext --}}
@@ -19,8 +19,8 @@
                 Mit deinen verdienten Baxx kannst du hier Features freischalten. Wähle aus, welche Features du
                 nutzen möchtest, und kaufe sie mit deinen Baxx. Einmal freigeschaltete Features bleiben dauerhaft aktiv.
                 Baxx verdienst du z.&nbsp;B. durch das Erledigen von Aufgaben, Rezensionen oder Romantausch-Angebote.
-                @if($this->reviewRewardConfiguration['is_active'])
-                    Aktuell gilt für Rezensionen: <strong>{{ $this->reviewRewardConfiguration['rule_label'] }}</strong>.
+                @if($this->reviewRewardConfiguration['effective_rule']['is_active'])
+                    Aktuell gilt für Rezensionen: <strong>{{ $this->reviewRewardConfiguration['effective_rule']['rule_label'] }}</strong>.
                 @else
                     Aktuell gibt es keine Baxx für neue Rezensionen.
                 @endif

--- a/resources/views/livewire/rezension-index.blade.php
+++ b/resources/views/livewire/rezension-index.blade.php
@@ -1,10 +1,19 @@
 <x-member-page>
+    @if($this->prominentReviewSpecialOffer)
+        <x-review-baxx-special-offer :offer="$this->prominentReviewSpecialOffer" />
+    @endif
+
     <x-card shadow class="mb-6">
         <x-header title="Rezensionen" class="!mb-2" />
-        <p class="text-base text-base-content">
-            Für jede <strong>zehnte</strong> verfasste Rezension erhältst du automatisch
-            <strong>1 Baxx</strong>.
-        </p>
+        @if($this->reviewRewardConfiguration['is_active'])
+            <p class="text-base text-base-content">
+                Aktuell erhältst du automatisch <strong>{{ $this->reviewRewardConfiguration['rule_label'] }}</strong>.
+            </p>
+        @else
+            <p class="text-base text-base-content">
+                Aktuell gibt es keine Baxx für neue Rezensionen.
+            </p>
+        @endif
     </x-card>
 
     <div x-data="{ open: @js($this->filtersApplied) }" class="mb-6">

--- a/resources/views/livewire/rezension-index.blade.php
+++ b/resources/views/livewire/rezension-index.blade.php
@@ -1,13 +1,13 @@
 <x-member-page>
-    @if($this->prominentReviewSpecialOffer)
-        <x-review-baxx-special-offer :offer="$this->prominentReviewSpecialOffer" />
+    @if($this->reviewRewardConfiguration['prominent_special_offer'])
+        <x-review-baxx-special-offer :offer="$this->reviewRewardConfiguration['prominent_special_offer']" />
     @endif
 
     <x-card shadow class="mb-6">
         <x-header title="Rezensionen" class="!mb-2" />
-        @if($this->reviewRewardConfiguration['is_active'])
+        @if($this->reviewRewardConfiguration['effective_rule']['is_active'])
             <p class="text-base text-base-content">
-                Aktuell erhältst du automatisch <strong>{{ $this->reviewRewardConfiguration['rule_label'] }}</strong>.
+                Aktuell erhältst du automatisch <strong>{{ $this->reviewRewardConfiguration['effective_rule']['rule_label'] }}</strong>.
             </p>
         @else
             <p class="text-base text-base-content">

--- a/tests/Feature/BelohnungenAdminTest.php
+++ b/tests/Feature/BelohnungenAdminTest.php
@@ -8,6 +8,7 @@ use App\Models\BaxxEarningRule;
 use App\Models\Download;
 use App\Models\Reward;
 use App\Models\RewardPurchase;
+use App\Models\ReviewBaxxSpecialOffer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
@@ -120,13 +121,55 @@ class BelohnungenAdminTest extends TestCase
             ->call('openEditRule', $rule->id)
             ->set('ruleLabel', 'Geänderter Name')
             ->set('rulePoints', 7)
+            ->set('ruleEveryCount', 3)
             ->call('saveRule');
 
         $this->assertDatabaseHas('baxx_earning_rules', [
             'id' => $rule->id,
             'label' => 'Geänderter Name',
             'points' => 7,
+            'every_count' => 3,
         ]);
+    }
+
+    public function test_create_review_special_offer(): void
+    {
+        $this->actingAdmin();
+
+        Livewire::test(BelohnungenAdmin::class)
+            ->set('reviewSpecialOfferPoints', 2)
+            ->set('reviewSpecialOfferEveryCount', 1)
+            ->set('reviewSpecialOfferEndsAt', now()->addDay()->format('Y-m-d\TH:i'))
+            ->set('reviewSpecialOfferIsActive', true)
+            ->call('saveReviewSpecialOffer');
+
+        $this->assertDatabaseHas('review_baxx_special_offers', [
+            'points' => 2,
+            'every_count' => 1,
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_second_active_review_special_offer_is_rejected(): void
+    {
+        $this->actingAdmin();
+
+        ReviewBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        Livewire::test(BelohnungenAdmin::class)
+            ->set('reviewSpecialOfferPoints', 3)
+            ->set('reviewSpecialOfferEveryCount', 1)
+            ->set('reviewSpecialOfferEndsAt', now()->addDays(2)->format('Y-m-d\TH:i'))
+            ->set('reviewSpecialOfferIsActive', true)
+            ->call('saveReviewSpecialOffer')
+            ->assertHasErrors(['reviewSpecialOfferIsActive']);
+
+        $this->assertSame(1, ReviewBaxxSpecialOffer::count());
     }
 
     // ── Freischaltungen / Refund ───────────────────────────

--- a/tests/Feature/BelohnungenIndexTest.php
+++ b/tests/Feature/BelohnungenIndexTest.php
@@ -155,7 +155,7 @@ class BelohnungenIndexTest extends TestCase
 
         $this->get('/belohnungen')
             ->assertOk()
-            ->assertSee('Special Offer')
+            ->assertSee('Sonderaktion')
             ->assertSee('2 Baxx pro Rezension');
     }
 }

--- a/tests/Feature/BelohnungenIndexTest.php
+++ b/tests/Feature/BelohnungenIndexTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Livewire\BelohnungenIndex;
 use App\Models\Reward;
 use App\Models\RewardPurchase;
+use App\Models\ReviewBaxxSpecialOffer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 use Tests\Concerns\CreatesUserWithRole;
@@ -139,5 +140,22 @@ class BelohnungenIndexTest extends TestCase
             ->assertOk()
             ->assertSee('Freigeschaltetes Feature')
             ->assertSee('Freigeschaltet');
+    }
+
+    public function test_belohnungen_shows_prominent_review_special_offer(): void
+    {
+        $this->actingMember();
+
+        ReviewBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $this->get('/belohnungen')
+            ->assertOk()
+            ->assertSee('Special Offer')
+            ->assertSee('2 Baxx pro Rezension');
     }
 }

--- a/tests/Feature/CustomEmailVerificationControllerTest.php
+++ b/tests/Feature/CustomEmailVerificationControllerTest.php
@@ -30,8 +30,8 @@ class CustomEmailVerificationControllerTest extends TestCase
 
         $response->assertRedirect(route('mitglied.werden.bestaetigt', absolute: false));
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
-        Mail::assertQueued(AntragAnVorstand::class, fn ($mail) => $mail->hasTo('vorstand@maddrax-fanclub.de'));
-        Mail::assertQueued(AntragAnAdmin::class, fn ($mail) => $mail->hasTo('holgerehrmann@gmail.com'));
+        Mail::assertQueued(AntragAnVorstand::class, fn ($mail) => $mail->hasTo('vorstand@maddrax-fanclub.de') && $mail->hasTo('kassenwart@maddrax-fanclub.de'));
+        Mail::assertQueued(AntragAnAdmin::class, fn ($mail) => $mail->hasTo('info@maddraxikon.com'));
     }
 
     public function test_verification_fails_with_invalid_hash(): void

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -264,7 +264,7 @@ class DashboardControllerTest extends TestCase
         $this->actingAs($member)
             ->get('/dashboard')
             ->assertOk()
-            ->assertSee('Special Offer')
+            ->assertSee('Sonderaktion')
             ->assertSee('2 Baxx pro Rezension');
     }
 

--- a/tests/Feature/DashboardControllerTest.php
+++ b/tests/Feature/DashboardControllerTest.php
@@ -13,6 +13,7 @@ use App\Models\BookRequest;
 use App\Models\BookSwap;
 use App\Models\Fanfiction;
 use App\Models\Review;
+use App\Models\ReviewBaxxSpecialOffer;
 use App\Models\ReviewComment;
 use App\Models\Team;
 use App\Models\Todo;
@@ -245,6 +246,26 @@ class DashboardControllerTest extends TestCase
         $this->actingAs($admin)
             ->get('/dashboard')
             ->assertViewHas('romantauschOffers', 7);
+    }
+
+    public function test_dashboard_shows_prominent_review_special_offer(): void
+    {
+        $team = Team::membersTeam();
+        $member = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($member, ['role' => Role::Mitglied->value]);
+
+        ReviewBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($member)
+            ->get('/dashboard')
+            ->assertOk()
+            ->assertSee('Special Offer')
+            ->assertSee('2 Baxx pro Rezension');
     }
 
     public function test_dashboard_counts_only_open_offers_of_current_user(): void

--- a/tests/Feature/ReviewCreationTest.php
+++ b/tests/Feature/ReviewCreationTest.php
@@ -4,8 +4,10 @@ namespace Tests\Feature;
 
 use App\Enums\BookType;
 use App\Livewire\RezensionForm;
+use App\Models\BaxxEarningRule;
 use App\Models\Book;
 use App\Models\Review;
+use App\Models\ReviewBaxxSpecialOffer;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
@@ -114,6 +116,78 @@ class ReviewCreationTest extends TestCase
         $this->assertDatabaseHas('user_points', [
             'user_id' => $user->id,
             'points' => 1,
+        ]);
+    }
+
+    public function test_active_special_offer_awards_points_using_special_offer_rule(): void
+    {
+        Mail::fake();
+
+        ReviewBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $book = Book::create([
+            'roman_number' => 11,
+            'title' => 'Roman11',
+            'author' => 'Author',
+        ]);
+
+        Livewire::test(RezensionForm::class, ['book' => $book])
+            ->set('title', 'Aktionsreview')
+            ->set('content', str_repeat('A', 150))
+            ->call('save');
+
+        $this->assertDatabaseHas('user_points', [
+            'user_id' => $user->id,
+            'points' => 2,
+        ]);
+    }
+
+    public function test_expired_special_offer_falls_back_to_updated_base_rule(): void
+    {
+        Mail::fake();
+
+        $rule = BaxxEarningRule::where('action_key', 'rezension')->firstOrFail();
+        $rule->update([
+            'points' => 3,
+            'every_count' => 1,
+        ]);
+
+        ReviewBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->subMinute(),
+            'is_active' => true,
+        ]);
+
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        $book = Book::create([
+            'roman_number' => 12,
+            'title' => 'Roman12',
+            'author' => 'Author',
+        ]);
+
+        Livewire::test(RezensionForm::class, ['book' => $book])
+            ->set('title', 'Fallbackreview')
+            ->set('content', str_repeat('A', 150))
+            ->call('save');
+
+        $this->assertDatabaseHas('user_points', [
+            'user_id' => $user->id,
+            'points' => 3,
+        ]);
+        $this->assertDatabaseMissing('user_points', [
+            'user_id' => $user->id,
+            'points' => 2,
         ]);
     }
 

--- a/tests/Feature/RezensionLivewireTest.php
+++ b/tests/Feature/RezensionLivewireTest.php
@@ -164,7 +164,7 @@ class RezensionLivewireTest extends TestCase
 
         Livewire::actingAs($user)
             ->test(RezensionIndex::class)
-            ->assertSee('Special Offer')
+            ->assertSee('Sonderaktion')
             ->assertSee('2 Baxx pro Rezension');
     }
 

--- a/tests/Feature/RezensionLivewireTest.php
+++ b/tests/Feature/RezensionLivewireTest.php
@@ -9,6 +9,7 @@ use App\Livewire\RezensionShow;
 use App\Mail\NewReviewNotification;
 use App\Models\Book;
 use App\Models\Review;
+use App\Models\ReviewBaxxSpecialOffer;
 use App\Models\Team;
 use App\Models\User;
 use Carbon\Carbon;
@@ -139,6 +140,32 @@ class RezensionLivewireTest extends TestCase
         Livewire::actingAs($user)
             ->test(RezensionIndex::class)
             ->assertSee('(2 Rezensionen)');
+    }
+
+    public function test_index_shows_dynamic_review_reward_text(): void
+    {
+        $user = $this->actingMember();
+
+        Livewire::actingAs($user)
+            ->test(RezensionIndex::class)
+            ->assertSee('1 Baxx pro 10 Rezensionen');
+    }
+
+    public function test_index_shows_prominent_special_offer_banner(): void
+    {
+        $user = $this->actingMember();
+
+        ReviewBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(RezensionIndex::class)
+            ->assertSee('Special Offer')
+            ->assertSee('2 Baxx pro Rezension');
     }
 
     public function test_index_shows_hardcover_books(): void

--- a/tests/Unit/ReviewBaxxServiceTest.php
+++ b/tests/Unit/ReviewBaxxServiceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use App\Models\ReviewBaxxSpecialOffer;
+use App\Models\Team;
 use App\Models\UserPoint;
 use App\Services\ReviewBaxxService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -81,7 +82,7 @@ class ReviewBaxxServiceTest extends TestCase
 
         $this->assertNotNull($banner);
         $this->assertSame('2,5', $banner['points_per_review_label']);
-        $this->assertStringContainsString('Special Offer', $banner['banner_text']);
+        $this->assertStringContainsString('Sonderaktion', $banner['banner_text']);
     }
 
     public function test_award_points_for_review_uses_effective_rule_interval(): void
@@ -104,5 +105,24 @@ class ReviewBaxxServiceTest extends TestCase
             'points' => 2,
         ]);
         $this->assertSame(1, UserPoint::count());
+    }
+
+    public function test_award_points_for_review_uses_explicit_team_id_override(): void
+    {
+        $user = $this->createUserWithRole('Mitglied');
+        $teamId = $user->currentTeam->id;
+        $otherTeam = Team::factory()->create();
+
+        $user->forceFill(['current_team_id' => $otherTeam->id])->save();
+        $user->unsetRelation('currentTeam');
+
+        $awardedPoints = app(ReviewBaxxService::class)->awardPointsForReview($user, 10, $teamId);
+
+        $this->assertSame(1, $awardedPoints);
+        $this->assertDatabaseHas('user_points', [
+            'user_id' => $user->id,
+            'team_id' => $teamId,
+            'points' => 1,
+        ]);
     }
 }

--- a/tests/Unit/ReviewBaxxServiceTest.php
+++ b/tests/Unit/ReviewBaxxServiceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\ReviewBaxxSpecialOffer;
+use App\Models\UserPoint;
+use App\Services\ReviewBaxxService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUserWithRole;
+use Tests\TestCase;
+
+class ReviewBaxxServiceTest extends TestCase
+{
+    use CreatesUserWithRole;
+    use RefreshDatabase;
+
+    public function test_effective_rule_falls_back_to_base_rule_without_active_special_offer(): void
+    {
+        $rule = app(ReviewBaxxService::class)->getEffectiveRule();
+
+        $this->assertFalse($rule['is_special_offer']);
+        $this->assertSame(1, $rule['points']);
+        $this->assertSame(10, $rule['every_count']);
+        $this->assertSame('1 Baxx pro 10 Rezensionen', $rule['rule_label']);
+    }
+
+    public function test_active_special_offer_overrides_base_rule(): void
+    {
+        ReviewBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $rule = app(ReviewBaxxService::class)->getEffectiveRule();
+
+        $this->assertTrue($rule['is_special_offer']);
+        $this->assertSame(2, $rule['points']);
+        $this->assertSame(1, $rule['every_count']);
+        $this->assertSame('2 Baxx pro Rezension', $rule['rule_label']);
+    }
+
+    public function test_expired_special_offer_is_ignored(): void
+    {
+        ReviewBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->subMinute(),
+            'is_active' => true,
+        ]);
+
+        $rule = app(ReviewBaxxService::class)->getEffectiveRule();
+
+        $this->assertFalse($rule['is_special_offer']);
+        $this->assertSame(1, $rule['points']);
+        $this->assertSame(10, $rule['every_count']);
+    }
+
+    public function test_prominent_special_offer_is_only_returned_for_one_baxx_or_more_per_review(): void
+    {
+        ReviewBaxxSpecialOffer::create([
+            'points' => 5,
+            'every_count' => 10,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $this->assertNull(app(ReviewBaxxService::class)->getProminentSpecialOffer());
+
+        ReviewBaxxSpecialOffer::query()->delete();
+
+        ReviewBaxxSpecialOffer::create([
+            'points' => 5,
+            'every_count' => 2,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $banner = app(ReviewBaxxService::class)->getProminentSpecialOffer();
+
+        $this->assertNotNull($banner);
+        $this->assertSame('2,5', $banner['points_per_review_label']);
+        $this->assertStringContainsString('Special Offer', $banner['banner_text']);
+    }
+
+    public function test_award_points_for_review_uses_effective_rule_interval(): void
+    {
+        $user = $this->createUserWithRole('Mitglied');
+
+        ReviewBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $awardedPoints = app(ReviewBaxxService::class)->awardPointsForReview($user, 1);
+
+        $this->assertSame(2, $awardedPoints);
+        $this->assertDatabaseHas('user_points', [
+            'user_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'points' => 2,
+        ]);
+        $this->assertSame(1, UserPoint::count());
+    }
+}

--- a/tests/Unit/RewardModelTest.php
+++ b/tests/Unit/RewardModelTest.php
@@ -102,6 +102,13 @@ class RewardModelTest extends TestCase
         $this->assertEquals(1, $points);
     }
 
+    public function test_baxx_earning_rule_get_every_count_for_returns_seeded_interval(): void
+    {
+        $everyCount = BaxxEarningRule::getEveryCountFor('rezension');
+
+        $this->assertEquals(10, $everyCount);
+    }
+
     public function test_baxx_earning_rule_get_points_for_unknown_action_returns_zero(): void
     {
         $points = BaxxEarningRule::getPointsFor('nonexistent_action');
@@ -115,6 +122,7 @@ class RewardModelTest extends TestCase
 
         $points = BaxxEarningRule::getPointsFor('rezension');
         $this->assertEquals(0, $points);
+        $this->assertEquals(1, BaxxEarningRule::getEveryCountFor('rezension'));
     }
 
     public function test_baxx_earning_rule_active_scope(): void


### PR DESCRIPTION
This pull request introduces a new, more flexible system for awarding "Baxx" points for reviews, allowing for configurable rules and special offers. The changes replace the previous hardcoded logic with a service-based approach, centralize the rule evaluation, and add admin tools for managing both base rules and time-limited special offers. Additionally, the reward configuration is now accessible throughout the app for both admins and members.

**Review points logic overhaul:**

- Replaced hardcoded review point awarding logic in `RezensionController`, `RezensionForm`, and `ImportOldReviews` with calls to the new `ReviewBaxxService`, which determines point awards based on the effective rule and any active special offers. [[1]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L277-R282) [[2]](diffhunk://#diff-a12779176afb304d3da917fe51e867c40bf9d98d934a6f896c3efbf451cfa531L126-R126) [[3]](diffhunk://#diff-efb62f1281e38c0478a516bf5d6d6a96d08d260f841533a7a5f58325a623ca99L141-R151)

- Updated the `BaxxEarningRule` model to support an `every_count` field (for awarding points every Nth review), added cache-based retrieval methods for the active rule, and provided a new `getEveryCountFor` helper. [[1]](diffhunk://#diff-2db511eb37f078d3334b55b8acbb58ec8c6435a521028bb57eaab1baca91c970R19-R43) [[2]](diffhunk://#diff-2db511eb37f078d3334b55b8acbb58ec8c6435a521028bb57eaab1baca91c970L45-R64)

**Admin interface enhancements:**

- Extended the `BelohnungenAdmin` Livewire component to allow admins to view, create, edit, and activate/deactivate review special offers, with validation to ensure only one active offer at a time and that offers cannot be reactivated after expiry. [[1]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR64-R80) [[2]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR117-R137) [[3]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR309) [[4]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR319) [[5]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR328-R337) [[6]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aL303-R463)

- Added the ability to configure the base review rule's `every_count` (award frequency) in the admin UI. [[1]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR309) [[2]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR319) [[3]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR328-R337)

**User/member interface improvements:**

- Made the current review reward configuration (base rule, effective rule, and prominent special offer) available in the dashboard, rewards index, and review index for both admins and members. [[1]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bR190-R191) [[2]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL201-R206) [[3]](diffhunk://#diff-4be67e7a8c9d48885c1d556e9d90d6a213faacfebcca3f713610b6dffc5d61f0R100-R105) [[4]](diffhunk://#diff-207a9bedf0a6ab19612e36ce5c1a0ede8f3e231c360d812ba63b68a33d73528aR61-R66)

**Dependency injection and service usage:**

- Injected the new `ReviewBaxxService` into all relevant controllers and Livewire components to centralize review reward logic. [[1]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bR18) [[2]](diffhunk://#diff-8e4280fb517b57e5c0169464fa137f0b20f21b381ab42199c667bc8f1e22df4bL29-R31) [[3]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004L11-R15) [[4]](diffhunk://#diff-9e64191b55caaf139d916b671760022eaa88f43e0703eb9bab400a00d9efd004R30) [[5]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR5-R11) [[6]](diffhunk://#diff-4be67e7a8c9d48885c1d556e9d90d6a213faacfebcca3f713610b6dffc5d61f0R7) [[7]](diffhunk://#diff-207a9bedf0a6ab19612e36ce5c1a0ede8f3e231c360d812ba63b68a33d73528aR11) [[8]](diffhunk://#diff-a12779176afb304d3da917fe51e867c40bf9d98d934a6f896c3efbf451cfa531L8-R12)

**Notification email adjustments:**

- Updated the email notification logic in `CustomEmailVerificationController` to send emails to the correct board and admin addresses, and to include the treasurer.

These changes make the review reward system more maintainable, configurable, and transparent for both admins and users.