### PR TITLE
Feature: Maddraxiversum reward and special offer

### DIFF
--- a/app/Http/Controllers/MaddraxiversumController.php
+++ b/app/Http/Controllers/MaddraxiversumController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Enums\Role;
-use App\Models\BaxxEarningRule;
 use App\Models\Mission;
 use App\Models\User;
+use App\Services\MaddraxiversumBaxxService;
 use App\Services\TeamPointService;
 use Carbon\Carbon;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -16,7 +16,10 @@ use Illuminate\View\View;
 
 class MaddraxiversumController extends Controller
 {
-    public function __construct(private TeamPointService $teamPointService) {}
+    public function __construct(
+        private TeamPointService $teamPointService,
+        private MaddraxiversumBaxxService $maddraxiversumBaxxService,
+    ) {}
 
     /**
      * Zeigt die Maddraxiversum-Seite mit der Karte an,
@@ -41,6 +44,7 @@ class MaddraxiversumController extends Controller
         return view('maddraxiversum.index', [
             'showMap' => $showMap,
             'userPoints' => $userPoints,
+            'rewardConfiguration' => $this->maddraxiversumBaxxService->getMemberConfiguration(),
             'tileUrl' => 'https://mapdraxv2.maddraxikon.com/v2/{z}/{x}/{y}.png', // URL-Muster für die Tiles
         ]);
     }
@@ -97,72 +101,42 @@ class MaddraxiversumController extends Controller
     public function checkMissionStatus(Request $request)
     {
         try {
+            /** @var User $user */
             $user = Auth::user();
-            \Log::info('Status-Check für Benutzer: '.$user->id);
 
             $mission = Mission::where('user_id', $user->id)
                 ->where('completed', false)
                 ->first();
 
             if (! $mission) {
-                \Log::info('Keine aktive Mission gefunden für Benutzer: '.$user->id);
-
                 return response()->json(['status' => 'none']);
             }
 
-            \Log::info('Aktive Mission gefunden:', [
-                'mission_id' => $mission->id,
-                'started_at' => $mission->started_at,
-                'arrival_at' => $mission->arrival_at,
-                'mission_ends_at' => $mission->mission_ends_at,
-                'completed' => $mission->completed,
-                'travel_duration' => $mission->travel_duration,
-                'mission_duration' => $mission->mission_duration,
-            ]);
-
             $now = Carbon::now();
-            \Log::info('Aktuelle Zeit: '.$now);
 
             // Berechne die Gesamtdauer der Mission
             $totalDuration = $mission->travel_duration + $mission->mission_duration + $mission->travel_duration;
             $expectedEndTime = $mission->started_at->copy()->addSeconds($totalDuration);
 
-            \Log::info('Berechnete Zeiten:', [
-                'total_duration' => $totalDuration,
-                'expected_end_time' => $expectedEndTime,
-                'time_diff' => $now->diffInSeconds($expectedEndTime),
-            ]);
-
             if ($now->greaterThanOrEqualTo($expectedEndTime)) {
-                \Log::info('Mission ist beendet, markiere als abgeschlossen');
-                // Mission erfolgreich abgeschlossen
                 $mission->completed = true;
                 $mission->save();
 
-                // Punkte vergeben
-                if ($user->currentTeam) {
-                    $defaultPoints = BaxxEarningRule::getPointsFor('maddraxiversum_mission');
-                    $earnedPoints = $mission->reward ?: $defaultPoints;
-                    if ($earnedPoints > 0) {
-                        $user->incrementTeamPoints($earnedPoints);
-                    }
-                    \Log::info('Punkte vergeben:', [
-                        'user_id' => $user->id,
-                        'team_id' => $user->currentTeam->id,
-                        'points' => $earnedPoints,
-                    ]);
-                } else {
-                    \Log::warning('Kein Team gefunden für Benutzer: '.$user->id);
-                }
+                $completedMissionCount = Mission::query()
+                    ->where('user_id', $user->id)
+                    ->where('completed', true)
+                    ->count();
+
+                $this->maddraxiversumBaxxService->awardPointsForMission(
+                    $user,
+                    $mission,
+                    $completedMissionCount,
+                );
 
                 return response()->json(['status' => 'completed']);
             } elseif ($now->greaterThanOrEqualTo($mission->arrival_at)) {
-                \Log::info('Mission läuft noch');
-
                 return response()->json(['status' => 'in_mission']);
             } else {
-                \Log::info('Mission ist noch unterwegs');
-
                 return response()->json(['status' => 'traveling']);
             }
         } catch (\Exception $e) {
@@ -178,30 +152,16 @@ class MaddraxiversumController extends Controller
     public function getMissionStatus(Request $request)
     {
         try {
+            /** @var User $user */
             $user = Auth::user();
-            \Log::info('Status-Abfrage für Benutzer: '.$user->id);
 
             $mission = Mission::where('user_id', $user->id)
                 ->where('completed', false)
                 ->first();
 
             if (! $mission) {
-                \Log::info('Keine aktive Mission gefunden für Benutzer: '.$user->id);
-
                 return response()->json(['status' => 'none']);
             }
-
-            \Log::info('Aktive Mission gefunden:', [
-                'mission_id' => $mission->id,
-                'started_at' => $mission->started_at,
-                'arrival_at' => $mission->arrival_at,
-                'mission_ends_at' => $mission->mission_ends_at,
-                'completed' => $mission->completed,
-                'travel_duration' => $mission->travel_duration,
-                'mission_duration' => $mission->mission_duration,
-                'origin' => $mission->origin,
-                'destination' => $mission->destination,
-            ]);
 
             $now = Carbon::now();
             $totalDuration = $mission->travel_duration + $mission->mission_duration + $mission->travel_duration;

--- a/app/Livewire/BelohnungenAdmin.php
+++ b/app/Livewire/BelohnungenAdmin.php
@@ -5,10 +5,12 @@ namespace App\Livewire;
 use Carbon\Carbon;
 use App\Models\BaxxEarningRule;
 use App\Models\Download;
+use App\Models\MaddraxiversumBaxxSpecialOffer;
 use App\Models\RomantauschBaxxSpecialOffer;
 use App\Models\Reward;
 use App\Models\RewardPurchase;
 use App\Models\ReviewBaxxSpecialOffer;
+use App\Services\MaddraxiversumBaxxService;
 use App\Services\Romantausch\RomantauschBaxxService;
 use App\Services\ReviewBaxxService;
 use App\Services\RewardService;
@@ -80,6 +82,19 @@ class BelohnungenAdmin extends Component
 
     public bool $reviewSpecialOfferIsActive = true;
 
+    // --- Maddraxiversum special offers ---
+    public bool $showMaddraxiversumSpecialOfferModal = false;
+
+    public ?int $editingMaddraxiversumSpecialOfferId = null;
+
+    public int $maddraxiversumSpecialOfferPoints = 1;
+
+    public int $maddraxiversumSpecialOfferEveryCount = 1;
+
+    public string $maddraxiversumSpecialOfferEndsAt = '';
+
+    public bool $maddraxiversumSpecialOfferIsActive = true;
+
     // --- Romantausch special offers ---
     public bool $showRomantauschSpecialOfferModal = false;
 
@@ -150,6 +165,27 @@ class BelohnungenAdmin extends Component
     public function reviewRewardConfiguration(): array
     {
         $service = app(ReviewBaxxService::class);
+
+        return [
+            'base_rule' => $service->getBaseRuleData(),
+            'effective_rule' => $service->getEffectiveRule(),
+            'prominent_special_offer' => $service->getProminentSpecialOffer(),
+        ];
+    }
+
+    #[Computed]
+    public function maddraxiversumSpecialOffers(): \Illuminate\Database\Eloquent\Collection
+    {
+        return MaddraxiversumBaxxSpecialOffer::query()
+            ->orderByDesc('is_active')
+            ->orderByDesc('ends_at')
+            ->get();
+    }
+
+    #[Computed]
+    public function maddraxiversumRewardConfiguration(): array
+    {
+        $service = app(MaddraxiversumBaxxService::class);
 
         return [
             'base_rule' => $service->getBaseRuleData(),
@@ -384,7 +420,12 @@ class BelohnungenAdmin extends Component
         $this->showRuleModal = false;
         $this->editingRuleId = null;
         $this->ruleEveryCount = 1;
-        unset($this->earningRules, $this->reviewRewardConfiguration);
+        unset(
+            $this->earningRules,
+            $this->reviewRewardConfiguration,
+            $this->maddraxiversumRewardConfiguration,
+            $this->romantauschRewardConfiguration,
+        );
     }
 
     public function toggleRuleActive(int $ruleId): void
@@ -393,7 +434,12 @@ class BelohnungenAdmin extends Component
         $rule->update(['is_active' => ! $rule->is_active]);
         $status = $rule->is_active ? 'aktiviert' : 'deaktiviert';
         $this->dispatch('toast', type: 'success', title: "Vergaberegel {$status}");
-        unset($this->earningRules, $this->reviewRewardConfiguration);
+        unset(
+            $this->earningRules,
+            $this->reviewRewardConfiguration,
+            $this->maddraxiversumRewardConfiguration,
+            $this->romantauschRewardConfiguration,
+        );
     }
 
     public function openCreateReviewSpecialOffer(): void
@@ -539,6 +585,127 @@ class BelohnungenAdmin extends Component
         $this->reviewSpecialOfferEveryCount = 1;
         $this->reviewSpecialOfferEndsAt = now()->addDay()->format('Y-m-d\TH:i');
         $this->reviewSpecialOfferIsActive = true;
+    }
+
+    public function openCreateMaddraxiversumSpecialOffer(): void
+    {
+        $this->resetMaddraxiversumSpecialOfferForm();
+        $this->showMaddraxiversumSpecialOfferModal = true;
+    }
+
+    public function openEditMaddraxiversumSpecialOffer(int $offerId): void
+    {
+        $offer = MaddraxiversumBaxxSpecialOffer::findOrFail($offerId);
+        $this->editingMaddraxiversumSpecialOfferId = $offer->id;
+        $this->maddraxiversumSpecialOfferPoints = $offer->points;
+        $this->maddraxiversumSpecialOfferEveryCount = $offer->every_count;
+        $this->maddraxiversumSpecialOfferEndsAt = $offer->ends_at->copy()->timezone(config('app.timezone'))->format('Y-m-d\TH:i');
+        $this->maddraxiversumSpecialOfferIsActive = $offer->is_active;
+        $this->showMaddraxiversumSpecialOfferModal = true;
+    }
+
+    public function saveMaddraxiversumSpecialOffer(): void
+    {
+        $this->validate([
+            'maddraxiversumSpecialOfferPoints' => 'required|integer|min:1',
+            'maddraxiversumSpecialOfferEveryCount' => 'required|integer|min:1',
+            'maddraxiversumSpecialOfferEndsAt' => 'required|date',
+        ]);
+
+        $endsAt = Carbon::parse($this->maddraxiversumSpecialOfferEndsAt, config('app.timezone'));
+
+        if ($this->maddraxiversumSpecialOfferIsActive && $endsAt->lte(now())) {
+            throw ValidationException::withMessages([
+                'maddraxiversumSpecialOfferEndsAt' => 'Das Enddatum einer aktiven Sonderaktion muss in der Zukunft liegen.',
+            ]);
+        }
+
+        $data = [
+            'points' => $this->maddraxiversumSpecialOfferPoints,
+            'every_count' => $this->maddraxiversumSpecialOfferEveryCount,
+            'ends_at' => $endsAt,
+            'is_active' => $this->maddraxiversumSpecialOfferIsActive,
+        ];
+
+        DB::transaction(function () use ($data) {
+            app(MaddraxiversumBaxxService::class)->getBaseRule();
+
+            BaxxEarningRule::query()
+                ->where('action_key', 'maddraxiversum_mission')
+                ->lockForUpdate()
+                ->first();
+
+            $hasConflictingOffer = MaddraxiversumBaxxSpecialOffer::query()
+                ->currentlyActive()
+                ->when($this->editingMaddraxiversumSpecialOfferId, fn ($query) => $query->whereKeyNot($this->editingMaddraxiversumSpecialOfferId))
+                ->exists();
+
+            if ($this->maddraxiversumSpecialOfferIsActive && $hasConflictingOffer) {
+                throw ValidationException::withMessages([
+                    'maddraxiversumSpecialOfferIsActive' => 'Es kann immer nur eine aktive Maddraxiversum-Sonderaktion gleichzeitig geben.',
+                ]);
+            }
+
+            if ($this->editingMaddraxiversumSpecialOfferId) {
+                MaddraxiversumBaxxSpecialOffer::findOrFail($this->editingMaddraxiversumSpecialOfferId)->update($data);
+
+                return;
+            }
+
+            MaddraxiversumBaxxSpecialOffer::create($data);
+        });
+
+        $title = $this->editingMaddraxiversumSpecialOfferId
+            ? 'Maddraxiversum-Sonderaktion aktualisiert'
+            : 'Maddraxiversum-Sonderaktion erstellt';
+        $this->dispatch('toast', type: 'success', title: $title);
+
+        $this->showMaddraxiversumSpecialOfferModal = false;
+        $this->resetMaddraxiversumSpecialOfferForm();
+        unset($this->maddraxiversumSpecialOffers, $this->maddraxiversumRewardConfiguration);
+    }
+
+    public function toggleMaddraxiversumSpecialOfferActive(int $offerId): void
+    {
+        $status = DB::transaction(function () use ($offerId) {
+            app(MaddraxiversumBaxxService::class)->getBaseRule();
+
+            BaxxEarningRule::query()
+                ->where('action_key', 'maddraxiversum_mission')
+                ->lockForUpdate()
+                ->first();
+
+            $offer = MaddraxiversumBaxxSpecialOffer::findOrFail($offerId);
+            $nextActiveState = ! $offer->is_active;
+
+            if ($nextActiveState && $offer->ends_at->lte(now())) {
+                throw ValidationException::withMessages([
+                    'maddraxiversumSpecialOfferIsActive' => 'Abgelaufene Sonderaktionen können nicht erneut aktiviert werden.',
+                ]);
+            }
+
+            if ($nextActiveState && MaddraxiversumBaxxSpecialOffer::query()->currentlyActive()->whereKeyNot($offer->id)->exists()) {
+                throw ValidationException::withMessages([
+                    'maddraxiversumSpecialOfferIsActive' => 'Es gibt bereits eine andere aktive Maddraxiversum-Sonderaktion.',
+                ]);
+            }
+
+            $offer->update(['is_active' => $nextActiveState]);
+
+            return $offer->is_active ? 'aktiviert' : 'deaktiviert';
+        });
+
+        $this->dispatch('toast', type: 'success', title: "Maddraxiversum-Sonderaktion {$status}");
+        unset($this->maddraxiversumSpecialOffers, $this->maddraxiversumRewardConfiguration);
+    }
+
+    private function resetMaddraxiversumSpecialOfferForm(): void
+    {
+        $this->editingMaddraxiversumSpecialOfferId = null;
+        $this->maddraxiversumSpecialOfferPoints = 1;
+        $this->maddraxiversumSpecialOfferEveryCount = 1;
+        $this->maddraxiversumSpecialOfferEndsAt = now()->addDay()->format('Y-m-d\TH:i');
+        $this->maddraxiversumSpecialOfferIsActive = true;
     }
 
     public function openCreateRomantauschSpecialOffer(): void

--- a/app/Models/MaddraxiversumBaxxSpecialOffer.php
+++ b/app/Models/MaddraxiversumBaxxSpecialOffer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MaddraxiversumBaxxSpecialOffer extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'points',
+        'every_count',
+        'ends_at',
+        'is_active',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'points' => 'integer',
+            'every_count' => 'integer',
+            'ends_at' => 'datetime',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function scopeCurrentlyActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true)
+            ->where('ends_at', '>', now());
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -146,6 +146,7 @@ class AppServiceProvider extends ServiceProvider
             Blade::component('testing.components.badge', 'badge');
             Blade::component('testing.components.icon', 'icon');
             Blade::component('testing.components.mary-modal', 'mary-modal');
+            Blade::component('testing.components.mary-modal', 'modal');
             Blade::component('testing.components.theme-toggle', 'theme-toggle');
             Blade::component('testing.components.toast', 'toast');
         }

