### PR TITLE
Fix: Various small bugfixes

### DIFF
--- a/app/Console/Commands/RepairLegacyRewardWallets.php
+++ b/app/Console/Commands/RepairLegacyRewardWallets.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\RewardPurchase;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class RepairLegacyRewardWallets extends Command
+{
+    protected $signature = 'rewards:repair-legacy-wallets
+        {--apply : Persistiert Änderungen statt nur einen Bericht auszugeben}
+        {--user=* : User-ID oder E-Mail-Adresse für eine gezielte Zuordnung nach manueller Prüfung}';
+
+    protected $description = 'Analysiert Legacy-Reward-Käufe ohne Wallet-Zuordnung und weist sie dem Mitglieder-Team zu, wenn der Fall sicher oder manuell geprüft ist.';
+
+    public function handle(): int
+    {
+        $walletTeam = Team::membersTeam();
+
+        if (! $walletTeam) {
+            $this->error('Mitglieder-Team nicht gefunden. Legacy-Käufe können nicht zugeordnet werden.');
+
+            return self::FAILURE;
+        }
+
+        $identifiers = collect($this->option('user'))
+            ->map(fn (mixed $identifier) => is_scalar($identifier) ? trim((string) $identifier) : '')
+            ->filter()
+            ->values();
+
+        if ($identifiers->isNotEmpty()) {
+            return $this->handleTargetUsers($walletTeam, $identifiers);
+        }
+
+        return $this->handleSafeUsers($walletTeam);
+    }
+
+    private function handleSafeUsers(Team $walletTeam): int
+    {
+        $safeUserIds = $this->resolvableLegacyUserIds($walletTeam);
+        $safePurchaseCount = $safeUserIds->isEmpty()
+            ? 0
+            : $this->legacyPurchasesQuery()->whereIn('user_id', $safeUserIds)->count();
+
+        if ($safePurchaseCount === 0) {
+            $this->info('Keine automatisch reparierbaren Legacy-Käufe gefunden.');
+        } elseif ($this->option('apply')) {
+            $updatedPurchases = $this->assignWalletTeam($walletTeam, $safeUserIds);
+            $this->info("{$updatedPurchases} Legacy-Käufe wurden dem Mitglieder-Team zugeordnet.");
+        } else {
+            $this->info("{$safePurchaseCount} Legacy-Käufe können automatisch dem Mitglieder-Team zugeordnet werden.");
+            $this->line('Mit --apply werden diese sicheren Fälle direkt repariert.');
+        }
+
+        $ambiguousUsers = $this->ambiguousLegacyUsers($safeUserIds);
+
+        if ($ambiguousUsers->isNotEmpty()) {
+            $legacyCounts = $this->legacyPurchaseCountsForUsers($ambiguousUsers->pluck('id'));
+
+            $this->table(
+                ['User-ID', 'E-Mail', 'Legacy-Käufe', 'Nicht-persönliche Teams'],
+                $ambiguousUsers->map(fn (User $user) => [
+                    $user->id,
+                    $user->email,
+                    $legacyCounts[$user->id] ?? 0,
+                    $this->formatTeamNames($user),
+                ])->all(),
+            );
+
+            $this->warn('Mehrdeutige Legacy-Fälle bleiben absichtlich unverändert. Nach manueller Prüfung kannst du sie mit --user=<id|email> --apply dem Mitglieder-Team zuordnen.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function handleTargetUsers(Team $walletTeam, Collection $identifiers): int
+    {
+        $resolvedUsers = collect();
+        $unresolvedIdentifiers = [];
+
+        foreach ($identifiers as $identifier) {
+            $user = ctype_digit($identifier)
+                ? User::query()->with('teams')->find((int) $identifier)
+                : User::query()->with('teams')->where('email', $identifier)->first();
+
+            if ($user) {
+                $resolvedUsers->put($user->id, $user);
+
+                continue;
+            }
+
+            $unresolvedIdentifiers[] = $identifier;
+        }
+
+        foreach ($unresolvedIdentifiers as $identifier) {
+            $this->warn("Kein User für '{$identifier}' gefunden.");
+        }
+
+        if ($resolvedUsers->isEmpty()) {
+            $this->info('Keine gültigen Ziel-User ausgewählt.');
+
+            return self::SUCCESS;
+        }
+
+        $eligibleUsers = $resolvedUsers->filter(
+            fn (User $user) => $user->teams->contains('id', $walletTeam->id)
+        );
+
+        foreach ($resolvedUsers->except($eligibleUsers->keys()) as $user) {
+            $this->warn("User {$user->id} ({$user->email}) ist nicht Mitglied im Mitglieder-Team und wird übersprungen.");
+        }
+
+        if ($eligibleUsers->isEmpty()) {
+            $this->info('Keine ausgewählten User können dem Mitglieder-Team zugeordnet werden.');
+
+            return self::SUCCESS;
+        }
+
+        $legacyCounts = $this->legacyPurchaseCountsForUsers($eligibleUsers->pluck('id'));
+
+        $this->table(
+            ['User-ID', 'E-Mail', 'Legacy-Käufe', 'Teams'],
+            $eligibleUsers->map(fn (User $user) => [
+                $user->id,
+                $user->email,
+                $legacyCounts[$user->id] ?? 0,
+                $this->formatTeamNames($user),
+            ])->values()->all(),
+        );
+
+        if (! $this->option('apply')) {
+            $this->line('Mit --apply wird die Zuordnung für diese User gespeichert.');
+
+            return self::SUCCESS;
+        }
+
+        $updatedPurchases = $this->assignWalletTeam($walletTeam, $eligibleUsers->pluck('id'));
+
+        $this->info("{$updatedPurchases} Legacy-Käufe wurden dem Mitglieder-Team zugeordnet.");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, int>
+     */
+    private function resolvableLegacyUserIds(Team $walletTeam): Collection
+    {
+        return DB::table('team_user')
+            ->join('teams', 'teams.id', '=', 'team_user.team_id')
+            ->where('teams.personal_team', false)
+            ->groupBy('team_user.user_id')
+            ->havingRaw('COUNT(*) = 1')
+            ->havingRaw('MIN(team_user.team_id) = ?', [$walletTeam->id])
+            ->pluck('team_user.user_id')
+            ->map(fn ($userId) => (int) $userId);
+    }
+
+    private function ambiguousLegacyUsers(Collection $safeUserIds): Collection
+    {
+        $legacyUserIds = $this->legacyPurchasesQuery()
+            ->select('user_id')
+            ->distinct()
+            ->pluck('user_id')
+            ->map(fn ($userId) => (int) $userId);
+
+        if ($legacyUserIds->isEmpty()) {
+            return collect();
+        }
+
+        return User::query()
+            ->with(['teams' => fn ($query) => $query->where('personal_team', false)->orderBy('name')])
+            ->whereIn('id', $legacyUserIds)
+            ->when($safeUserIds->isNotEmpty(), fn ($query) => $query->whereNotIn('id', $safeUserIds))
+            ->orderBy('id')
+            ->get();
+    }
+
+    private function legacyPurchasesQuery()
+    {
+        return RewardPurchase::query()
+            ->active()
+            ->whereNull('wallet_team_id');
+    }
+
+    private function assignWalletTeam(Team $walletTeam, Collection $userIds): int
+    {
+        if ($userIds->isEmpty()) {
+            return 0;
+        }
+
+        $timestamp = now();
+
+        return $this->legacyPurchasesQuery()
+            ->whereIn('user_id', $userIds)
+            ->update([
+                'wallet_team_id' => $walletTeam->id,
+                'updated_at' => $timestamp,
+            ]);
+    }
+
+    /**
+     * @return Collection<int, int>
+     */
+    private function legacyPurchaseCountsForUsers(Collection $userIds): Collection
+    {
+        if ($userIds->isEmpty()) {
+            return collect();
+        }
+
+        return $this->legacyPurchasesQuery()
+            ->whereIn('user_id', $userIds)
+            ->selectRaw('user_id, COUNT(*) as purchase_count')
+            ->groupBy('user_id')
+            ->pluck('purchase_count', 'user_id')
+            ->map(fn ($count) => (int) $count);
+    }
+
+    private function formatTeamNames(User $user): string
+    {
+        $teamNames = $user->teams
+            ->filter(fn (Team $team) => ! $team->personal_team)
+            ->pluck('name')
+            ->unique()
+            ->values();
+
+        return $teamNames->isEmpty() ? '—' : $teamNames->implode(', ');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Console;
 
 use App\Console\Commands\ArchiveEndedPolls;
+use App\Console\Commands\RepairLegacyRewardWallets;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -15,6 +16,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         ArchiveEndedPolls::class,
+        RepairLegacyRewardWallets::class,
     ];
 
     protected function schedule(Schedule $schedule): void

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -381,7 +381,7 @@ class DashboardController extends Controller
     {
         $actions = [
             [
-                'title' => 'Challenges öffnen',
+                'title' => 'Baxx verdienen',
                 'description' => 'Finde offene Aufgaben, prüfe Zusagen und springe direkt in deinen Arbeitsmodus.',
                 'href' => route('todos.index'),
                 'icon' => 'o-bolt',

--- a/app/Http/Controllers/DownloadsController.php
+++ b/app/Http/Controllers/DownloadsController.php
@@ -72,7 +72,7 @@ class DownloadsController extends Controller
                 ->exists();
 
             if (! $hasAccess) {
-                return back()->withErrors('Du musst diese Belohnung erst unter Belohnungen freischalten.');
+                return back()->withErrors('Diesen Download kannst du erst öffnen, nachdem du ihn im Bereich Belohnungen einlösen freigeschaltet hast.');
             }
         }
 

--- a/app/Http/Controllers/FanfictionCommentController.php
+++ b/app/Http/Controllers/FanfictionCommentController.php
@@ -47,7 +47,9 @@ class FanfictionCommentController extends Controller
             abort(404);
         }
 
-        $this->fanfictionAccessService->refundOwnPurchases($user);
+        if ($this->fanfictionAccessService->isOwnContribution($user, $fanfiction)) {
+            $this->fanfictionAccessService->refundOwnPurchases($user);
+        }
 
         // Prüfe ob die Fanfiction freigeschaltet wurde (Vorstand/Admin dürfen immer kommentieren)
         if ($fanfiction->reward

--- a/app/Http/Controllers/FanfictionCommentController.php
+++ b/app/Http/Controllers/FanfictionCommentController.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Concerns\MembersTeamAware;
 use App\Models\Activity;
 use App\Models\Fanfiction;
 use App\Models\FanfictionComment;
-use App\Services\RewardService;
+use App\Services\FanfictionAccessService;
 use App\Services\UserRoleService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -20,7 +20,7 @@ class FanfictionCommentController extends Controller
 
     public function __construct(
         private readonly UserRoleService $userRoleService,
-        private readonly RewardService $rewardService,
+        private readonly FanfictionAccessService $fanfictionAccessService,
     ) {}
 
     protected function getUserRoleService(): UserRoleService
@@ -47,10 +47,12 @@ class FanfictionCommentController extends Controller
             abort(404);
         }
 
+        $this->fanfictionAccessService->refundOwnPurchases($user);
+
         // Prüfe ob die Fanfiction freigeschaltet wurde (Vorstand/Admin dürfen immer kommentieren)
         if ($fanfiction->reward
             && ! in_array($role, [Role::Vorstand, Role::Admin], true)
-            && ! $this->rewardService->hasUnlockedRewardId($user, $fanfiction->reward->id)) {
+            && ! $this->fanfictionAccessService->hasUnlocked($user, $fanfiction)) {
             return redirect()->route('fanfiction.show', $fanfiction)
                 ->withErrors(['reward' => 'Du musst diese Fanfiction zuerst freischalten, um kommentieren zu können.']);
         }

--- a/app/Http/Controllers/FanfictionController.php
+++ b/app/Http/Controllers/FanfictionController.php
@@ -7,6 +7,7 @@ use App\Enums\Role;
 use App\Http\Controllers\Concerns\MembersTeamAware;
 use App\Models\Fanfiction;
 use App\Models\User;
+use App\Services\FanfictionAccessService;
 use App\Services\RewardService;
 use App\Services\UserRoleService;
 use Illuminate\Http\RedirectResponse;
@@ -22,6 +23,7 @@ class FanfictionController extends Controller
     public function __construct(
         private readonly UserRoleService $userRoleService,
         private readonly RewardService $rewardService,
+        private readonly FanfictionAccessService $fanfictionAccessService,
     ) {}
 
     protected function getUserRoleService(): UserRoleService
@@ -65,16 +67,19 @@ class FanfictionController extends Controller
 
         /** @var User $user */
         $user = Auth::user();
+        $autoRefundedPurchases = $this->fanfictionAccessService->refundOwnPurchases($user);
         $walletState = $this->rewardService->getWalletState($user);
-
-        // Einmalig alle freigeschalteten Reward-IDs laden (statt N+1 Queries)
         $unlockedRewardIds = $this->rewardService->getUnlockedRewardIds($user);
-
-        // Fanfictions ohne Reward gelten als kostenlos/freigeschaltet
-        $unlockedFanfictionIds = $fanfictions->getCollection()->filter(function ($fanfiction) use ($unlockedRewardIds) {
-            return ! $fanfiction->reward
-                || in_array($fanfiction->reward_id, $unlockedRewardIds, true);
-        })->pluck('id')->toArray();
+        $unlockedFanfictionIds = $this->fanfictionAccessService->getUnlockedFanfictionIds(
+            $user,
+            $fanfictions->getCollection(),
+            $unlockedRewardIds,
+        );
+        $ownFanfictionIds = $fanfictions->getCollection()
+            ->filter(fn (Fanfiction $fanfiction) => $this->fanfictionAccessService->isOwnContribution($user, $fanfiction))
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
 
         return view('fanfiction.index', [
             'fanfictions' => $fanfictions,
@@ -82,6 +87,8 @@ class FanfictionController extends Controller
             'availableBaxx' => $walletState['availableBaxx'],
             'walletWarning' => $walletState['warning'],
             'unlockedFanfictionIds' => $unlockedFanfictionIds,
+            'ownFanfictionIds' => $ownFanfictionIds,
+            'autoRefundedPurchases' => $autoRefundedPurchases,
         ]);
     }
 
@@ -106,16 +113,19 @@ class FanfictionController extends Controller
 
         /** @var User $user */
         $user = Auth::user();
+        $autoRefundedPurchases = $this->fanfictionAccessService->refundOwnPurchases($user);
         $walletState = $this->rewardService->getWalletState($user);
-        $hasUnlocked = ! $fanfiction->reward
-            || $this->rewardService->hasUnlockedRewardId($user, $fanfiction->reward->id);
+        $isOwnFanfiction = $this->fanfictionAccessService->isOwnContribution($user, $fanfiction);
+        $hasUnlocked = $this->fanfictionAccessService->hasUnlocked($user, $fanfiction);
 
         return view('fanfiction.show', [
             'fanfiction' => $fanfiction,
             'role' => $role,
             'hasUnlocked' => $hasUnlocked,
+            'isOwnFanfiction' => $isOwnFanfiction,
             'availableBaxx' => $walletState['availableBaxx'],
             'walletWarning' => $walletState['warning'],
+            'autoRefundedPurchases' => $autoRefundedPurchases,
         ]);
     }
 
@@ -145,6 +155,16 @@ class FanfictionController extends Controller
 
         /** @var User $user */
         $user = Auth::user();
+        $autoRefundedPurchases = $this->fanfictionAccessService->refundOwnPurchases($user);
+
+        if ($this->fanfictionAccessService->isOwnContribution($user, $fanfiction)) {
+            $message = $autoRefundedPurchases > 0
+                ? 'Deine eigene Fanfiction ist bereits freigeschaltet. Frühere Eigenkäufe wurden automatisch erstattet.'
+                : 'Deine eigene Fanfiction ist bereits freigeschaltet.';
+
+            return redirect()->route('fanfiction.show', $fanfiction)
+                ->with('info', $message);
+        }
 
         try {
             $this->rewardService->purchaseReward($user, $fanfiction->reward);

--- a/app/Http/Controllers/FanfictionController.php
+++ b/app/Http/Controllers/FanfictionController.php
@@ -113,9 +113,11 @@ class FanfictionController extends Controller
 
         /** @var User $user */
         $user = Auth::user();
-        $autoRefundedPurchases = $this->fanfictionAccessService->refundOwnPurchases($user);
         $walletState = $this->rewardService->getWalletState($user);
         $isOwnFanfiction = $this->fanfictionAccessService->isOwnContribution($user, $fanfiction);
+        $autoRefundedPurchases = $isOwnFanfiction
+            ? $this->fanfictionAccessService->refundOwnPurchases($user)
+            : 0;
         $hasUnlocked = $this->fanfictionAccessService->hasUnlocked($user, $fanfiction);
 
         return view('fanfiction.show', [
@@ -155,9 +157,8 @@ class FanfictionController extends Controller
 
         /** @var User $user */
         $user = Auth::user();
-        $autoRefundedPurchases = $this->fanfictionAccessService->refundOwnPurchases($user);
-
         if ($this->fanfictionAccessService->isOwnContribution($user, $fanfiction)) {
+            $autoRefundedPurchases = $this->fanfictionAccessService->refundOwnPurchases($user);
             $message = $autoRefundedPurchases > 0
                 ? 'Deine eigene Fanfiction ist bereits freigeschaltet. Frühere Eigenkäufe wurden automatisch erstattet.'
                 : 'Deine eigene Fanfiction ist bereits freigeschaltet.';

--- a/app/Http/Controllers/FanfictionController.php
+++ b/app/Http/Controllers/FanfictionController.php
@@ -113,11 +113,11 @@ class FanfictionController extends Controller
 
         /** @var User $user */
         $user = Auth::user();
-        $walletState = $this->rewardService->getWalletState($user);
         $isOwnFanfiction = $this->fanfictionAccessService->isOwnContribution($user, $fanfiction);
         $autoRefundedPurchases = $isOwnFanfiction
             ? $this->fanfictionAccessService->refundOwnPurchases($user)
             : 0;
+        $walletState = $this->rewardService->getWalletState($user);
         $hasUnlocked = $this->fanfictionAccessService->hasUnlocked($user, $fanfiction);
 
         return view('fanfiction.show', [

--- a/app/Livewire/BelohnungenIndex.php
+++ b/app/Livewire/BelohnungenIndex.php
@@ -3,7 +3,6 @@
 namespace App\Livewire;
 
 use App\Models\Reward;
-use App\Models\RewardPurchase;
 use App\Services\ReviewBaxxService;
 use App\Services\RewardService;
 use Illuminate\Support\Facades\Auth;

--- a/app/Livewire/BelohnungenIndex.php
+++ b/app/Livewire/BelohnungenIndex.php
@@ -65,10 +65,8 @@ class BelohnungenIndex extends Component
     public function rewards(): array
     {
         $user = Auth::user();
-        $purchasedRewardIds = RewardPurchase::where('user_id', $user->id)
-            ->active()
-            ->pluck('reward_id')
-            ->toArray();
+        $rewardService = app(RewardService::class);
+        $unlockedRewardSlugs = $rewardService->getUnlockedRewardSlugs($user);
         $walletAvailableBaxx = $this->hasAvailableWallet ? $this->availableBaxx : null;
 
         $query = Reward::active()->orderBy('sort_order')->orderBy('cost_baxx');
@@ -77,8 +75,8 @@ class BelohnungenIndex extends Component
             $query->byCategory($this->categoryFilter);
         }
 
-        $rewards = $query->get()->map(function (Reward $reward) use ($purchasedRewardIds, $walletAvailableBaxx) {
-            $purchased = in_array($reward->id, $purchasedRewardIds);
+        $rewards = $query->get()->map(function (Reward $reward) use ($unlockedRewardSlugs, $walletAvailableBaxx) {
+            $purchased = in_array($reward->slug, $unlockedRewardSlugs, true);
             $canAfford = $walletAvailableBaxx !== null && $walletAvailableBaxx >= $reward->cost_baxx;
             $missingBaxx = $walletAvailableBaxx !== null && ! $canAfford
                 ? $reward->cost_baxx - $walletAvailableBaxx

--- a/app/Services/FanfictionAccessService.php
+++ b/app/Services/FanfictionAccessService.php
@@ -53,12 +53,15 @@ class FanfictionAccessService
 
     public function refundOwnPurchases(User $user): int
     {
+        $refundedAt = now();
+
         return RewardPurchase::query()
             ->where('user_id', $user->id)
             ->active()
             ->whereHas('reward.fanfiction', fn ($query) => $query->withTrashed()->where('user_id', $user->id))
             ->update([
-                'refunded_at' => now(),
+                'refunded_at' => $refundedAt,
+                'updated_at' => $refundedAt,
                 'refunded_by' => null,
             ]);
     }

--- a/app/Services/FanfictionAccessService.php
+++ b/app/Services/FanfictionAccessService.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Fanfiction;
+use App\Models\RewardPurchase;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+class FanfictionAccessService
+{
+    public function __construct(
+        private readonly RewardService $rewardService,
+    ) {}
+
+    public function isOwnContribution(User $user, Fanfiction $fanfiction): bool
+    {
+        return $fanfiction->user_id === $user->id;
+    }
+
+    public function hasUnlocked(User $user, Fanfiction $fanfiction, ?array $unlockedRewardIds = null): bool
+    {
+        if ($this->isOwnContribution($user, $fanfiction)) {
+            return true;
+        }
+
+        if (! $fanfiction->reward_id) {
+            return true;
+        }
+
+        if (is_array($unlockedRewardIds)) {
+            return in_array($fanfiction->reward_id, $unlockedRewardIds, true);
+        }
+
+        return $this->rewardService->hasUnlockedRewardId($user, $fanfiction->reward_id);
+    }
+
+    /**
+     * @param  Collection<int, Fanfiction>  $fanfictions
+     * @param  array<int>|null  $unlockedRewardIds
+     * @return array<int>
+     */
+    public function getUnlockedFanfictionIds(User $user, Collection $fanfictions, ?array $unlockedRewardIds = null): array
+    {
+        $resolvedRewardIds = $unlockedRewardIds ?? $this->rewardService->getUnlockedRewardIds($user);
+
+        return $fanfictions
+            ->filter(fn (Fanfiction $fanfiction) => $this->hasUnlocked($user, $fanfiction, $resolvedRewardIds))
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+    }
+
+    public function refundOwnPurchases(User $user): int
+    {
+        $purchaseIds = RewardPurchase::query()
+            ->where('user_id', $user->id)
+            ->active()
+            ->whereHas('reward.fanfiction', fn ($query) => $query->where('user_id', $user->id))
+            ->pluck('id');
+
+        if ($purchaseIds->isEmpty()) {
+            return 0;
+        }
+
+        return RewardPurchase::query()
+            ->whereIn('id', $purchaseIds)
+            ->update([
+                'refunded_at' => now(),
+                'refunded_by' => null,
+            ]);
+    }
+}

--- a/app/Services/FanfictionAccessService.php
+++ b/app/Services/FanfictionAccessService.php
@@ -56,7 +56,7 @@ class FanfictionAccessService
         return RewardPurchase::query()
             ->where('user_id', $user->id)
             ->active()
-            ->whereHas('reward.fanfiction', fn ($query) => $query->where('user_id', $user->id))
+            ->whereHas('reward.fanfiction', fn ($query) => $query->withTrashed()->where('user_id', $user->id))
             ->update([
                 'refunded_at' => now(),
                 'refunded_by' => null,

--- a/app/Services/FanfictionAccessService.php
+++ b/app/Services/FanfictionAccessService.php
@@ -53,18 +53,10 @@ class FanfictionAccessService
 
     public function refundOwnPurchases(User $user): int
     {
-        $purchaseIds = RewardPurchase::query()
+        return RewardPurchase::query()
             ->where('user_id', $user->id)
             ->active()
             ->whereHas('reward.fanfiction', fn ($query) => $query->where('user_id', $user->id))
-            ->pluck('id');
-
-        if ($purchaseIds->isEmpty()) {
-            return 0;
-        }
-
-        return RewardPurchase::query()
-            ->whereIn('id', $purchaseIds)
             ->update([
                 'refunded_at' => now(),
                 'refunded_by' => null,

--- a/app/Services/RewardService.php
+++ b/app/Services/RewardService.php
@@ -16,7 +16,7 @@ use LogicException;
 class RewardService
 {
     /**
-     * Legacy-Reward-Slugs, die weiterhin als gueltige Freischaltungen gelten.
+    * Legacy-Reward-Slugs, die weiterhin als gültige Freischaltungen gelten.
      *
      * @var array<string, array<int, string>>
      */

--- a/app/Services/RewardService.php
+++ b/app/Services/RewardService.php
@@ -15,6 +15,15 @@ use LogicException;
 
 class RewardService
 {
+    /**
+     * Legacy-Reward-Slugs, die weiterhin als gueltige Freischaltungen gelten.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private const REWARD_SLUG_ALIASES = [
+        'kompendium' => ['kompendium-suche'],
+    ];
+
     public function __construct(
         private readonly TeamPointService $teamPointService
     ) {}
@@ -167,14 +176,16 @@ class RewardService
 
     public function hasUnlockedReward(User $user, string $slug): bool
     {
-        $reward = Reward::where('slug', $slug)->first();
+        $rewardIds = Reward::query()
+            ->whereIn('slug', $this->resolveRewardSlugs($slug))
+            ->pluck('id');
 
-        if (! $reward) {
+        if ($rewardIds->isEmpty()) {
             return false;
         }
 
         return RewardPurchase::where('user_id', $user->id)
-            ->where('reward_id', $reward->id)
+            ->whereIn('reward_id', $rewardIds)
             ->active()
             ->exists();
     }
@@ -185,6 +196,30 @@ class RewardService
             ->where('reward_id', $rewardId)
             ->active()
             ->exists();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getUnlockedRewardSlugs(User $user): array
+    {
+        $rewardSlugs = Reward::query()
+            ->whereIn(
+                'id',
+                RewardPurchase::query()
+                    ->where('user_id', $user->id)
+                    ->active()
+                    ->pluck('reward_id')
+            )
+            ->pluck('slug');
+
+        $unlockedSlugs = [];
+
+        foreach ($rewardSlugs as $rewardSlug) {
+            $unlockedSlugs = [...$unlockedSlugs, ...$this->resolveRewardSlugs($rewardSlug)];
+        }
+
+        return array_values(array_unique($unlockedSlugs));
     }
 
     /**
@@ -212,7 +247,7 @@ class RewardService
         }
 
         if (! $this->hasUnlockedReward($user, $rewardSlug)) {
-            throw new AuthorizationException('Du musst diese Belohnung zuerst unter /belohnungen freischalten.');
+            throw new AuthorizationException('Du musst diese Belohnung zuerst im Bereich Belohnungen einlösen freischalten.');
         }
     }
 
@@ -300,5 +335,21 @@ class RewardService
     private function missingMembersTeamWarning(): string
     {
         return 'Das Mitglieder-Team ist derzeit nicht verfügbar. Baxx-Guthaben und neue Freischaltungen können aktuell nicht geladen werden.';
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function resolveRewardSlugs(string $slug): array
+    {
+        foreach (self::REWARD_SLUG_ALIASES as $canonicalSlug => $legacySlugs) {
+            $knownSlugs = [$canonicalSlug, ...$legacySlugs];
+
+            if (in_array($slug, $knownSlugs, true)) {
+                return $knownSlugs;
+            }
+        }
+
+        return [$slug];
     }
 }

--- a/app/Services/RewardService.php
+++ b/app/Services/RewardService.php
@@ -16,7 +16,7 @@ use LogicException;
 class RewardService
 {
     /**
-    * Legacy-Reward-Slugs, die weiterhin als gültige Freischaltungen gelten.
+     * Legacy-Reward-Slugs, die weiterhin als gültige Freischaltungen gelten.
      *
      * @var array<string, array<int, string>>
      */

--- a/app/Services/RewardService.php
+++ b/app/Services/RewardService.php
@@ -203,7 +203,7 @@ class RewardService
      */
     public function getUnlockedRewardSlugs(User $user): array
     {
-        $rewardSlugs = Reward::query()
+        return Reward::query()
             ->whereIn(
                 'id',
                 RewardPurchase::query()
@@ -211,15 +211,11 @@ class RewardService
                     ->active()
                     ->pluck('reward_id')
             )
-            ->pluck('slug');
-
-        $unlockedSlugs = [];
-
-        foreach ($rewardSlugs as $rewardSlug) {
-            $unlockedSlugs = [...$unlockedSlugs, ...$this->resolveRewardSlugs($rewardSlug)];
-        }
-
-        return array_values(array_unique($unlockedSlugs));
+            ->pluck('slug')
+            ->flatMap(fn (string $rewardSlug): array => $this->resolveRewardSlugs($rewardSlug))
+            ->unique()
+            ->values()
+            ->all();
     }
 
     /**

--- a/config/navigation.php
+++ b/config/navigation.php
@@ -78,8 +78,8 @@ return [
             'title' => 'Baxx',
             'icon' => 'o-bolt',
             'items' => [
-                ['title' => 'Challenges', 'route' => 'todos.index'],
-                ['title' => 'Belohnungen', 'route' => 'rewards.index'],
+                ['title' => 'Baxx verdienen', 'route' => 'todos.index'],
+                ['title' => 'Belohnungen einlösen', 'route' => 'rewards.index'],
             ],
         ],
         [

--- a/resources/views/components/book-list.blade.php
+++ b/resources/views/components/book-list.blade.php
@@ -34,18 +34,20 @@
                     <td class="text-base-content">{{ $book->author }}</td>
                     <td>
                         @if($book->has_review)
-                            <x-badge value="" class="badge-success">
+                            <x-badge value="Vorhanden" class="badge-success badge-sm">
                                 <x-slot:prepend>
                                     <x-icon name="o-check" class="w-4 h-4" />
                                 </x-slot:prepend>
                             </x-badge>
                         @else
-                            <a href="{{ route('reviews.create', $book) }}" wire:navigate title="Rezension schreiben">
-                                <x-badge value="" class="badge-info cursor-pointer hover:opacity-80">
-                                    <x-slot:prepend>
-                                        <x-icon name="o-pencil" class="w-4 h-4" />
-                                    </x-slot:prepend>
-                                </x-badge>
+                            <a href="{{ route('reviews.create', $book) }}" wire:navigate title="Rezension schreiben" aria-label="Rezension schreiben" class="inline-flex items-center">
+                                <span class="hidden sm:inline-flex items-center gap-2 rounded-full border border-info/20 bg-info/10 px-3 py-1.5 text-xs font-medium text-info transition hover:bg-info/15">
+                                    <x-icon name="o-pencil-square" class="w-4 h-4" />
+                                    <span>Rezension schreiben</span>
+                                </span>
+                                <span class="inline-flex sm:hidden items-center justify-center rounded-full border border-info/20 bg-info/10 p-2 text-info transition hover:bg-info/15" aria-hidden="true">
+                                    <x-icon name="o-pencil-square" class="w-4 h-4" />
+                                </span>
                             </a>
                         @endif
                     </td>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -10,7 +10,7 @@
                     </x-ui.action-cluster>
 
                     <x-ui.action-cluster align="end">
-                        <a href="{{ route('todos.index') }}" wire:navigate class="btn btn-primary btn-sm rounded-full">Challenges öffnen</a>
+                        <a href="{{ route('todos.index') }}" wire:navigate class="btn btn-primary btn-sm rounded-full">Baxx verdienen</a>
                         <a href="{{ route('fantreffen.2026') }}" wire:navigate class="btn btn-ghost btn-sm rounded-full bg-base-100/70">Fantreffen 2026</a>
                     </x-ui.action-cluster>
                 </x-slot:actions>

--- a/resources/views/fanfiction/index.blade.php
+++ b/resources/views/fanfiction/index.blade.php
@@ -21,6 +21,16 @@
             </x-alert>
         @endif
 
+        @if (($autoRefundedPurchases ?? 0) > 0)
+            <x-alert icon="o-arrow-uturn-left" class="alert-info mb-6" dismissible>
+                @if ($autoRefundedPurchases === 1)
+                    Ein früherer Eigenkauf deiner Fanfiction wurde automatisch erstattet.
+                @else
+                    {{ $autoRefundedPurchases }} frühere Eigenkäufe deiner Fanfiction wurden automatisch erstattet.
+                @endif
+            </x-alert>
+        @endif
+
         @if ($fanfictions->isEmpty())
             <x-ui.panel>
                 <div class="text-center py-12">
@@ -36,6 +46,7 @@
                 @foreach ($fanfictions as $fanfiction)
                     @php
                         $isUnlocked = !$fanfiction->reward || in_array($fanfiction->id, $unlockedFanfictionIds);
+                        $isOwnFanfiction = in_array($fanfiction->id, $ownFanfictionIds ?? [], true);
                     @endphp
                     <x-ui.panel x-data="{ expanded: false }" data-fanfiction-item>
                         {{-- Header mit Titel und Autor --}}
@@ -45,7 +56,9 @@
                                     {{ $fanfiction->title }}
                                 </a>
                                 @if ($fanfiction->reward)
-                                    @if ($isUnlocked)
+                                    @if ($isOwnFanfiction)
+                                        <x-badge value="Eigener Beitrag" class="badge-info badge-sm" icon="o-pencil-square" />
+                                    @elseif ($isUnlocked)
                                         <x-badge value="Freigeschaltet" class="badge-success badge-sm" icon="o-lock-open" />
                                     @else
                                         <x-badge value="{{ $fanfiction->reward->cost_baxx }} Baxx" class="badge-warning badge-sm" icon="o-currency-dollar" />

--- a/resources/views/fanfiction/show.blade.php
+++ b/resources/views/fanfiction/show.blade.php
@@ -12,7 +12,9 @@
             <x-slot:actions>
                 <div class="flex flex-wrap items-center gap-2">
                     @if ($fanfiction->reward)
-                        @if ($hasUnlocked)
+                        @if ($isOwnFanfiction)
+                            <x-badge value="Eigener Beitrag" class="badge-info" icon="o-pencil-square" />
+                        @elseif ($hasUnlocked)
                             <x-badge value="Freigeschaltet" class="badge-success" icon="o-lock-open" />
                         @else
                             <x-badge value="{{ $fanfiction->reward->cost_baxx }} Baxx" class="badge-warning" icon="o-currency-dollar" />
@@ -29,6 +31,16 @@
         @if ($walletWarning)
             <x-alert icon="o-exclamation-triangle" class="alert-warning mb-6" dismissible>
                 {{ $walletWarning }}
+            </x-alert>
+        @endif
+
+        @if (($autoRefundedPurchases ?? 0) > 0)
+            <x-alert icon="o-arrow-uturn-left" class="alert-info mb-6" dismissible>
+                @if ($autoRefundedPurchases === 1)
+                    Ein früherer Eigenkauf deiner Fanfiction wurde automatisch erstattet.
+                @else
+                    {{ $autoRefundedPurchases }} frühere Eigenkäufe deiner Fanfiction wurden automatisch erstattet.
+                @endif
             </x-alert>
         @endif
 

--- a/resources/views/maddraxiversum/index.blade.php
+++ b/resources/views/maddraxiversum/index.blade.php
@@ -17,7 +17,7 @@
                     @else
                         <div class="bg-warning/10 border-l-4 border-warning text-warning-content p-4">
                             <p class="font-bold">Zugriff eingeschränkt</p>
-                            <p>Du musst diese Belohnung zuerst unter <a href="/belohnungen" class="underline font-semibold">Belohnungen</a> freischalten.</p>
+                            <p>Du musst diese Belohnung zuerst im Bereich <a href="/belohnungen" class="underline font-semibold">Belohnungen einlösen</a> freischalten.</p>
                             <p>Du hast aktuell {{ $userPoints }} Baxx gesammelt.</p>
                         </div>
                     @endif

--- a/resources/views/mitglieder/karte-locked.blade.php
+++ b/resources/views/mitglieder/karte-locked.blade.php
@@ -3,15 +3,15 @@
         <x-ui.page-header
             eyebrow="Mitgliederbereich"
             title="Mitgliederkarte"
-            description="Die Kartenansicht wird freigeschaltet, sobald du erste Baxx gesammelt und mindestens eine Challenge abgeschlossen hast."
+            description="Die Kartenansicht wird freigeschaltet, sobald du erste Baxx gesammelt und mindestens eine Aufgabe abgeschlossen hast."
             data-testid="page-title"
         />
 
         <x-ui.panel>
             <x-alert title="Karte noch nicht verfügbar" icon="o-lock-closed" class="alert-warning">
-                Die Mitgliederkarte wird freigeschaltet, sobald du mindestens eine Challenge erfolgreich abgeschlossen hast.
+                Die Mitgliederkarte wird freigeschaltet, sobald du mindestens eine Aufgabe erfolgreich abgeschlossen hast.
                 <x-slot:actions>
-                    <x-button label="Zu den verfügbaren Challenges" link="{{ route('todos.index') }}" wire:navigate icon="o-clipboard-document-list" class="btn-primary btn-sm" />
+                    <x-button label="Zu Baxx verdienen" link="{{ route('todos.index') }}" wire:navigate icon="o-clipboard-document-list" class="btn-primary btn-sm" />
                 </x-slot:actions>
             </x-alert>
         </x-ui.panel>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -47,22 +47,20 @@
                         <x-ui.action-cluster>
                             @foreach($sectionNavigation as $section)
                                 <x-dropdown :label="$section['title']" :right="$loop->last" class="btn-sm rounded-full whitespace-nowrap {{ $section['active'] ? 'btn-primary btn-outline' : 'btn-ghost bg-base-100/60' }}">
-                                    <div class="w-fit min-w-[14rem] max-w-[min(24rem,calc(100vw-2rem))]" data-testid="desktop-nav-dropdown-panel">
-                                        @foreach($section['items'] as $item)
-                                            <li>
-                                                <a
-                                                    href="{{ $item['href'] }}"
-                                                    wire:navigate
-                                                    class="my-0.5 flex items-center gap-3 rounded-xl px-4 py-2 text-sm leading-5 text-base-content transition hover:bg-base-200/80 whitespace-nowrap"
-                                                >
-                                                    @if($item['icon'] ?? null)
-                                                        <x-icon :name="$item['icon']" class="h-4 w-4 shrink-0" />
-                                                    @endif
-                                                    <span class="whitespace-nowrap">{{ $item['title'] }}</span>
-                                                </a>
-                                            </li>
-                                        @endforeach
-                                    </div>
+                                    @foreach($section['items'] as $item)
+                                        <li class="w-fit min-w-[14rem] max-w-[min(24rem,calc(100vw-2rem))]" data-testid="desktop-nav-dropdown-item">
+                                            <a
+                                                href="{{ $item['href'] }}"
+                                                wire:navigate
+                                                class="my-0.5 flex w-full items-center gap-3 rounded-xl px-4 py-2 text-sm leading-5 text-base-content transition hover:bg-base-200/80 whitespace-nowrap"
+                                            >
+                                                @if($item['icon'] ?? null)
+                                                    <x-icon :name="$item['icon']" class="h-4 w-4 shrink-0" />
+                                                @endif
+                                                <span class="whitespace-nowrap">{{ $item['title'] }}</span>
+                                            </a>
+                                        </li>
+                                    @endforeach
                                 </x-dropdown>
                             @endforeach
                         </x-ui.action-cluster>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -46,10 +46,23 @@
                         <p class="hidden px-2 pb-2 text-[0.62rem] font-semibold uppercase tracking-[0.24em] text-base-content/45 2xl:block">Bereiche</p>
                         <x-ui.action-cluster>
                             @foreach($sectionNavigation as $section)
-                                <x-dropdown :label="$section['title']" class="btn-sm rounded-full whitespace-nowrap {{ $section['active'] ? 'btn-primary btn-outline' : 'btn-ghost bg-base-100/60' }}">
-                                    @foreach($section['items'] as $item)
-                                        <x-menu-item :title="$item['title']" :link="$item['href']" wire:navigate :icon="$item['icon'] ?? null" />
-                                    @endforeach
+                                <x-dropdown :label="$section['title']" :right="$loop->last" class="btn-sm rounded-full whitespace-nowrap {{ $section['active'] ? 'btn-primary btn-outline' : 'btn-ghost bg-base-100/60' }}">
+                                    <div class="w-fit min-w-[14rem] max-w-[min(24rem,calc(100vw-2rem))]" data-testid="desktop-nav-dropdown-panel">
+                                        @foreach($section['items'] as $item)
+                                            <li>
+                                                <a
+                                                    href="{{ $item['href'] }}"
+                                                    wire:navigate
+                                                    class="my-0.5 flex items-center gap-3 rounded-xl px-4 py-2 text-sm leading-5 text-base-content transition hover:bg-base-200/80 whitespace-nowrap"
+                                                >
+                                                    @if($item['icon'] ?? null)
+                                                        <x-icon :name="$item['icon']" class="h-4 w-4 shrink-0" />
+                                                    @endif
+                                                    <span class="whitespace-nowrap">{{ $item['title'] }}</span>
+                                                </a>
+                                            </li>
+                                        @endforeach
+                                    </div>
                                 </x-dropdown>
                             @endforeach
                         </x-ui.action-cluster>

--- a/resources/views/pages/downloads.blade.php
+++ b/resources/views/pages/downloads.blade.php
@@ -11,7 +11,7 @@
         <x-ui.page-header
             eyebrow="Exklusive Inhalte für Mitglieder"
             title="Downloads"
-            description="Hier findest du Bauanleitungen, Fanstories und weitere Dateien aus dem Vereinsbereich. Gesperrte Inhalte lassen sich direkt über Belohnungen freischalten."
+            description="Hier findest du Bauanleitungen, Fanstories und weitere Dateien aus dem Vereinsbereich. Gesperrte Inhalte lassen sich direkt im Bereich Belohnungen einlösen freischalten."
         >
             <x-slot:actions>
                 <div class="flex flex-wrap gap-2">
@@ -85,7 +85,7 @@
                                                     @if(isset($unlockedDownloadIds[$download->id]) || $download->reward === null)
                                                         <x-button label="Herunterladen" link="{{ route('downloads.download', $download) }}" icon="o-arrow-down-tray" class="btn-primary btn-sm" />
                                                     @elseif($download->reward->is_active)
-                                                        <a href="{{ route('rewards.index') }}" wire:navigate class="inline-flex items-center gap-2 rounded-full border border-base-content/10 bg-base-100 px-4 py-2 text-sm font-medium text-base-content transition hover:border-primary/30 hover:text-primary" title="Unter Belohnungen freischalten">
+                                                        <a href="{{ route('rewards.index') }}" wire:navigate class="inline-flex items-center gap-2 rounded-full border border-base-content/10 bg-base-100 px-4 py-2 text-sm font-medium text-base-content transition hover:border-primary/30 hover:text-primary" title="Im Bereich Belohnungen einlösen öffnen">
                                                             <x-icon name="o-lock-closed" class="h-4 w-4" />
                                                             <span>Freischalten</span>
                                                         </a>

--- a/resources/views/pages/kompendium.blade.php
+++ b/resources/views/pages/kompendium.blade.php
@@ -7,7 +7,7 @@
         <x-ui.page-header
             eyebrow="Volltextsuche für Mitglieder"
             title="Maddrax-Kompendium"
-            description="Die Kompendium-Suche bündelt indexierte Maddrax-Reihen an einer Stelle. Zugriff erhältst du über das Kompendium-Reward oder über deine Mitgliedschaft in der AG Maddraxikon."
+            description="Die Kompendium-Suche bündelt indexierte Maddrax-Reihen an einer Stelle. Zugriff erhältst du über das Kompendium-Reward im Bereich Belohnungen einlösen oder über deine Mitgliedschaft in der AG Maddraxikon."
         >
             <x-slot:actions>
                 <div class="flex flex-wrap gap-2">
@@ -50,14 +50,14 @@
                     @endif
                 </x-ui.panel>
 
-                <x-ui.panel title="{{ $showSearch ? 'Volltextsuche' : 'Zugang zum Kompendium' }}" description="{{ $showSearch ? 'Suche direkt in den indexierten Inhalten nach Begriffen, Phrasen und Treffern in verschiedenen Reihen.' : 'Wenn die Suche noch gesperrt ist, kannst du den Zugang direkt über das Reward freischalten oder ihn über die AG Maddraxikon erhalten.' }}">
+                <x-ui.panel title="{{ $showSearch ? 'Volltextsuche' : 'Zugang zum Kompendium' }}" description="{{ $showSearch ? 'Suche direkt in den indexierten Inhalten nach Begriffen, Phrasen und Treffern in verschiedenen Reihen.' : 'Wenn die Suche noch gesperrt ist, kannst du den Zugang direkt im Bereich Belohnungen einlösen freischalten oder ihn über die AG Maddraxikon erhalten.' }}">
                     @if($showSearch)
                         @livewire('kompendium-suche')
                     @else
                         @if($kompendiumReward && $kompendiumReward->is_active)
                             <div class="mb-4 rounded-[1.25rem] border border-base-content/10 bg-base-100/72 px-4 py-4 text-sm leading-relaxed text-base-content/76 sm:text-base">
                                 <p>Die Kompendium-Suche ist aktuell noch nicht freigeschaltet.</p>
-                                <p class="mt-2">Mit dem Reward schaltest du den Suchzugang für dein Konto frei. Mitglieder der AG Maddraxikon erhalten den Zugriff automatisch.</p>
+                                <p class="mt-2">Im Bereich Belohnungen einlösen schaltest du den Suchzugang für dein Konto frei. Mitglieder der AG Maddraxikon erhalten den Zugriff automatisch.</p>
                             </div>
 
                             @livewire('kompendium-kauf-overlay', [

--- a/tests/Feature/BelohnungenIndexTest.php
+++ b/tests/Feature/BelohnungenIndexTest.php
@@ -4,9 +4,9 @@ namespace Tests\Feature;
 
 use App\Enums\Role;
 use App\Livewire\BelohnungenIndex;
+use App\Models\ReviewBaxxSpecialOffer;
 use App\Models\Reward;
 use App\Models\RewardPurchase;
-use App\Models\ReviewBaxxSpecialOffer;
 use App\Models\Team;
 use App\Models\UserPoint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -144,10 +144,14 @@ class BelohnungenIndexTest extends TestCase
     {
         $user = $this->actingMemberWithPoints(20);
         $reward = Reward::factory()->create(['cost_baxx' => 5, 'slug' => 'owned']);
+        $membersTeam = Team::membersTeam();
+
+        $this->assertNotNull($membersTeam);
 
         RewardPurchase::factory()->create([
             'user_id' => $user->id,
             'reward_id' => $reward->id,
+            'wallet_team_id' => $membersTeam->id,
             'cost_baxx' => 5,
         ]);
 
@@ -182,10 +186,14 @@ class BelohnungenIndexTest extends TestCase
             'slug' => 'unlocked-test',
             'title' => 'Freigeschaltetes Feature',
         ]);
+        $membersTeam = Team::membersTeam();
+
+        $this->assertNotNull($membersTeam);
 
         RewardPurchase::factory()->create([
             'user_id' => $user->id,
             'reward_id' => $reward->id,
+            'wallet_team_id' => $membersTeam->id,
             'cost_baxx' => 5,
         ]);
 
@@ -198,6 +206,9 @@ class BelohnungenIndexTest extends TestCase
     public function test_legacy_kompendium_purchase_marks_current_reward_as_unlocked(): void
     {
         $user = $this->actingMemberWithPoints(120);
+        $membersTeam = Team::membersTeam();
+
+        $this->assertNotNull($membersTeam);
 
         Reward::updateOrCreate(
             ['slug' => 'kompendium'],
@@ -226,7 +237,7 @@ class BelohnungenIndexTest extends TestCase
         RewardPurchase::create([
             'user_id' => $user->id,
             'reward_id' => $legacyReward->id,
-            'wallet_team_id' => Team::membersTeam()?->id,
+            'wallet_team_id' => $membersTeam->id,
             'cost_baxx' => 100,
             'purchased_at' => now(),
         ]);

--- a/tests/Feature/BelohnungenIndexTest.php
+++ b/tests/Feature/BelohnungenIndexTest.php
@@ -195,6 +195,49 @@ class BelohnungenIndexTest extends TestCase
             ->assertSee('Freigeschaltet');
     }
 
+    public function test_legacy_kompendium_purchase_marks_current_reward_as_unlocked(): void
+    {
+        $user = $this->actingMemberWithPoints(120);
+
+        Reward::updateOrCreate(
+            ['slug' => 'kompendium'],
+            [
+                'title' => 'Maddrax-Kompendium',
+                'description' => 'Aktueller Zugang zum Maddrax-Kompendium.',
+                'category' => 'Kompendium',
+                'cost_baxx' => 100,
+                'is_active' => true,
+                'sort_order' => 0,
+            ]
+        );
+
+        $legacyReward = Reward::updateOrCreate(
+            ['slug' => 'kompendium-suche'],
+            [
+                'title' => 'Kompendium-Suche',
+                'description' => 'Legacy-Zugang zur Kompendium-Suche.',
+                'category' => 'Kompendium',
+                'cost_baxx' => 100,
+                'is_active' => false,
+                'sort_order' => 1,
+            ]
+        );
+
+        RewardPurchase::create([
+            'user_id' => $user->id,
+            'reward_id' => $legacyReward->id,
+            'wallet_team_id' => Team::membersTeam()?->id,
+            'cost_baxx' => 100,
+            'purchased_at' => now(),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(BelohnungenIndex::class)
+            ->set('filter', 'freigeschaltet')
+            ->assertSee('Maddrax-Kompendium')
+            ->assertSee('Freigeschaltet');
+    }
+
     public function test_belohnungen_shows_prominent_review_special_offer(): void
     {
         $this->actingMember();

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -233,7 +233,7 @@ class DashboardTest extends TestCase
         $response->assertOk();
         $response->assertSeeText('Willkommen zurück, Alex');
         $response->assertSeeText('Schnellstart');
-        $response->assertSeeText('Challenges öffnen');
+        $response->assertSeeText('Baxx verdienen');
         $response->assertSeeText('Fantreffen 2026 ansehen');
         $response->assertDontSeeText('Fantreffen verwalten');
     }
@@ -257,7 +257,7 @@ class DashboardTest extends TestCase
 
         $response = $this->actingAs($user)->get('/dashboard');
         $quickActions = collect($response->viewData('quickActions'));
-        $challengeAction = $quickActions->firstWhere('title', 'Challenges öffnen');
+        $challengeAction = $quickActions->firstWhere('title', 'Baxx verdienen');
         $verificationAction = $quickActions->firstWhere('title', 'Verifizierungen prüfen');
 
         $response->assertOk();

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -257,15 +257,15 @@ class DashboardTest extends TestCase
 
         $response = $this->actingAs($user)->get('/dashboard');
         $quickActions = collect($response->viewData('quickActions'));
-        $challengeAction = $quickActions->firstWhere('title', 'Baxx verdienen');
+        $earnBaxxAction = $quickActions->firstWhere('title', 'Baxx verdienen');
         $verificationAction = $quickActions->firstWhere('title', 'Verifizierungen prüfen');
 
         $response->assertOk();
         $response->assertSeeText('Mitgliedsanträge prüfen');
         $response->assertSeeText('Verifizierungen prüfen');
         $response->assertSeeText('Fantreffen verwalten');
-        $this->assertNotNull($challengeAction);
-        $this->assertArrayNotHasKey('badge', $challengeAction);
+        $this->assertNotNull($earnBaxxAction);
+        $this->assertArrayNotHasKey('badge', $earnBaxxAction);
         $this->assertSame(route('todos.index', ['filter' => 'pending']), $verificationAction['href'] ?? null);
         $this->assertSame('1', $verificationAction['badge'] ?? null);
     }

--- a/tests/Feature/DownloadsTest.php
+++ b/tests/Feature/DownloadsTest.php
@@ -74,6 +74,30 @@ class DownloadsTest extends TestCase
 
         $response->assertRedirect('/downloads');
         $response->assertSessionHasErrors();
+        $this->assertStringContainsString(
+            'im Bereich Belohnungen einlösen',
+            $response->getSession()->get('errors')->first()
+        );
+    }
+
+    public function test_downloads_page_points_locked_files_to_rewards_redeem_flow(): void
+    {
+        $this->actingMember();
+
+        $download = Download::factory()->create([
+            'title' => 'Belohnter Download',
+            'category' => 'Spezialinhalte',
+        ]);
+        Reward::factory()->create([
+            'download_id' => $download->id,
+            'is_active' => true,
+        ]);
+
+        $response = $this->get('/downloads');
+
+        $response->assertOk();
+        $response->assertSee('Belohnungen einlösen');
+        $response->assertSee('Belohnung nötig');
     }
 
     public function test_download_with_inactive_reward_shows_nicht_verfuegbar_message(): void

--- a/tests/Feature/FanfictionCommentControllerTest.php
+++ b/tests/Feature/FanfictionCommentControllerTest.php
@@ -253,6 +253,45 @@ class FanfictionCommentControllerTest extends TestCase
         ]);
     }
 
+    public function test_commenting_on_foreign_fanfiction_does_not_refund_unrelated_own_purchases(): void
+    {
+        $ownFanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+            'title' => 'Eigene Geschichte mit Alt-Kauf',
+        ]);
+        $ownReward = $this->createRewardForFanfiction($ownFanfiction);
+        $ownPurchase = RewardPurchase::create([
+            'user_id' => $this->member->id,
+            'reward_id' => $ownReward->id,
+            'cost_baxx' => $ownReward->cost_baxx,
+            'purchased_at' => now(),
+        ]);
+
+        $foreignFanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->otherMember->id,
+            'created_by' => $this->otherMember->id,
+        ]);
+
+        $response = $this->actingAs($this->member)
+            ->post(route('fanfiction.comments.store', $foreignFanfiction), [
+                'content' => 'Kommentar ohne Nebenwirkung',
+            ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasNoErrors();
+
+        $ownPurchase->refresh();
+        $this->assertNull($ownPurchase->refunded_at);
+        $this->assertDatabaseHas('fanfiction_comments', [
+            'fanfiction_id' => $foreignFanfiction->id,
+            'user_id' => $this->member->id,
+            'content' => 'Kommentar ohne Nebenwirkung',
+        ]);
+    }
+
     public function test_vorstand_can_comment_on_locked_fanfiction_without_purchase(): void
     {
         $vorstand = User::factory()->create();

--- a/tests/Feature/FanfictionCommentControllerTest.php
+++ b/tests/Feature/FanfictionCommentControllerTest.php
@@ -233,6 +233,26 @@ class FanfictionCommentControllerTest extends TestCase
         ]);
     }
 
+    public function test_author_can_comment_on_own_locked_fanfiction_without_purchase(): void
+    {
+        $this->fanfiction->update(['user_id' => $this->member->id]);
+        $this->createRewardForFanfiction($this->fanfiction);
+
+        $response = $this->actingAs($this->member)
+            ->post(route('fanfiction.comments.store', $this->fanfiction), [
+                'content' => 'Kommentar zur eigenen Geschichte',
+            ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasNoErrors();
+
+        $this->assertDatabaseHas('fanfiction_comments', [
+            'fanfiction_id' => $this->fanfiction->id,
+            'user_id' => $this->member->id,
+            'content' => 'Kommentar zur eigenen Geschichte',
+        ]);
+    }
+
     public function test_vorstand_can_comment_on_locked_fanfiction_without_purchase(): void
     {
         $vorstand = User::factory()->create();

--- a/tests/Feature/FanfictionCommentControllerTest.php
+++ b/tests/Feature/FanfictionCommentControllerTest.php
@@ -214,6 +214,7 @@ class FanfictionCommentControllerTest extends TestCase
         RewardPurchase::create([
             'user_id' => $this->member->id,
             'reward_id' => $reward->id,
+            'wallet_team_id' => $this->memberTeam->id,
             'cost_baxx' => $reward->cost_baxx,
             'purchased_at' => now(),
         ]);
@@ -265,6 +266,7 @@ class FanfictionCommentControllerTest extends TestCase
         $ownPurchase = RewardPurchase::create([
             'user_id' => $this->member->id,
             'reward_id' => $ownReward->id,
+            'wallet_team_id' => $this->memberTeam->id,
             'cost_baxx' => $ownReward->cost_baxx,
             'purchased_at' => now(),
         ]);

--- a/tests/Feature/FanfictionControllerTest.php
+++ b/tests/Feature/FanfictionControllerTest.php
@@ -180,6 +180,119 @@ class FanfictionControllerTest extends TestCase
         ]);
     }
 
+    public function test_author_can_view_own_rewarded_fanfiction_without_purchase(): void
+    {
+        $fanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+            'title' => 'Eigene verriegelte Geschichte',
+        ]);
+        $this->createRewardForFanfiction($fanfiction, 25);
+
+        $response = $this->actingAs($this->member)
+            ->get(route('fanfiction.show', $fanfiction));
+
+        $response->assertOk();
+        $response->assertSee('Eigener Beitrag');
+        $response->assertDontSee('Diese Geschichte ist gesperrt');
+    }
+
+    public function test_creator_without_linked_author_must_still_unlock_rewarded_fanfiction(): void
+    {
+        $fanfiction = Fanfiction::factory()->published()->externalAuthor()->create([
+            'team_id' => $this->memberTeam->id,
+            'created_by' => $this->member->id,
+            'title' => 'Nicht technisch verknüpfte Geschichte',
+        ]);
+        $this->createRewardForFanfiction($fanfiction, 25);
+
+        $response = $this->actingAs($this->member)
+            ->get(route('fanfiction.show', $fanfiction));
+
+        $response->assertOk();
+        $response->assertSee('Diese Geschichte ist gesperrt');
+        $response->assertDontSee('Eigener Beitrag');
+    }
+
+    public function test_fanfiction_index_refunds_existing_self_purchases_automatically(): void
+    {
+        $this->member->incrementTeamPoints(40);
+
+        $firstFanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+            'title' => 'Erste eigene Geschichte',
+        ]);
+        $secondFanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+            'title' => 'Zweite eigene Geschichte',
+        ]);
+
+        $firstReward = $this->createRewardForFanfiction($firstFanfiction, 5);
+        $secondReward = $this->createRewardForFanfiction($secondFanfiction, 7);
+
+        $firstPurchase = RewardPurchase::create([
+            'user_id' => $this->member->id,
+            'reward_id' => $firstReward->id,
+            'wallet_team_id' => $this->memberTeam->id,
+            'cost_baxx' => 5,
+            'purchased_at' => now(),
+        ]);
+        $secondPurchase = RewardPurchase::create([
+            'user_id' => $this->member->id,
+            'reward_id' => $secondReward->id,
+            'wallet_team_id' => $this->memberTeam->id,
+            'cost_baxx' => 7,
+            'purchased_at' => now(),
+        ]);
+
+        $response = $this->actingAs($this->member)
+            ->get(route('fanfiction.index'));
+
+        $response->assertOk();
+        $response->assertSee('2 frühere Eigenkäufe deiner Fanfiction wurden automatisch erstattet.');
+        $response->assertSee('40 Baxx verfügbar');
+        $response->assertSee('Eigener Beitrag');
+
+        $this->assertNotNull($firstPurchase->fresh()->refunded_at);
+        $this->assertNotNull($secondPurchase->fresh()->refunded_at);
+        $this->assertNull($firstPurchase->fresh()->refunded_by);
+        $this->assertNull($secondPurchase->fresh()->refunded_by);
+    }
+
+    public function test_purchase_route_does_not_charge_for_own_fanfiction(): void
+    {
+        $fanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+        ]);
+        $reward = $this->createRewardForFanfiction($fanfiction, 9);
+
+        $purchase = RewardPurchase::create([
+            'user_id' => $this->member->id,
+            'reward_id' => $reward->id,
+            'wallet_team_id' => $this->memberTeam->id,
+            'cost_baxx' => 9,
+            'purchased_at' => now(),
+        ]);
+
+        $response = $this->actingAs($this->member)
+            ->post(route('fanfiction.purchase', $fanfiction));
+
+        $response->assertRedirect(route('fanfiction.show', $fanfiction));
+        $response->assertSessionHas('info', 'Deine eigene Fanfiction ist bereits freigeschaltet. Frühere Eigenkäufe wurden automatisch erstattet.');
+
+        $purchase->refresh();
+        $this->assertNotNull($purchase->refunded_at);
+        $this->assertNull($purchase->refunded_by);
+        $this->assertSame(1, RewardPurchase::where('user_id', $this->member->id)->count());
+    }
+
     public function test_fanfiction_index_shows_wallet_warning_for_ambiguous_legacy_purchase(): void
     {
         $reward = Reward::factory()->create(['cost_baxx' => 5, 'slug' => 'fanfiction-legacy-warning']);

--- a/tests/Feature/FanfictionControllerTest.php
+++ b/tests/Feature/FanfictionControllerTest.php
@@ -264,6 +264,40 @@ class FanfictionControllerTest extends TestCase
         $this->assertNull($secondPurchase->fresh()->refunded_by);
     }
 
+    public function test_fanfiction_index_refunds_self_purchase_for_soft_deleted_own_fanfiction(): void
+    {
+        $this->member->incrementTeamPoints(10);
+
+        $fanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+            'title' => 'Gelöschte eigene Geschichte',
+        ]);
+        $reward = $this->createRewardForFanfiction($fanfiction, 5);
+
+        $purchase = RewardPurchase::create([
+            'user_id' => $this->member->id,
+            'reward_id' => $reward->id,
+            'wallet_team_id' => $this->memberTeam->id,
+            'cost_baxx' => 5,
+            'purchased_at' => now(),
+        ]);
+
+        $fanfiction->delete();
+
+        $response = $this->actingAs($this->member)
+            ->get(route('fanfiction.index'));
+
+        $response->assertOk();
+        $response->assertSee('Ein früherer Eigenkauf deiner Fanfiction wurde automatisch erstattet.');
+        $response->assertSee('10 Baxx verfügbar');
+
+        $purchase->refresh();
+        $this->assertNotNull($purchase->refunded_at);
+        $this->assertNull($purchase->refunded_by);
+    }
+
     public function test_purchase_route_does_not_charge_for_own_fanfiction(): void
     {
         $fanfiction = Fanfiction::factory()->published()->create([

--- a/tests/Feature/FanfictionControllerTest.php
+++ b/tests/Feature/FanfictionControllerTest.php
@@ -198,6 +198,38 @@ class FanfictionControllerTest extends TestCase
         $response->assertDontSee('Diese Geschichte ist gesperrt');
     }
 
+    public function test_show_reloads_wallet_state_after_auto_refund_for_own_fanfiction(): void
+    {
+        $this->member->incrementTeamPoints(10);
+
+        $fanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+            'title' => 'Eigene Geschichte mit Erstattung in Detailansicht',
+        ]);
+        $reward = $this->createRewardForFanfiction($fanfiction, 5);
+        $purchase = RewardPurchase::create([
+            'user_id' => $this->member->id,
+            'reward_id' => $reward->id,
+            'wallet_team_id' => $this->memberTeam->id,
+            'cost_baxx' => 5,
+            'purchased_at' => now(),
+        ]);
+
+        $response = $this->actingAs($this->member)
+            ->get(route('fanfiction.show', $fanfiction));
+
+        $response->assertOk();
+        $response->assertSee('Ein früherer Eigenkauf deiner Fanfiction wurde automatisch erstattet.');
+        $response->assertViewHas('autoRefundedPurchases', 1);
+        $response->assertViewHas('availableBaxx', 10);
+
+        $purchase->refresh();
+        $this->assertNotNull($purchase->refunded_at);
+        $this->assertNull($purchase->refunded_by);
+    }
+
     public function test_creator_without_linked_author_must_still_unlock_rewarded_fanfiction(): void
     {
         $fanfiction = Fanfiction::factory()->published()->externalAuthor()->create([

--- a/tests/Feature/FanfictionControllerTest.php
+++ b/tests/Feature/FanfictionControllerTest.php
@@ -328,6 +328,8 @@ class FanfictionControllerTest extends TestCase
 
         $this->assertNotNull($firstPurchase->fresh()->refunded_at);
         $this->assertNotNull($secondPurchase->fresh()->refunded_at);
+        $this->assertTrue($firstPurchase->fresh()->updated_at?->equalTo($firstPurchase->fresh()->refunded_at));
+        $this->assertTrue($secondPurchase->fresh()->updated_at?->equalTo($secondPurchase->fresh()->refunded_at));
         $this->assertNull($firstPurchase->fresh()->refunded_by);
         $this->assertNull($secondPurchase->fresh()->refunded_by);
     }

--- a/tests/Feature/FanfictionControllerTest.php
+++ b/tests/Feature/FanfictionControllerTest.php
@@ -215,6 +215,42 @@ class FanfictionControllerTest extends TestCase
         $response->assertDontSee('Eigener Beitrag');
     }
 
+    public function test_showing_foreign_fanfiction_does_not_refund_unrelated_own_purchases(): void
+    {
+        $ownFanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+            'title' => 'Eigene Geschichte mit Alt-Kauf',
+        ]);
+        $ownReward = $this->createRewardForFanfiction($ownFanfiction, 5);
+        $purchase = RewardPurchase::create([
+            'user_id' => $this->member->id,
+            'reward_id' => $ownReward->id,
+            'wallet_team_id' => $this->memberTeam->id,
+            'cost_baxx' => 5,
+            'purchased_at' => now(),
+        ]);
+
+        $otherAuthor = User::factory()->create();
+        $foreignFanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $otherAuthor->id,
+            'created_by' => $otherAuthor->id,
+            'title' => 'Fremde Geschichte',
+        ]);
+        $this->createRewardForFanfiction($foreignFanfiction, 5);
+
+        $response = $this->actingAs($this->member)
+            ->get(route('fanfiction.show', $foreignFanfiction));
+
+        $response->assertOk();
+        $response->assertDontSee('Ein früherer Eigenkauf deiner Fanfiction wurde automatisch erstattet.');
+
+        $purchase->refresh();
+        $this->assertNull($purchase->refunded_at);
+    }
+
     public function test_fanfiction_index_refunds_existing_self_purchases_automatically(): void
     {
         $this->member->incrementTeamPoints(40);
@@ -325,6 +361,50 @@ class FanfictionControllerTest extends TestCase
         $this->assertNotNull($purchase->refunded_at);
         $this->assertNull($purchase->refunded_by);
         $this->assertSame(1, RewardPurchase::where('user_id', $this->member->id)->count());
+    }
+
+    public function test_purchasing_foreign_fanfiction_does_not_refund_unrelated_own_purchases(): void
+    {
+        $this->member->incrementTeamPoints(20);
+
+        $ownFanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+            'title' => 'Eigene Geschichte mit Alt-Kauf',
+        ]);
+        $ownReward = $this->createRewardForFanfiction($ownFanfiction, 5);
+        $ownPurchase = RewardPurchase::create([
+            'user_id' => $this->member->id,
+            'reward_id' => $ownReward->id,
+            'wallet_team_id' => $this->memberTeam->id,
+            'cost_baxx' => 5,
+            'purchased_at' => now(),
+        ]);
+
+        $otherAuthor = User::factory()->create();
+        $foreignFanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $otherAuthor->id,
+            'created_by' => $otherAuthor->id,
+            'title' => 'Fremde Kaufgeschichte',
+        ]);
+        $foreignReward = $this->createRewardForFanfiction($foreignFanfiction, 5);
+
+        $response = $this->actingAs($this->member)
+            ->post(route('fanfiction.purchase', $foreignFanfiction));
+
+        $response->assertRedirect(route('fanfiction.show', $foreignFanfiction));
+        $response->assertSessionHas('success');
+
+        $ownPurchase->refresh();
+        $this->assertNull($ownPurchase->refunded_at);
+        $this->assertDatabaseHas('reward_purchases', [
+            'user_id' => $this->member->id,
+            'reward_id' => $foreignReward->id,
+            'wallet_team_id' => $this->memberTeam->id,
+            'cost_baxx' => 5,
+        ]);
     }
 
     public function test_fanfiction_index_shows_wallet_warning_for_ambiguous_legacy_purchase(): void

--- a/tests/Feature/KompendiumControllerTest.php
+++ b/tests/Feature/KompendiumControllerTest.php
@@ -50,6 +50,28 @@ class KompendiumControllerTest extends TestCase
         ]);
     }
 
+    private function purchaseLegacyKompendiumForUser(User $user): void
+    {
+        $reward = Reward::updateOrCreate(
+            ['slug' => 'kompendium-suche'],
+            [
+                'title' => 'Kompendium-Suche',
+                'description' => 'Legacy-Zugang zur Kompendium-Suche.',
+                'category' => 'Kompendium',
+                'cost_baxx' => 100,
+                'is_active' => true,
+                'sort_order' => 0,
+            ]
+        );
+
+        RewardPurchase::create([
+            'user_id' => $user->id,
+            'reward_id' => $reward->id,
+            'cost_baxx' => $reward->cost_baxx,
+            'purchased_at' => now(),
+        ]);
+    }
+
     public function test_index_hides_search_when_reward_not_purchased(): void
     {
         $user = $this->actingMemberWithPoints(50);
@@ -64,6 +86,17 @@ class KompendiumControllerTest extends TestCase
     {
         $user = $this->actingMemberWithPoints(120);
         $this->purchaseKompendiumForUser($user);
+
+        $response = $this->get('/kompendium');
+
+        $response->assertOk();
+        $response->assertViewHas('showSearch', true);
+    }
+
+    public function test_index_shows_search_for_legacy_kompendium_purchase(): void
+    {
+        $user = $this->actingMemberWithPoints(120);
+        $this->purchaseLegacyKompendiumForUser($user);
 
         $response = $this->get('/kompendium');
 
@@ -181,6 +214,7 @@ class KompendiumControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertViewHas('showSearch', false);
+        $response->assertSee('Belohnungen einlösen');
     }
 
     public function test_user_with_purchased_reward_but_no_ag_can_still_search(): void

--- a/tests/Feature/MaddraxiversumControllerTest.php
+++ b/tests/Feature/MaddraxiversumControllerTest.php
@@ -81,6 +81,7 @@ class MaddraxiversumControllerTest extends TestCase
 
         $response->assertOk();
         $response->assertViewHas('showMap', false);
+        $response->assertSee('Belohnungen einlösen');
     }
 
     public function test_get_cities_returns_api_response(): void

--- a/tests/Feature/MitgliederKarteFeatureTest.php
+++ b/tests/Feature/MitgliederKarteFeatureTest.php
@@ -25,6 +25,7 @@ class MitgliederKarteFeatureTest extends TestCase
         $response->assertOk();
         $response->assertViewIs('mitglieder.karte-locked');
         $response->assertSee('Karte noch nicht verfügbar');
+        $response->assertSee('Zu Baxx verdienen');
     }
 
     public function test_coordinates_are_cached(): void

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -38,6 +38,8 @@ class NavigationMenuTest extends TestCase
         $member = $this->createUserWithRole(Role::Mitglied);
 
         $response = $this->actingAs($member)->get(route('dashboard'));
+        $crawler = new Crawler($response->getContent());
+        $navigationText = preg_replace('/\s+/u', ' ', $crawler->filter('nav[aria-label="Hauptnavigation"]')->text());
 
         $response->assertOk();
         $response->assertSeeText('Dashboard');
@@ -46,6 +48,10 @@ class NavigationMenuTest extends TestCase
         $response->assertSeeText('Veranstaltungen');
         $response->assertSeeText('Verein');
         $response->assertSeeText('Baxx');
+        $this->assertIsString($navigationText);
+        $this->assertStringContainsString('Baxx verdienen', $navigationText);
+        $this->assertStringContainsString('Belohnungen einlösen', $navigationText);
+        $this->assertStringNotContainsString('Challenges', $navigationText);
         $response->assertDontSeeText('Vorstand');
         $response->assertDontSeeText('Admin');
     }
@@ -105,6 +111,19 @@ class NavigationMenuTest extends TestCase
         $response = $this->actingAs($user)->get('/');
 
         $response->assertSee(route('termine'));
+    }
+
+    public function test_authenticated_navigation_uses_adaptive_desktop_dropdown_widths(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertOk();
+        $response->assertSee('data-testid="desktop-nav-dropdown-panel"', false);
+        $response->assertSee('min-w-[14rem]', false);
+        $response->assertSee('max-w-[min(24rem,calc(100vw-2rem))]', false);
+        $response->assertSee('whitespace-nowrap', false);
     }
 
     public function test_authenticated_users_see_satzung_between_protokolle_and_kassenstand(): void

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -120,7 +120,8 @@ class NavigationMenuTest extends TestCase
         $response = $this->actingAs($user)->get('/');
 
         $response->assertOk();
-        $response->assertSee('data-testid="desktop-nav-dropdown-panel"', false);
+        $response->assertSee('data-testid="desktop-nav-dropdown-item"', false);
+        $response->assertDontSee('data-testid="desktop-nav-dropdown-panel"', false);
         $response->assertSee('min-w-[14rem]', false);
         $response->assertSee('max-w-[min(24rem,calc(100vw-2rem))]', false);
         $response->assertSee('whitespace-nowrap', false);

--- a/tests/Feature/RepairLegacyRewardWalletsCommandTest.php
+++ b/tests/Feature/RepairLegacyRewardWalletsCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Models\Reward;
+use App\Models\RewardPurchase;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RepairLegacyRewardWalletsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_backfills_safe_legacy_purchases_with_apply(): void
+    {
+        $membersTeam = Team::membersTeam();
+
+        $this->assertNotNull($membersTeam);
+
+        $user = User::factory()->create();
+        $user->teams()->attach($membersTeam, ['role' => Role::Mitglied->value]);
+        $user->switchTeam($membersTeam);
+
+        $reward = Reward::factory()->create(['slug' => 'safe-legacy-repair']);
+        $purchase = RewardPurchase::create([
+            'user_id' => $user->id,
+            'reward_id' => $reward->id,
+            'wallet_team_id' => null,
+            'cost_baxx' => 5,
+            'purchased_at' => now(),
+        ]);
+
+        $this->artisan('rewards:repair-legacy-wallets', ['--apply' => true])
+            ->assertExitCode(0);
+
+        $purchase->refresh();
+
+        $this->assertSame($membersTeam->id, $purchase->wallet_team_id);
+        $this->assertNotNull($purchase->updated_at);
+    }
+
+    public function test_command_can_backfill_selected_ambiguous_user_after_manual_review(): void
+    {
+        $membersTeam = Team::membersTeam();
+
+        $this->assertNotNull($membersTeam);
+
+        $otherTeam = Team::factory()->create([
+            'personal_team' => false,
+            'name' => 'AG Legacy',
+        ]);
+
+        $user = User::factory()->create();
+        $user->teams()->attach($membersTeam, ['role' => Role::Mitglied->value]);
+        $user->teams()->attach($otherTeam, ['role' => Role::Mitglied->value]);
+        $user->switchTeam($membersTeam);
+
+        $reward = Reward::factory()->create(['slug' => 'ambiguous-legacy-repair']);
+        $purchase = RewardPurchase::create([
+            'user_id' => $user->id,
+            'reward_id' => $reward->id,
+            'wallet_team_id' => null,
+            'cost_baxx' => 5,
+            'purchased_at' => now(),
+        ]);
+
+        $this->artisan('rewards:repair-legacy-wallets', ['--apply' => true])
+            ->assertExitCode(0);
+
+        $purchase->refresh();
+        $this->assertNull($purchase->wallet_team_id);
+
+        $this->artisan('rewards:repair-legacy-wallets', ['--user' => [$user->id], '--apply' => true])
+            ->assertExitCode(0);
+
+        $purchase->refresh();
+        $this->assertSame($membersTeam->id, $purchase->wallet_team_id);
+        $this->assertNotNull($purchase->updated_at);
+    }
+}

--- a/tests/Feature/RezensionLivewireTest.php
+++ b/tests/Feature/RezensionLivewireTest.php
@@ -945,4 +945,45 @@ class RezensionLivewireTest extends TestCase
             file_put_contents($path, $original);
         }
     }
+
+    public function test_reviews_index_shows_explicit_review_write_action_for_books_without_review(): void
+    {
+        Book::create([
+            'roman_number' => 1,
+            'title' => 'Roman ohne Rezension',
+            'author' => 'Autor A',
+        ]);
+
+        $user = $this->actingMember();
+
+        $response = $this->actingAs($user)->get('/rezensionen');
+
+        $response->assertOk();
+        $response->assertSee('Rezension schreiben');
+        $response->assertSee('aria-label="Rezension schreiben"', false);
+    }
+
+    public function test_reviews_index_marks_reviewed_books_as_vorhanden(): void
+    {
+        $book = Book::create([
+            'roman_number' => 1,
+            'title' => 'Roman mit Rezension',
+            'author' => 'Autor B',
+        ]);
+        $user = $this->actingMember();
+
+        Review::create([
+            'team_id' => Team::membersTeam()->id,
+            'book_id' => $book->id,
+            'user_id' => $user->id,
+            'title' => 'Schon bewertet',
+            'content' => str_repeat('A', 140),
+        ]);
+
+        $response = $this->actingAs($user)->get('/rezensionen');
+
+        $response->assertOk();
+        $response->assertSee('Roman mit Rezension');
+        $response->assertSee('Vorhanden');
+    }
 }

--- a/tests/Unit/RewardServiceTest.php
+++ b/tests/Unit/RewardServiceTest.php
@@ -293,6 +293,26 @@ class RewardServiceTest extends TestCase
         $this->assertTrue($this->service->hasUnlockedReward($user, 'test-feature'));
     }
 
+    public function test_has_unlocked_reward_accepts_legacy_kompendium_slug(): void
+    {
+        $user = $this->actingMemberWithPoints(120);
+        $legacyReward = Reward::updateOrCreate(
+            ['slug' => 'kompendium-suche'],
+            [
+                'title' => 'Kompendium-Suche',
+                'description' => 'Legacy-Zugang zur Kompendium-Suche.',
+                'category' => 'Kompendium',
+                'cost_baxx' => 100,
+                'is_active' => true,
+                'sort_order' => 0,
+            ]
+        );
+
+        $this->service->purchaseReward($user, $legacyReward);
+
+        $this->assertTrue($this->service->hasUnlockedReward($user, 'kompendium'));
+    }
+
     public function test_has_unlocked_reward_returns_false_for_not_purchased(): void
     {
         $user = $this->actingMemberWithPoints(10);

--- a/tests/Unit/RewardServiceTest.php
+++ b/tests/Unit/RewardServiceTest.php
@@ -31,13 +31,16 @@ class RewardServiceTest extends TestCase
     {
         $user = $this->actingMemberWithPoints(10);
         $reward = Reward::factory()->create(['cost_baxx' => 5]);
+        $membersTeam = Team::membersTeam();
+
+        $this->assertNotNull($membersTeam);
 
         $purchase = $this->service->purchaseReward($user, $reward);
 
         $this->assertNotNull($purchase);
         $this->assertEquals($user->id, $purchase->user_id);
         $this->assertEquals($reward->id, $purchase->reward_id);
-        $this->assertEquals(Team::membersTeam()?->id, $purchase->wallet_team_id);
+        $this->assertEquals($membersTeam->id, $purchase->wallet_team_id);
         $this->assertEquals(5, $purchase->cost_baxx);
         $this->assertNotNull($purchase->purchased_at);
         $this->assertNull($purchase->refunded_at);

--- a/tests/e2e/mitglieder-karte.spec.js
+++ b/tests/e2e/mitglieder-karte.spec.js
@@ -31,6 +31,6 @@ test.describe('Mitgliederkarte', () => {
 
         await expect(page.locator('[data-testid="page-title"]')).toContainText('Mitgliederkarte');
         await expect(page.getByText('Karte noch nicht verfügbar')).toBeVisible();
-        await expect(page.getByRole('link', { name: 'Zu den verfügbaren Challenges' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Zu Baxx verdienen' })).toBeVisible();
     });
 });


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to reward handling, user access to fanfictions, and administrative tools for managing legacy reward data. The most significant changes include the introduction of a new service to unify fanfiction access logic, automatic refunds for users who purchased access to their own fanfictions, improvements to reward unlocking logic, and the addition of a console command for repairing legacy reward wallet assignments.

**Fanfiction Access and Reward Logic Improvements**

* Introduced a new `FanfictionAccessService` that centralizes logic for determining fanfiction access, checking if a user is the author, handling unlock status, and refunding purchases for a user's own contributions. Controllers now use this service instead of duplicating logic. [[1]](diffhunk://#diff-a2da87bb6e44e5312b1dc178fef6b688cbf89d0bd4101a818547a05aac4b461bR1-R68) [[2]](diffhunk://#diff-80ad6d6cad1aedf058b4eab6ff5ac071908ff869e1a8d7b52462d7619af154e5L11-R11) [[3]](diffhunk://#diff-80ad6d6cad1aedf058b4eab6ff5ac071908ff869e1a8d7b52462d7619af154e5L23-R23) [[4]](diffhunk://#diff-80ad6d6cad1aedf058b4eab6ff5ac071908ff869e1a8d7b52462d7619af154e5R50-R57) [[5]](diffhunk://#diff-306ee5235235c51af266eb19efe360ad5fe9c5e387c5b0d36a78c1da8f207fa4R10) [[6]](diffhunk://#diff-306ee5235235c51af266eb19efe360ad5fe9c5e387c5b0d36a78c1da8f207fa4R26) [[7]](diffhunk://#diff-306ee5235235c51af266eb19efe360ad5fe9c5e387c5b0d36a78c1da8f207fa4R70-R91) [[8]](diffhunk://#diff-306ee5235235c51af266eb19efe360ad5fe9c5e387c5b0d36a78c1da8f207fa4R116-R130) [[9]](diffhunk://#diff-306ee5235235c51af266eb19efe360ad5fe9c5e387c5b0d36a78c1da8f207fa4R160-R168)

* Users who previously purchased access to their own fanfictions are now automatically refunded, and this is reflected in both the index and show views, as well as during purchase attempts. [[1]](diffhunk://#diff-306ee5235235c51af266eb19efe360ad5fe9c5e387c5b0d36a78c1da8f207fa4R70-R91) [[2]](diffhunk://#diff-306ee5235235c51af266eb19efe360ad5fe9c5e387c5b0d36a78c1da8f207fa4R116-R130) [[3]](diffhunk://#diff-306ee5235235c51af266eb19efe360ad5fe9c5e387c5b0d36a78c1da8f207fa4R160-R168) [[4]](diffhunk://#diff-80ad6d6cad1aedf058b4eab6ff5ac071908ff869e1a8d7b52462d7619af154e5R50-R57)

**Reward Unlocking and Display Enhancements**

* Improved reward unlocking logic by adding support for slug aliases, ensuring that legacy and current reward slugs are correctly recognized as valid unlocks. [[1]](diffhunk://#diff-c987467c80af5176431d99ccdeb4ace15ffa822356aa0ecd9bec291cf54de6c1R18-R26) [[2]](diffhunk://#diff-c987467c80af5176431d99ccdeb4ace15ffa822356aa0ecd9bec291cf54de6c1L170-R188)

* Updated the reward listing in `BelohnungenIndex` to use reward slugs (with alias support) instead of reward IDs for determining unlocked rewards, improving consistency and compatibility with legacy data. [[1]](diffhunk://#diff-4be67e7a8c9d48885c1d556e9d90d6a213faacfebcca3f713610b6dffc5d61f0L6) [[2]](diffhunk://#diff-4be67e7a8c9d48885c1d556e9d90d6a213faacfebcca3f713610b6dffc5d61f0L68-R68) [[3]](diffhunk://#diff-4be67e7a8c9d48885c1d556e9d90d6a213faacfebcca3f713610b6dffc5d61f0L80-R78)

**Administrative Tools**

* Added a new Artisan command, `RepairLegacyRewardWallets`, which analyzes and (optionally) repairs legacy reward purchases missing wallet team assignments. The command supports both safe automatic repairs and targeted manual repairs for ambiguous cases. [[1]](diffhunk://#diff-a766befc9bd0844719cb823f75e966bfea6d59275853934a0f7b5133016e399eR1-R233) [[2]](diffhunk://#diff-3e91b9df26f6ed49ead694c97ddcddf5f3c3e878390064d0b8849f22d54e5603R6) [[3]](diffhunk://#diff-3e91b9df26f6ed49ead694c97ddcddf5f3c3e878390064d0b8849f22d54e5603R19)

**User Experience Improvements**

* Updated quick action title in the dashboard from "Challenges öffnen" to "Baxx verdienen" for clarity.

* Improved error messaging for locked downloads, making instructions clearer for users.