### PR TITLE
Fix: Allow Admin to comment

### DIFF
--- a/app/Http/Controllers/ReviewCommentController.php
+++ b/app/Http/Controllers/ReviewCommentController.php
@@ -38,7 +38,7 @@ class ReviewCommentController extends Controller
             ->where('user_id', $user->id)
             ->exists();
 
-        if (! ($hasOwn || in_array($role, [Role::Ehrenmitglied, Role::Vorstand], true))) {
+        if (! ($hasOwn || in_array($role, [Role::Ehrenmitglied, Role::Vorstand, Role::Admin], true))) {
             abort(403);
         }
 

--- a/tests/Feature/ReviewCommentControllerTest.php
+++ b/tests/Feature/ReviewCommentControllerTest.php
@@ -19,7 +19,71 @@ class ReviewCommentControllerTest extends TestCase
     use CreatesUserWithRole;
     use RefreshDatabase;
 
-    public function test_comment_saves_and_notifies_author(): void
+    public function test_vorstand_without_own_review_can_comment_and_notify_author(): void
+    {
+        Mail::fake();
+
+        $team = Team::membersTeam();
+        $author = User::factory()->create(['current_team_id' => $team->id, 'notify_new_review' => true]);
+        $team->users()->attach($author, ['role' => Role::Mitglied->value]);
+        $book = Book::create(['roman_number' => 1, 'title' => 'Roman1', 'author' => 'Foo']);
+        $review = Review::create([
+            'team_id' => $team->id,
+            'user_id' => $author->id,
+            'book_id' => $book->id,
+            'title' => 'Review',
+            'content' => str_repeat('B', 140),
+        ]);
+
+        $commenter = $this->actingMember('Vorstand');
+        $this->actingAs($commenter);
+
+        $response = $this->post(route('reviews.comments.store', $review), [
+            'content' => 'Nice review',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('review_comments', [
+            'review_id' => $review->id,
+            'user_id' => $commenter->id,
+            'content' => 'Nice review',
+        ]);
+        Mail::assertQueued(ReviewCommentNotification::class);
+    }
+
+    public function test_admin_without_own_review_can_comment_and_notify_author(): void
+    {
+        Mail::fake();
+
+        $team = Team::membersTeam();
+        $author = User::factory()->create(['current_team_id' => $team->id, 'notify_new_review' => true]);
+        $team->users()->attach($author, ['role' => Role::Mitglied->value]);
+        $book = Book::create(['roman_number' => 1, 'title' => 'Roman1', 'author' => 'Foo']);
+        $review = Review::create([
+            'team_id' => $team->id,
+            'user_id' => $author->id,
+            'book_id' => $book->id,
+            'title' => 'Review',
+            'content' => str_repeat('B', 140),
+        ]);
+
+        $commenter = $this->actingMember('Admin');
+        $this->actingAs($commenter);
+
+        $response = $this->post(route('reviews.comments.store', $review), [
+            'content' => 'Admin-Kommentar',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('review_comments', [
+            'review_id' => $review->id,
+            'user_id' => $commenter->id,
+            'content' => 'Admin-Kommentar',
+        ]);
+        Mail::assertQueued(ReviewCommentNotification::class);
+    }
+
+    public function test_ehrenmitglied_without_own_review_can_comment_and_notify_author(): void
     {
         Mail::fake();
 
@@ -39,14 +103,14 @@ class ReviewCommentControllerTest extends TestCase
         $this->actingAs($commenter);
 
         $response = $this->post(route('reviews.comments.store', $review), [
-            'content' => 'Nice review',
+            'content' => 'Ehren-Kommentar',
         ]);
 
         $response->assertRedirect();
         $this->assertDatabaseHas('review_comments', [
             'review_id' => $review->id,
             'user_id' => $commenter->id,
-            'content' => 'Nice review',
+            'content' => 'Ehren-Kommentar',
         ]);
         Mail::assertQueued(ReviewCommentNotification::class);
     }

--- a/tests/Feature/RezensionLivewireTest.php
+++ b/tests/Feature/RezensionLivewireTest.php
@@ -335,6 +335,101 @@ class RezensionLivewireTest extends TestCase
             ->assertRedirect(route('reviews.create', $book));
     }
 
+    public function test_show_displays_review_for_ehrenmitglied_without_own_review(): void
+    {
+        $user = $this->actingMember('Ehrenmitglied');
+
+        $book = Book::create([
+            'roman_number' => 1,
+            'title' => 'Roman1',
+            'author' => 'Author',
+        ]);
+        $other = $this->createUserWithRole('Mitglied');
+        Review::create([
+            'team_id' => $other->currentTeam->id,
+            'user_id' => $other->id,
+            'book_id' => $book->id,
+            'title' => 'R',
+            'content' => str_repeat('B', 140),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(RezensionShow::class, ['book' => $book])
+            ->assertSee('R')
+            ->assertOk();
+    }
+
+    public function test_show_redirects_kassenwart_without_own_review(): void
+    {
+        $user = $this->actingMember('Kassenwart');
+
+        $book = Book::create([
+            'roman_number' => 1,
+            'title' => 'Roman1',
+            'author' => 'Author',
+        ]);
+        $other = $this->createUserWithRole('Mitglied');
+        Review::create([
+            'team_id' => $other->currentTeam->id,
+            'user_id' => $other->id,
+            'book_id' => $book->id,
+            'title' => 'R',
+            'content' => str_repeat('B', 140),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(RezensionShow::class, ['book' => $book])
+            ->assertRedirect(route('reviews.create', $book));
+    }
+
+    public function test_show_displays_review_for_vorstand_without_own_review(): void
+    {
+        $user = $this->actingMember('Vorstand');
+
+        $book = Book::create([
+            'roman_number' => 1,
+            'title' => 'Roman1',
+            'author' => 'Author',
+        ]);
+        $other = $this->createUserWithRole('Mitglied');
+        Review::create([
+            'team_id' => $other->currentTeam->id,
+            'user_id' => $other->id,
+            'book_id' => $book->id,
+            'title' => 'R',
+            'content' => str_repeat('B', 140),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(RezensionShow::class, ['book' => $book])
+            ->assertSee('R')
+            ->assertOk();
+    }
+
+    public function test_show_displays_review_for_admin_without_own_review(): void
+    {
+        $user = $this->actingMember('Admin');
+
+        $book = Book::create([
+            'roman_number' => 1,
+            'title' => 'Roman1',
+            'author' => 'Author',
+        ]);
+        $other = $this->createUserWithRole('Mitglied');
+        Review::create([
+            'team_id' => $other->currentTeam->id,
+            'user_id' => $other->id,
+            'book_id' => $book->id,
+            'title' => 'R',
+            'content' => str_repeat('B', 140),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(RezensionShow::class, ['book' => $book])
+            ->assertSee('R')
+            ->assertOk();
+    }
+
     public function test_show_displays_review_for_author(): void
     {
         $user = $this->actingMember();


### PR DESCRIPTION
This pull request expands permissions for commenting on and viewing reviews to include users with the `Admin` role, alongside `Vorstand` and `Ehrenmitglied`. It also adds and updates tests to ensure these permissions are correctly enforced and that unauthorized roles (like `Kassenwart`) are still restricted.

**Authorization changes:**

* Updated the permission logic in `ReviewCommentController` to allow users with the `Admin` role to comment on reviews they do not own, in addition to `Vorstand` and `Ehrenmitglied`.

**Test enhancements:**

_Permissions for commenting:_
* Added new tests in `ReviewCommentControllerTest` to verify that both `Admin` and `Ehrenmitglied` roles (without owning the review) can comment and trigger notifications, and refactored an existing test to clarify it covers the `Vorstand` role. [[1]](diffhunk://#diff-ca8b11877527f70d58f79f152f55b4f87eef672110e484c352afbbaa3da8f4f3L22-R22) [[2]](diffhunk://#diff-ca8b11877527f70d58f79f152f55b4f87eef672110e484c352afbbaa3da8f4f3L38-R38) [[3]](diffhunk://#diff-ca8b11877527f70d58f79f152f55b4f87eef672110e484c352afbbaa3da8f4f3R54-R117)

_Permissions for viewing reviews:_
* Added tests in `RezensionLivewireTest` to confirm that `Admin`, `Vorstand`, and `Ehrenmitglied` roles can view reviews they do not own, while `Kassenwart` is correctly redirected due to lack of permission.