--- a/app/Services/MaddraxiversumBaxxService.php
+++ b/app/Services/MaddraxiversumBaxxService.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\BaxxEarningRule;
+use App\Models\MaddraxiversumBaxxSpecialOffer;
+use App\Models\Mission;
+use App\Models\User;
+use App\Models\UserPoint;
+use Carbon\CarbonInterface;
+
+class MaddraxiversumBaxxService
+{
+    private ?BaxxEarningRule $baseRule = null;
+
+    private bool $activeSpecialOfferLoaded = false;
+
+    private ?MaddraxiversumBaxxSpecialOffer $activeSpecialOffer = null;
+
+    /**
+     * @return array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_mission:float,
+     *     points_per_mission_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }
+     */
+    public function getEffectiveRule(): array
+    {
+        $specialOffer = $this->getActiveSpecialOffer();
+
+        if ($specialOffer) {
+            return $this->makeRuleData(
+                points: $specialOffer->points,
+                everyCount: $specialOffer->every_count,
+                isActive: true,
+                isSpecialOffer: true,
+                endsAt: $specialOffer->ends_at,
+            );
+        }
+
+        $baseRule = $this->getBaseRule();
+
+        return $this->makeRuleData(
+            points: $baseRule->points,
+            everyCount: $baseRule->every_count,
+            isActive: $baseRule->is_active,
+            isSpecialOffer: false,
+            endsAt: null,
+        );
+    }
+
+    /**
+     * @return array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_mission:float,
+     *     points_per_mission_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }
+     */
+    public function getBaseRuleData(): array
+    {
+        $baseRule = $this->getBaseRule();
+
+        return $this->makeRuleData(
+            points: $baseRule->points,
+            everyCount: $baseRule->every_count,
+            isActive: $baseRule->is_active,
+            isSpecialOffer: false,
+            endsAt: null,
+        );
+    }
+
+    /**
+     * @return array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_mission:float,
+     *     points_per_mission_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }|null
+     */
+    public function getProminentSpecialOffer(): ?array
+    {
+        return $this->extractProminentSpecialOffer($this->getEffectiveRule());
+    }
+
+    /**
+     * @return array{
+     *     effective_rule: array{
+     *         points:int,
+     *         every_count:int,
+     *         is_active:bool,
+     *         is_special_offer:bool,
+     *         points_per_mission:float,
+     *         points_per_mission_label:string,
+     *         rule_label:string,
+     *         ends_at:?CarbonInterface,
+     *         ends_at_formatted:?string,
+     *         banner_text:?string,
+     *         banner_end_text:?string
+     *     },
+     *     prominent_special_offer: array{
+     *         points:int,
+     *         every_count:int,
+     *         is_active:bool,
+     *         is_special_offer:bool,
+     *         points_per_mission:float,
+     *         points_per_mission_label:string,
+     *         rule_label:string,
+     *         ends_at:?CarbonInterface,
+     *         ends_at_formatted:?string,
+     *         banner_text:?string,
+     *         banner_end_text:?string
+     *     }|null
+     * }
+     */
+    public function getMemberConfiguration(): array
+    {
+        $effectiveRule = $this->getEffectiveRule();
+
+        return [
+            'effective_rule' => $effectiveRule,
+            'prominent_special_offer' => $this->extractProminentSpecialOffer($effectiveRule),
+        ];
+    }
+
+    public function resolveMissionRewardPoints(?Mission $mission = null, ?int $completedMissionCount = null): int
+    {
+        $missionReward = $mission?->getAttribute('reward');
+
+        if (is_numeric($missionReward) && (int) $missionReward > 0) {
+            return (int) $missionReward;
+        }
+
+        $effectiveRule = $this->getEffectiveRule();
+
+        if (! $effectiveRule['is_active'] || $effectiveRule['points'] <= 0) {
+            return 0;
+        }
+
+        if ($completedMissionCount !== null && ($completedMissionCount <= 0 || $completedMissionCount % $effectiveRule['every_count'] !== 0)) {
+            return 0;
+        }
+
+        return $effectiveRule['points'];
+    }
+
+    public function awardPointsForMission(User $user, ?Mission $mission = null, ?int $completedMissionCount = null, ?CarbonInterface $awardedAt = null): int
+    {
+        $points = $this->resolveMissionRewardPoints($mission, $completedMissionCount);
+        $teamId = $user->currentTeam?->id;
+
+        if ($points <= 0 || ! $teamId) {
+            return 0;
+        }
+
+        $userPoint = new UserPoint([
+            'user_id' => $user->id,
+            'team_id' => $teamId,
+            'points' => $points,
+        ]);
+
+        if ($awardedAt) {
+            $userPoint->created_at = $awardedAt;
+            $userPoint->updated_at = $awardedAt;
+        }
+
+        $userPoint->save();
+
+        return $points;
+    }
+
+    public function getBaseRule(): BaxxEarningRule
+    {
+        if ($this->baseRule) {
+            return $this->baseRule;
+        }
+
+        return $this->baseRule = BaxxEarningRule::query()->firstOrCreate(
+            ['action_key' => 'maddraxiversum_mission'],
+            [
+                'label' => 'Maddraxiversum-Mission',
+                'description' => 'Standard-Baxx für eine abgeschlossene Maddraxiversum-Mission (kann pro Mission überschrieben werden).',
+                'points' => 5,
+                'every_count' => 1,
+                'is_active' => true,
+            ]
+        );
+    }
+
+    public function getActiveSpecialOffer(): ?MaddraxiversumBaxxSpecialOffer
+    {
+        if ($this->activeSpecialOfferLoaded) {
+            return $this->activeSpecialOffer;
+        }
+
+        $this->activeSpecialOfferLoaded = true;
+
+        return $this->activeSpecialOffer = MaddraxiversumBaxxSpecialOffer::query()
+            ->currentlyActive()
+            ->orderByDesc('ends_at')
+            ->first();
+    }
+
+    /**
+     * @param  array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_mission:float,
+     *     points_per_mission_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }  $effectiveRule
+     * @return array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_mission:float,
+     *     points_per_mission_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }|null
+     */
+    private function extractProminentSpecialOffer(array $effectiveRule): ?array
+    {
+        if (! $effectiveRule['is_special_offer']) {
+            return null;
+        }
+
+        return $effectiveRule['points_per_mission'] >= 1 ? $effectiveRule : null;
+    }
+
+    /**
+     * @return array{
+     *     points:int,
+     *     every_count:int,
+     *     is_active:bool,
+     *     is_special_offer:bool,
+     *     points_per_mission:float,
+     *     points_per_mission_label:string,
+     *     rule_label:string,
+     *     ends_at:?CarbonInterface,
+     *     ends_at_formatted:?string,
+     *     banner_text:?string,
+     *     banner_end_text:?string
+     * }
+     */
+    private function makeRuleData(
+        int $points,
+        int $everyCount,
+        bool $isActive,
+        bool $isSpecialOffer,
+        ?CarbonInterface $endsAt,
+    ): array {
+        $everyCount = max(1, $everyCount);
+        $pointsPerMission = $points / $everyCount;
+        $pointsPerMissionLabel = $this->formatNumber($pointsPerMission);
+
+        return [
+            'points' => $points,
+            'every_count' => $everyCount,
+            'is_active' => $isActive,
+            'is_special_offer' => $isSpecialOffer,
+            'points_per_mission' => $pointsPerMission,
+            'points_per_mission_label' => $pointsPerMissionLabel,
+            'rule_label' => $this->formatRuleLabel($points, $everyCount),
+            'ends_at' => $endsAt,
+            'ends_at_formatted' => $endsAt?->copy()->timezone(config('app.timezone'))->format('d.m.Y, H:i'),
+            'banner_text' => $isSpecialOffer
+                ? 'Sonderaktion: Jetzt für einen begrenzten Zeitraum '.$pointsPerMissionLabel.' Baxx pro Mission!'
+                : null,
+            'banner_end_text' => $endsAt
+                ? 'Die Aktion endet am '.$endsAt->copy()->timezone(config('app.timezone'))->format('d.m.Y').' um '.$endsAt->copy()->timezone(config('app.timezone'))->format('H:i').' Uhr.'
+                : null,
+        ];
+    }
+
+    private function formatRuleLabel(int $points, int $everyCount): string
+    {
+        if ($everyCount === 1) {
+            return $points.' Baxx pro Mission';
+        }
+
+        return $points.' Baxx pro '.$everyCount.' Missionen';
+    }
+
+    private function formatNumber(float $value): string
+    {
+        if ((float) (int) $value === $value) {
+            return (string) (int) $value;
+        }
+
+        $formatted = number_format($value, 2, ',', '');
+
+        return rtrim(rtrim($formatted, '0'), ',');
+    }
+}

--- a/database/migrations/2026_05_09_120000_create_maddraxiversum_baxx_special_offers_table.php
+++ b/database/migrations/2026_05_09_120000_create_maddraxiversum_baxx_special_offers_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('maddraxiversum_baxx_special_offers', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('points');
+            $table->unsignedInteger('every_count')->default(1);
+            $table->timestamp('ends_at');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index(['is_active', 'ends_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('maddraxiversum_baxx_special_offers');
+    }
+};

--- a/resources/views/livewire/belohnungen-admin.blade.php
+++ b/resources/views/livewire/belohnungen-admin.blade.php
@@ -114,6 +114,27 @@
                     />
                 </div>
 
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+                    <x-stat
+                        title="Basisregel Maddraxiversum"
+                        :value="$this->maddraxiversumRewardConfiguration['base_rule']['rule_label']"
+                        icon="o-globe-alt"
+                        class="shadow"
+                    />
+                    <x-stat
+                        title="Aktuell wirksam"
+                        :value="$this->maddraxiversumRewardConfiguration['effective_rule']['rule_label']"
+                        icon="o-rocket-launch"
+                        class="shadow"
+                    />
+                    <x-stat
+                        title="Sonderaktion"
+                        :value="$this->maddraxiversumRewardConfiguration['prominent_special_offer'] ? 'Prominent sichtbar' : 'Keine prominente Aktion'"
+                        icon="o-megaphone"
+                        class="shadow"
+                    />
+                </div>
+
                 <x-table :headers="[
                     ['key' => 'action_key', 'label' => 'Aktion'],
                     ['key' => 'label', 'label' => 'Bezeichnung'],
@@ -147,6 +168,58 @@
                                 class="btn-ghost btn-xs"
                                 wire:click="toggleRuleActive({{ $rule->id }})"
                                 tooltip="{{ $rule->is_active ? 'Deaktivieren' : 'Aktivieren' }}"
+                            />
+                        </div>
+                    @endscope
+                </x-table>
+
+                <div class="flex items-center justify-between mt-8 mb-4 gap-4">
+                    <div>
+                        <h3 class="text-lg font-bold text-primary">Maddraxiversum-Sonderaktionen</h3>
+                        <p class="text-sm text-base-content">Zeitlich begrenzte Mission-Boni überschreiben die Basisregel für abgeschlossene Missionen automatisch bis zum Endzeitpunkt.</p>
+                    </div>
+                    <x-button label="Neue Maddraxiversum-Sonderaktion" icon="o-plus" class="btn-primary" wire:click="openCreateMaddraxiversumSpecialOffer" />
+                </div>
+
+                <x-table :headers="[
+                    ['key' => 'rule_pattern', 'label' => 'Aktionsregel'],
+                    ['key' => 'ends_at', 'label' => 'Endet'],
+                    ['key' => 'status', 'label' => 'Status'],
+                    ['key' => 'actions', 'label' => 'Aktionen'],
+                ]" :rows="$this->maddraxiversumSpecialOffers" striped>
+
+                    @scope('cell_rule_pattern', $offer)
+                        @if($offer->every_count === 1)
+                            {{ $offer->points }} Baxx pro Mission
+                        @else
+                            {{ $offer->points }} Baxx pro {{ $offer->every_count }} Missionen
+                        @endif
+                    @endscope
+
+                    @scope('cell_ends_at', $offer)
+                        {{ $offer->ends_at->format('d.m.Y H:i') }}
+                    @endscope
+
+                    @scope('cell_status', $offer)
+                        @if($offer->is_active && $offer->ends_at->isFuture())
+                            <x-badge value="Aktiv" class="badge-success" icon="o-bolt" />
+                        @elseif($offer->ends_at->isPast())
+                            <x-badge value="Abgelaufen" class="badge-warning" icon="o-clock" />
+                        @else
+                            <x-badge value="Inaktiv" class="badge-ghost" icon="o-pause" />
+                        @endif
+                    @endscope
+
+                    @scope('cell_actions', $offer)
+                        @php($toggleAction = $this->specialOfferToggleAction($offer->is_active, $offer->ends_at))
+                        <div class="flex gap-2">
+                            <x-button icon="o-pencil" class="btn-ghost btn-xs" wire:click="openEditMaddraxiversumSpecialOffer({{ $offer->id }})" tooltip="Bearbeiten" />
+                            <x-button
+                                icon="{{ $toggleAction['icon'] }}"
+                                class="btn-ghost btn-xs"
+                                wire:click="toggleMaddraxiversumSpecialOfferActive({{ $offer->id }})"
+                                tooltip="{{ $toggleAction['tooltip'] }}"
+                                :disabled="$toggleAction['disabled']"
                             />
                         </div>
                     @endscope
@@ -534,6 +607,20 @@
             <x-slot:actions>
                 <x-button label="Abbrechen" wire:click="$set('showReviewSpecialOfferModal', false)" />
                 <x-button label="Speichern" class="btn-primary" wire:click="saveReviewSpecialOffer" />
+            </x-slot:actions>
+        </x-modal>
+
+        <x-modal wire:model="showMaddraxiversumSpecialOfferModal" title="{{ $editingMaddraxiversumSpecialOfferId ? 'Maddraxiversum-Sonderaktion bearbeiten' : 'Neue Maddraxiversum-Sonderaktion' }}">
+            <div class="space-y-4">
+                <x-input wire:model="maddraxiversumSpecialOfferPoints" label="Baxx" type="number" min="1" />
+                <x-input wire:model="maddraxiversumSpecialOfferEveryCount" label="Pro Anzahl Missionen" type="number" min="1" />
+                <x-input wire:model="maddraxiversumSpecialOfferEndsAt" label="Endet am" type="datetime-local" />
+                <x-toggle wire:model="maddraxiversumSpecialOfferIsActive" label="Aktiv" />
+            </div>
+
+            <x-slot:actions>
+                <x-button label="Abbrechen" wire:click="$set('showMaddraxiversumSpecialOfferModal', false)" />
+                <x-button label="Speichern" class="btn-primary" wire:click="saveMaddraxiversumSpecialOffer" />
             </x-slot:actions>
         </x-modal>
 

--- a/resources/views/maddraxiversum/index.blade.php
+++ b/resources/views/maddraxiversum/index.blade.php
@@ -5,20 +5,37 @@
                 <div class="p-4 flex-grow flex flex-col">
                     @if ($showMap)
 
+                        @php($skipAssetsInMinimalTests = app()->runningUnitTests() && config('app.testing_minimal_layout', false))
+
                         <div id="map" class="w-full flex-grow border border-base-content/10 rounded"></div>
 
-                        <script>
-                            const csrfToken = '{{ csrf_token() }}';
-                            const tileUrl = '{{ $tileUrl }}';
-                        </script>
-                        @assets
-                            @vite(['resources/js/maddraxiversum.js'])
-                        @endassets
+                        @unless($skipAssetsInMinimalTests)
+                            <script>
+                                const csrfToken = '{{ csrf_token() }}';
+                                const tileUrl = '{{ $tileUrl }}';
+                            </script>
+                            @assets
+                                @vite(['resources/js/maddraxiversum.js'])
+                            @endassets
+                        @endunless
                     @else
                         <div class="bg-warning/10 border-l-4 border-warning text-warning-content p-4">
                             <p class="font-bold">Zugriff eingeschränkt</p>
                             <p>Du musst diese Belohnung zuerst im Bereich <a href="/belohnungen" class="underline font-semibold">Belohnungen einlösen</a> freischalten.</p>
                             <p>Du hast aktuell {{ $userPoints }} Baxx gesammelt.</p>
+
+                            @if(($rewardConfiguration['effective_rule']['is_active'] ?? false) && ($rewardConfiguration['effective_rule']['points'] ?? 0) > 0)
+                                <p class="mt-3 text-sm">
+                                    Aktuelle Vergaberegel für Missionen: <span class="font-semibold">{{ $rewardConfiguration['effective_rule']['rule_label'] }}</span>
+                                </p>
+                            @endif
+
+                            @if($rewardConfiguration['prominent_special_offer'] ?? null)
+                                <p class="mt-2 text-sm font-semibold">{{ $rewardConfiguration['prominent_special_offer']['banner_text'] }}</p>
+                                @if($rewardConfiguration['prominent_special_offer']['banner_end_text'])
+                                    <p class="text-sm">{{ $rewardConfiguration['prominent_special_offer']['banner_end_text'] }}</p>
+                                @endif
+                            @endif
                         </div>
                     @endif
                 </div>

--- a/resources/views/testing/livewire/belohnungen-admin.blade.php
+++ b/resources/views/testing/livewire/belohnungen-admin.blade.php
@@ -46,8 +46,16 @@
         <section>
             <h2>Vergaberegeln</h2>
 
+            <div>Maddraxiversum</div>
+            <div>{{ $this->maddraxiversumRewardConfiguration['base_rule']['rule_label'] }}</div>
+            <div>{{ $this->maddraxiversumRewardConfiguration['effective_rule']['rule_label'] }}</div>
+
             @foreach($this->earningRules as $rule)
                 <div>{{ $rule->label }}</div>
+            @endforeach
+
+            @foreach($this->maddraxiversumSpecialOffers as $offer)
+                <div>{{ $offer->points }}</div>
             @endforeach
 
             @foreach($this->romantauschRewardConfiguration as $configuration)

--- a/tests/Feature/BelohnungenAdminTest.php
+++ b/tests/Feature/BelohnungenAdminTest.php
@@ -6,6 +6,7 @@ use App\Enums\Role;
 use App\Livewire\BelohnungenAdmin;
 use App\Models\BaxxEarningRule;
 use App\Models\Download;
+use App\Models\MaddraxiversumBaxxSpecialOffer;
 use App\Models\RomantauschBaxxSpecialOffer;
 use App\Models\Reward;
 use App\Models\RewardPurchase;
@@ -200,6 +201,83 @@ class BelohnungenAdminTest extends TestCase
             ->assertHasErrors(['reviewSpecialOfferIsActive']);
 
         $this->assertSame(1, ReviewBaxxSpecialOffer::count());
+    }
+
+    public function test_create_maddraxiversum_special_offer(): void
+    {
+        $this->actingAdmin();
+
+        Livewire::test(BelohnungenAdmin::class)
+            ->set('maddraxiversumSpecialOfferPoints', 3)
+            ->set('maddraxiversumSpecialOfferEveryCount', 1)
+            ->set('maddraxiversumSpecialOfferEndsAt', now()->addDay()->format('Y-m-d\TH:i'))
+            ->set('maddraxiversumSpecialOfferIsActive', true)
+            ->call('saveMaddraxiversumSpecialOffer');
+
+        $this->assertDatabaseHas('maddraxiversum_baxx_special_offers', [
+            'points' => 3,
+            'every_count' => 1,
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_second_active_maddraxiversum_special_offer_is_rejected(): void
+    {
+        $this->actingAdmin();
+
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        Livewire::test(BelohnungenAdmin::class)
+            ->set('maddraxiversumSpecialOfferPoints', 4)
+            ->set('maddraxiversumSpecialOfferEveryCount', 1)
+            ->set('maddraxiversumSpecialOfferEndsAt', now()->addDays(2)->format('Y-m-d\TH:i'))
+            ->set('maddraxiversumSpecialOfferIsActive', true)
+            ->call('saveMaddraxiversumSpecialOffer')
+            ->assertHasErrors(['maddraxiversumSpecialOfferIsActive']);
+
+        $this->assertSame(1, MaddraxiversumBaxxSpecialOffer::count());
+    }
+
+    public function test_toggle_maddraxiversum_special_offer_active_status(): void
+    {
+        $this->actingAdmin();
+
+        $offer = MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 5,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => false,
+        ]);
+
+        Livewire::test(BelohnungenAdmin::class)
+            ->call('toggleMaddraxiversumSpecialOfferActive', $offer->id);
+
+        $this->assertDatabaseHas('maddraxiversum_baxx_special_offers', [
+            'id' => $offer->id,
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_rules_tab_shows_maddraxiversum_configuration(): void
+    {
+        $this->actingAdmin();
+
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        Livewire::test(BelohnungenAdmin::class)
+            ->set('activeTab', 'rules')
+            ->assertSee('Maddraxiversum')
+            ->assertSee('2 Baxx pro Mission');
     }
 
     public function test_create_romantausch_special_offer(): void

--- a/tests/Feature/MaddraxiversumControllerTest.php
+++ b/tests/Feature/MaddraxiversumControllerTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use App\Models\BaxxEarningRule;
 use App\Models\MaddraxiversumBaxxSpecialOffer;
-use App\Models\Mission;
 use App\Models\Reward;
 use App\Models\RewardPurchase;
 use App\Models\Team;

--- a/tests/Feature/MaddraxiversumControllerTest.php
+++ b/tests/Feature/MaddraxiversumControllerTest.php
@@ -2,18 +2,30 @@
 
 namespace Tests\Feature;
 
+use App\Models\BaxxEarningRule;
+use App\Models\MaddraxiversumBaxxSpecialOffer;
+use App\Models\Mission;
 use App\Models\Reward;
 use App\Models\RewardPurchase;
 use App\Models\Team;
+use App\Models\UserPoint;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 class MaddraxiversumControllerTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('app.testing_minimal_layout', true);
+    }
 
     private function actingMember(string $role = 'Mitglied', int $points = 0): User
     {
@@ -84,6 +96,26 @@ class MaddraxiversumControllerTest extends TestCase
         $response->assertSee('Belohnungen einlösen');
     }
 
+    public function test_index_shows_effective_maddraxiversum_rule_when_reward_is_locked(): void
+    {
+        $user = $this->actingMember('Mitglied', 2);
+        $this->actingAs($user);
+
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 4,
+            'every_count' => 2,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $response = $this->get('/maddraxiversum');
+
+        $response->assertOk();
+        $response->assertSee('Aktuelle Vergaberegel für Missionen');
+        $response->assertSee('4 Baxx pro 2 Missionen');
+        $response->assertSee('Sonderaktion: Jetzt für einen begrenzten Zeitraum 2 Baxx pro Mission!');
+    }
+
     public function test_get_cities_returns_api_response(): void
     {
         Http::fake(['de.maddraxikon.com/*' => Http::response(['test' => 'data'], 200)]);
@@ -147,5 +179,72 @@ class MaddraxiversumControllerTest extends TestCase
                 'status' => 'traveling',
                 'current_location' => 'A',
             ]);
+    }
+
+    public function test_check_mission_status_marks_completed_and_awards_points_from_effective_rule(): void
+    {
+        Carbon::setTestNow('2025-01-01 12:00:00');
+
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        BaxxEarningRule::updateOrCreate(
+            ['action_key' => 'maddraxiversum_mission'],
+            [
+                'label' => 'Maddraxiversum-Mission',
+                'description' => 'Testregel',
+                'points' => 7,
+                'every_count' => 1,
+                'is_active' => true,
+            ]
+        );
+
+        $this->startMission($user);
+
+        Carbon::setTestNow('2025-01-01 12:00:45');
+
+        $this->postJson('/mission/status-pruefen')
+            ->assertOk()
+            ->assertJson(['status' => 'completed']);
+
+        $this->assertDatabaseHas('missions', [
+            'user_id' => $user->id,
+            'completed' => true,
+        ]);
+        $this->assertDatabaseHas('user_points', [
+            'user_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'points' => 7,
+        ]);
+    }
+
+    public function test_check_mission_status_uses_active_special_offer_rule(): void
+    {
+        Carbon::setTestNow('2025-01-01 12:00:00');
+
+        $user = $this->actingMember();
+        $this->actingAs($user);
+
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 11,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $this->startMission($user);
+
+        Carbon::setTestNow('2025-01-01 12:00:45');
+
+        $this->postJson('/mission/status-pruefen')
+            ->assertOk()
+            ->assertJson(['status' => 'completed']);
+
+        $this->assertDatabaseHas('user_points', [
+            'user_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'points' => 11,
+        ]);
+        $this->assertSame(1, UserPoint::count());
     }
 }

--- a/tests/Unit/MaddraxiversumBaxxServiceTest.php
+++ b/tests/Unit/MaddraxiversumBaxxServiceTest.php
@@ -4,7 +4,6 @@ namespace Tests\Unit;
 
 use App\Models\MaddraxiversumBaxxSpecialOffer;
 use App\Models\Mission;
-use App\Models\Team;
 use App\Models\UserPoint;
 use App\Services\MaddraxiversumBaxxService;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Unit/MaddraxiversumBaxxServiceTest.php
+++ b/tests/Unit/MaddraxiversumBaxxServiceTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\MaddraxiversumBaxxSpecialOffer;
+use App\Models\Mission;
+use App\Models\Team;
+use App\Models\UserPoint;
+use App\Services\MaddraxiversumBaxxService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUserWithRole;
+use Tests\TestCase;
+
+class MaddraxiversumBaxxServiceTest extends TestCase
+{
+    use CreatesUserWithRole;
+    use RefreshDatabase;
+
+    public function test_effective_rule_falls_back_to_base_rule_without_active_special_offer(): void
+    {
+        $rule = app(MaddraxiversumBaxxService::class)->getEffectiveRule();
+
+        $this->assertFalse($rule['is_special_offer']);
+        $this->assertSame(5, $rule['points']);
+        $this->assertSame(1, $rule['every_count']);
+        $this->assertSame('5 Baxx pro Mission', $rule['rule_label']);
+    }
+
+    public function test_active_special_offer_overrides_base_rule(): void
+    {
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $rule = app(MaddraxiversumBaxxService::class)->getEffectiveRule();
+
+        $this->assertTrue($rule['is_special_offer']);
+        $this->assertSame(2, $rule['points']);
+        $this->assertSame(1, $rule['every_count']);
+        $this->assertSame('2 Baxx pro Mission', $rule['rule_label']);
+    }
+
+    public function test_expired_special_offer_is_ignored(): void
+    {
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 2,
+            'every_count' => 1,
+            'ends_at' => now()->subMinute(),
+            'is_active' => true,
+        ]);
+
+        $rule = app(MaddraxiversumBaxxService::class)->getEffectiveRule();
+
+        $this->assertFalse($rule['is_special_offer']);
+        $this->assertSame(5, $rule['points']);
+        $this->assertSame(1, $rule['every_count']);
+    }
+
+    public function test_prominent_special_offer_is_only_returned_for_one_baxx_or_more_per_mission(): void
+    {
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 1,
+            'every_count' => 4,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $this->assertNull(app(MaddraxiversumBaxxService::class)->getProminentSpecialOffer());
+
+        MaddraxiversumBaxxSpecialOffer::query()->delete();
+
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 5,
+            'every_count' => 2,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $banner = app(MaddraxiversumBaxxService::class)->getProminentSpecialOffer();
+
+        $this->assertNotNull($banner);
+        $this->assertSame('2,5', $banner['points_per_mission_label']);
+        $this->assertStringContainsString('Sonderaktion', $banner['banner_text']);
+    }
+
+    public function test_explicit_mission_reward_has_priority_over_special_offer_and_base_rule(): void
+    {
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 3,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $mission = new Mission;
+        $mission->setAttribute('reward', 9);
+
+        $points = app(MaddraxiversumBaxxService::class)->resolveMissionRewardPoints($mission);
+
+        $this->assertSame(9, $points);
+    }
+
+    public function test_award_points_for_mission_uses_effective_rule_and_current_team(): void
+    {
+        $user = $this->createUserWithRole('Mitglied');
+
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 4,
+            'every_count' => 1,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $awardedPoints = app(MaddraxiversumBaxxService::class)->awardPointsForMission($user, completedMissionCount: 1);
+
+        $this->assertSame(4, $awardedPoints);
+        $this->assertDatabaseHas('user_points', [
+            'user_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'points' => 4,
+        ]);
+        $this->assertSame(1, UserPoint::count());
+    }
+
+    public function test_award_points_for_mission_returns_zero_without_current_team(): void
+    {
+        $user = $this->createUserWithRole('Mitglied');
+        $user->setRelation('currentTeam', null);
+
+        $awardedPoints = app(MaddraxiversumBaxxService::class)->awardPointsForMission($user, completedMissionCount: 1);
+
+        $this->assertSame(0, $awardedPoints);
+        $this->assertSame(0, UserPoint::count());
+    }
+
+    public function test_award_points_for_mission_respects_every_count_for_effective_rule(): void
+    {
+        $user = $this->createUserWithRole('Mitglied');
+
+        MaddraxiversumBaxxSpecialOffer::create([
+            'points' => 6,
+            'every_count' => 2,
+            'ends_at' => now()->addDay(),
+            'is_active' => true,
+        ]);
+
+        $firstAward = app(MaddraxiversumBaxxService::class)->awardPointsForMission($user, completedMissionCount: 1);
+        $secondAward = app(MaddraxiversumBaxxService::class)->awardPointsForMission($user, completedMissionCount: 2);
+
+        $this->assertSame(0, $firstAward);
+        $this->assertSame(6, $secondAward);
+        $this->assertDatabaseHas('user_points', [
+            'user_id' => $user->id,
+            'team_id' => $user->currentTeam->id,
+            'points' => 6,
+        ]);
+        $this->assertSame(1, UserPoint::count());
+    }
+}


### PR DESCRIPTION
This pull request introduces a new "Maddraxiversum" special offer system for managing and awarding bonus points for missions, along with related admin interface enhancements and model additions. The main changes include integrating a new `MaddraxiversumBaxxSpecialOffer` model, updating controllers and Livewire components to support special offer creation, editing, and activation, and refactoring the mission completion logic to use the new service.

**Maddraxiversum Special Offer System:**

* Added new model `MaddraxiversumBaxxSpecialOffer` with fields for points, frequency, end date, and active status, including a query scope for currently active offers.
* Extended the admin Livewire component (`BelohnungenAdmin`) to support CRUD operations for Maddraxiversum special offers, including validation, modal handling, and toggling activation, with appropriate state resets and cache invalidation. [[1]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR85-R97) [[2]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR176-R196) [[3]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aL387-R428) [[4]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aL396-R442) [[5]](diffhunk://#diff-b31a2e6cc0327e1aaeb7780face64f3002be115b3714e682d6c361525a37807aR590-R710)

**Mission Completion & Reward Logic:**

* Refactored `MaddraxiversumController` to use the new `MaddraxiversumBaxxService` for awarding mission points and retrieving reward configurations, replacing direct logic and removing old logging code. [[1]](diffhunk://#diff-53a5fba91f37ab618b27111450aebcc58e78898c80c3375093bdad153cbef889L6-R8) [[2]](diffhunk://#diff-53a5fba91f37ab618b27111450aebcc58e78898c80c3375093bdad153cbef889L19-R22) [[3]](diffhunk://#diff-53a5fba91f37ab618b27111450aebcc58e78898c80c3375093bdad153cbef889R47) [[4]](diffhunk://#diff-53a5fba91f37ab618b27111450aebcc58e78898c80c3375093bdad153cbef889R104-L165) [[5]](diffhunk://#diff-53a5fba91f37ab618b27111450aebcc58e78898c80c3375093bdad153cbef889R155-L205)

**Blade Components:**

* Registered a new Blade component alias `modal` for `mary-modal` to streamline frontend modal usage.