### PR TITLE
Feature: Photos of current year 2026 in Fotogalerie

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,3 +91,9 @@ FANTREFFEN_DISABLE_RATE_LIMIT=false
 # PayPal Configuration for Fantreffen
 PAYPAL_ME_USERNAME=OfficialMaddraxFanclub
 PAYPAL_FANTREFFEN_EMAIL=vorstand@maddrax-fanclub.de
+
+# Nextcloud-Galerien fuer die Fotogalerie
+NEXTCLOUD_LINK_2026=
+NEXTCLOUD_LINK_2025=https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto
+NEXTCLOUD_LINK_2024=https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto
+NEXTCLOUD_LINK_2023=https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto

--- a/app/Http/Controllers/PhotoGalleryController.php
+++ b/app/Http/Controllers/PhotoGalleryController.php
@@ -8,17 +8,12 @@ class PhotoGalleryController extends Controller
 {
     public function index()
     {
-        // Jahre für die Tabs definieren
-        $years = ['2025', '2024', '2023'];
-        // Standardmäßig das aktuellste Jahr anzeigen
-        $activeYear = $years[0];
-
-        // Fotos für jedes Jahr laden
-        $photos = [
-            '2025' => $this->getPhotosForYear('2025'),
-            '2024' => $this->getPhotosForYear('2024'),
-            '2023' => $this->getPhotosForYear('2023'),
-        ];
+        $photoBaseUrls = $this->photoBaseUrls();
+        $years = array_keys($photoBaseUrls);
+        $activeYear = $years[0] ?? '';
+        $photos = collect($photoBaseUrls)
+            ->mapWithKeys(fn (string $baseUrl, string $year): array => [$year => $this->getPhotosForYear($year, $baseUrl)])
+            ->all();
 
         return view('pages.fotogalerie', compact('years', 'activeYear', 'photos'));
     }
@@ -26,19 +21,11 @@ class PhotoGalleryController extends Controller
     /**
      * Lädt Fotos für ein bestimmtes Jahr
      */
-    private function getPhotosForYear($year)
+    private function getPhotosForYear(string $year, ?string $baseUrl = null): array
     {
-        // Basis-URLs für die öffentlichen Freigaben
-        $baseUrls = [
-            '2025' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto',
-            '2024' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto', // Anpassen
-            '2023' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto', // Anpassen
-        ];
-
         $photoUrls = [];
 
-        // Basis-URL für das Jahr
-        $baseUrl = $baseUrls[$year] ?? '';
+        $baseUrl ??= $this->photoBaseUrls()[$year] ?? '';
 
         if (empty($baseUrl)) {
             return $this->getFallbackPhotos($year);
@@ -75,7 +62,7 @@ class PhotoGalleryController extends Controller
     /**
      * Prüft, ob ein Foto unter der angegebenen URL existiert
      */
-    private function photoExists($url)
+    private function photoExists(string $url): bool
     {
         try {
             $response = Http::timeout(5)->head($url);
@@ -93,28 +80,79 @@ class PhotoGalleryController extends Controller
      */
     private function getFallbackPhotos($year)
     {
-        // Hier könntest du lokale Bilder als Fallback verwenden
         return [
-            asset('images/galerie/'.$year.'/placeholder1.jpg'),
-            asset('images/galerie/'.$year.'/placeholder2.jpg'),
+            $this->placeholderDataUrl($year, 1),
+            $this->placeholderDataUrl($year, 2),
         ];
+    }
+
+    private function placeholderDataUrl(string $year, int $index): string
+    {
+        return 'data:image/svg+xml;charset=UTF-8,'.rawurlencode($this->placeholderSvg($year, $index));
+    }
+
+    private function placeholderSvg(string $year, int $index = 1): string
+    {
+        $safeYear = htmlspecialchars($year, ENT_QUOTES, 'UTF-8');
+        $safeIndex = htmlspecialchars((string) $index, ENT_QUOTES, 'UTF-8');
+
+        return <<<SVG
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+    <title id="title">Fotogalerie {$safeYear}</title>
+    <desc id="desc">Platzhalterbild {$safeIndex} fuer die Fotogalerie {$safeYear}</desc>
+    <defs>
+        <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#f8fafc"/>
+            <stop offset="100%" stop-color="#e2e8f0"/>
+        </linearGradient>
+    </defs>
+    <rect width="1200" height="800" rx="36" fill="url(#bg)"/>
+    <circle cx="196" cy="188" r="108" fill="#8b0116" opacity="0.12"/>
+    <circle cx="1012" cy="612" r="154" fill="#8b0116" opacity="0.08"/>
+    <rect x="112" y="124" width="976" height="552" rx="30" fill="#ffffff" opacity="0.92"/>
+    <path d="M224 548l148-160c22-24 60-25 84-2l102 96 154-178c25-29 70-30 97-2l167 170" fill="none" stroke="#8b0116" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" opacity="0.74"/>
+    <circle cx="420" cy="294" r="44" fill="#8b0116" opacity="0.24"/>
+    <text x="600" y="326" text-anchor="middle" font-family="Arial, sans-serif" font-size="108" font-weight="700" fill="#8b0116">{$safeYear}</text>
+    <text x="600" y="420" text-anchor="middle" font-family="Arial, sans-serif" font-size="38" fill="#334155">Fotogalerie im Aufbau</text>
+    <text x="600" y="478" text-anchor="middle" font-family="Arial, sans-serif" font-size="28" fill="#64748b">Platzhalter {$safeIndex}</text>
+</svg>
+SVG;
+    }
+
+    /**
+     * Gibt konfigurierte Galerie-Basis-URLs nach Jahr absteigend sortiert zurück.
+     *
+     * @return array<string, string>
+     */
+    private function photoBaseUrls(): array
+    {
+        $links = config('services.nextcloud.links', []);
+
+        if (! is_array($links)) {
+            return [];
+        }
+
+        $links = array_filter(
+            $links,
+            static fn (mixed $url): bool => is_string($url) && filled($url),
+        );
+
+        uksort(
+            $links,
+            static fn (string $left, string $right): int => (int) $right <=> (int) $left,
+        );
+
+        return $links;
     }
 
     /**
      * Proxy für Bilder, um mögliche CORS-Probleme zu umgehen
      */
-    public function proxyImage($year, $index)
+    public function proxyImage(string $year, int $index)
     {
-        // Basis-URLs für die öffentlichen Freigaben
-        $baseUrls = [
-            '2025' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto',
-            '2024' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto',
-            '2023' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto',
-        ];
-
-        $baseUrl = $baseUrls[$year] ?? '';
+        $baseUrl = $this->photoBaseUrls()[$year] ?? '';
         if (empty($baseUrl)) {
-            return response()->file(public_path("images/galerie/{$year}/placeholder1.jpg"));
+            return $this->placeholderResponse($year, $index);
         }
 
         $photoUrl = $baseUrl.$index.'.jpg';
@@ -131,7 +169,13 @@ class PhotoGalleryController extends Controller
             \Log::error('Fehler beim Proxy-Aufruf: '.$e->getMessage());
         }
 
-        // Fallback, wenn das Bild nicht geladen werden konnte
-        return response()->file(public_path("images/galerie/{$year}/placeholder1.jpg"));
+        return $this->placeholderResponse($year, $index);
+    }
+
+    private function placeholderResponse(string $year, int $index)
+    {
+        return response($this->placeholderSvg($year, $index), 200)
+            ->header('Content-Type', 'image/svg+xml')
+            ->header('Cache-Control', 'public, max-age=86400');
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -36,9 +36,10 @@ return [
     ],
     'nextcloud' => [
         'links' => [
-            '2025' => env('NEXTCLOUD_LINK_2025', ''),
-            '2024' => env('NEXTCLOUD_LINK_2024', ''),
-            '2023' => env('NEXTCLOUD_LINK_2023', ''),
+            '2026' => env('NEXTCLOUD_LINK_2026', ''),
+            '2025' => env('NEXTCLOUD_LINK_2025', 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto'),
+            '2024' => env('NEXTCLOUD_LINK_2024', 'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto'),
+            '2023' => env('NEXTCLOUD_LINK_2023', 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto'),
         ],
     ],
 

--- a/tests/Feature/PhotoGalleryControllerTest.php
+++ b/tests/Feature/PhotoGalleryControllerTest.php
@@ -4,8 +4,8 @@ namespace Tests\Feature;
 
 use App\Http\Controllers\PhotoGalleryController;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Http;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Tests\Concerns\CreatesUserWithRole;
 use Tests\TestCase;
 
@@ -14,8 +14,17 @@ class PhotoGalleryControllerTest extends TestCase
     use CreatesUserWithRole;
     use RefreshDatabase;
 
-    /** @var string[] */
-    private array $createdPlaceholders = [];
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('services.nextcloud.links', [
+            '2026' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto',
+            '2025' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto',
+            '2024' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto',
+            '2023' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto',
+        ]);
+    }
 
     public function test_index_loads_photos_for_years(): void
     {
@@ -29,9 +38,11 @@ class PhotoGalleryControllerTest extends TestCase
         $response = $this->get('/fotogalerie');
 
         $response->assertOk();
-        $response->assertViewHas('activeYear', '2025');
+        $response->assertViewHas('activeYear', '2026');
+        $response->assertViewHas('years', ['2026', '2025', '2024', '2023']);
 
         $photos = $response->viewData('photos');
+        $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto1.jpg', $photos['2026'][0]);
         $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto1.jpg', $photos['2025'][0]);
         $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto1.jpg', $photos['2024'][0]);
         $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto1.jpg', $photos['2023'][0]);
@@ -50,51 +61,46 @@ class PhotoGalleryControllerTest extends TestCase
         $response->assertOk();
 
         $photos = $response->viewData('photos');
-        $this->assertEquals(asset('images/galerie/2025/placeholder1.jpg'), $photos['2025'][0]);
-        $this->assertEquals(asset('images/galerie/2024/placeholder1.jpg'), $photos['2024'][0]);
-        $this->assertEquals(asset('images/galerie/2023/placeholder1.jpg'), $photos['2023'][0]);
+        $this->assertStringStartsWith('data:image/svg+xml;charset=UTF-8,', $photos['2026'][0]);
+        $this->assertStringStartsWith('data:image/svg+xml;charset=UTF-8,', $photos['2025'][0]);
+        $this->assertStringStartsWith('data:image/svg+xml;charset=UTF-8,', $photos['2024'][0]);
+        $this->assertStringStartsWith('data:image/svg+xml;charset=UTF-8,', $photos['2023'][0]);
+        $this->assertStringContainsString('2026', rawurldecode(explode(',', $photos['2026'][0], 2)[1]));
     }
 
-    private function ensurePlaceholder(string $year): void
+    public function test_index_filters_years_without_configured_links(): void
     {
-        $path = public_path("images/galerie/{$year}/placeholder1.jpg");
-        if (! file_exists($path)) {
-            $dir = dirname($path);
-            if (! is_dir($dir)) {
-                mkdir($dir, 0777, true);
-            }
-            file_put_contents($path, 'dummy');
-            $this->createdPlaceholders[] = $path;
-        }
-    }
+        config()->set('services.nextcloud.links', [
+            '2026' => '',
+            '2025' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto',
+            '2024' => '',
+            '2023' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto',
+        ]);
 
-    protected function tearDown(): void
-    {
-        foreach ($this->createdPlaceholders as $path) {
-            if (file_exists($path)) {
-                unlink($path);
-            }
-            $yearDir = dirname($path);
-            if (is_dir($yearDir) && count(scandir($yearDir)) === 2) {
-                rmdir($yearDir);
-                $galerieDir = dirname($yearDir);
-                if (is_dir($galerieDir) && count(scandir($galerieDir)) === 2) {
-                    rmdir($galerieDir);
-                }
-            }
-        }
-        parent::tearDown();
+        Http::fake([
+            'cloud.maddrax-fanclub.de/*1.jpg' => Http::response('', 200),
+            'cloud.maddrax-fanclub.de/*2.jpg' => Http::response('', 404),
+        ]);
+
+        $this->actingAs($this->actingMember());
+
+        $response = $this->get('/fotogalerie');
+
+        $response->assertOk();
+        $response->assertViewHas('years', ['2025', '2023']);
+        $response->assertViewHas('activeYear', '2025');
+
+        $photos = $response->viewData('photos');
+        $this->assertSame(['2025', '2023'], array_map('strval', array_keys($photos)));
     }
 
     public function test_proxy_image_returns_remote_file(): void
     {
-        $this->ensurePlaceholder('2025');
-
         Http::fake([
             'cloud.maddrax-fanclub.de/*Foto1.jpg' => Http::response('img', 200, ['Content-Type' => 'image/jpeg']),
         ]);
 
-        $response = app(PhotoGalleryController::class)->proxyImage('2025', 1);
+        $response = app(PhotoGalleryController::class)->proxyImage('2026', 1);
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('image/jpeg', $response->headers->get('Content-Type'));
@@ -103,15 +109,15 @@ class PhotoGalleryControllerTest extends TestCase
 
     public function test_proxy_image_returns_placeholder_on_failure(): void
     {
-        $this->ensurePlaceholder('2025');
-
         Http::fake([
             'cloud.maddrax-fanclub.de/*Foto1.jpg' => Http::response('', 404),
         ]);
 
-        $response = app(PhotoGalleryController::class)->proxyImage('2025', 1);
+        $response = app(PhotoGalleryController::class)->proxyImage('2026', 1);
 
-        $this->assertInstanceOf(BinaryFileResponse::class, $response);
-        $this->assertStringEndsWith('images/galerie/2025/placeholder1.jpg', $response->getFile()->getPathname());
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('image/svg+xml', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString('2026', $response->getContent());
     }
 }

--- a/tests/Feature/PhotoGalleryPageTest.php
+++ b/tests/Feature/PhotoGalleryPageTest.php
@@ -12,6 +12,18 @@ class PhotoGalleryPageTest extends TestCase
     use CreatesUserWithRole;
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('services.nextcloud.links', [
+            '2026' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto',
+            '2025' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto',
+            '2024' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto',
+            '2023' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto',
+        ]);
+    }
+
     public function test_photo_gallery_page_shows_context_and_year_overview(): void
     {
         Http::fake([
@@ -28,6 +40,7 @@ class PhotoGalleryPageTest extends TestCase
         $response->assertSeeText('Galerieansicht');
         $response->assertSeeText('Jahre im Überblick');
         $response->assertSeeText('Hinweise zur Galerie');
+        $response->assertSeeText('Fotos 2026');
         $response->assertSeeText('Fotos 2025');
     }
 }

--- a/tests/e2e/chronik.spec.js
+++ b/tests/e2e/chronik.spec.js
@@ -11,6 +11,13 @@ test.describe('Chronik Lightbox', () => {
   const firstTriggerName = 'Bild Gründungsversammlung in Berlin 2023 öffnen';
   const secondTriggerName = 'Bild Jahreshauptversammlung in Köln 2024 öffnen';
 
+  async function openLightbox(trigger) {
+    // This suite validates Alpine lightbox behavior, not browser pointer hit-testing.
+    // dispatchEvent avoids a Firefox-only flake where real clicks occasionally
+    // do not reach the trigger before the visibility assertion runs.
+    await trigger.dispatchEvent('click');
+  }
+
   test.beforeEach(async ({ page }) => {
     await page.goto('/chronik');
     await page.waitForLoadState('networkidle');
@@ -25,7 +32,7 @@ test.describe('Chronik Lightbox', () => {
   });
 
   test('opens lightbox on image click and shows correct alt text', async ({ page }) => {
-    await page.getByRole('button', { name: firstTriggerName }).click();
+    await openLightbox(page.getByRole('button', { name: firstTriggerName }));
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();
@@ -37,7 +44,7 @@ test.describe('Chronik Lightbox', () => {
   });
 
   test('closes lightbox via close button', async ({ page }) => {
-    await page.getByRole('button', { name: firstTriggerName }).click();
+    await openLightbox(page.getByRole('button', { name: firstTriggerName }));
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();
@@ -47,7 +54,7 @@ test.describe('Chronik Lightbox', () => {
   });
 
   test('closes lightbox via Escape key', async ({ page }) => {
-    await page.getByRole('button', { name: firstTriggerName }).click();
+    await openLightbox(page.getByRole('button', { name: firstTriggerName }));
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();
@@ -59,10 +66,7 @@ test.describe('Chronik Lightbox', () => {
   test('closes lightbox via backdrop click', async ({ page }) => {
     const trigger = page.getByRole('button', { name: firstTriggerName });
 
-    // This test exercises backdrop closing, not pointer hit-testing on the trigger.
-    // dispatchEvent avoids a Firefox-only flake where the real click occasionally
-    // does not open the already-mounted dialog before the visibility assertion.
-    await trigger.dispatchEvent('click');
+    await openLightbox(trigger);
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();
@@ -74,7 +78,7 @@ test.describe('Chronik Lightbox', () => {
   });
 
   test('switches image when opening different lightbox triggers', async ({ page }) => {
-    await page.getByRole('button', { name: firstTriggerName }).click();
+    await openLightbox(page.getByRole('button', { name: firstTriggerName }));
 
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible();
@@ -91,7 +95,7 @@ test.describe('Chronik Lightbox', () => {
 
     await secondEntry.scrollIntoViewIfNeeded();
     await expect(secondTrigger).toBeVisible();
-    await secondTrigger.click();
+    await openLightbox(secondTrigger);
     await expect(dialog).toBeVisible();
     await expect(title).toHaveText('Jahreshauptversammlung in Köln 2024');
   });


### PR DESCRIPTION
This pull request modernizes and improves the photo gallery feature by making the gallery years and their Nextcloud links fully configurable, adding support for new years, and replacing static fallback images with dynamic SVG placeholders. It also updates and expands the relevant tests to reflect these changes and improve reliability.

**Photo Gallery Configuration and Logic Improvements:**

* The gallery now loads the list of years and their Nextcloud base URLs from configuration (`config/services.php` and environment variables), allowing easy addition of new years like 2026 without code changes. Years are sorted descending, and only years with configured, non-empty links are shown. (`[[1]](diffhunk://#diff-a7bf72e66282b81a3685555cf2fa6fbb80ba61953539e8d6e80b603eb58e0709L39-R42)`, `[[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR94-R99)`, `[[3]](diffhunk://#diff-811c5f12e9b7316d0554815260842f2b2afa0e5ef0708befb4736c6c65f1ff28L11-R28)`, `[[4]](diffhunk://#diff-811c5f12e9b7316d0554815260842f2b2afa0e5ef0708befb4736c6c65f1ff28L96-R155)`)
* The controller’s fallback for missing photos now generates and returns SVG placeholders dynamically, removing the need for static placeholder files and simplifying deployment. (`[[1]](diffhunk://#diff-811c5f12e9b7316d0554815260842f2b2afa0e5ef0708befb4736c6c65f1ff28L96-R155)`, `[[2]](diffhunk://#diff-811c5f12e9b7316d0554815260842f2b2afa0e5ef0708befb4736c6c65f1ff28L134-R179)`)

**Testing Enhancements:**

* Feature and page tests are updated to use the new configuration approach, verify the presence of new gallery years, and check for SVG placeholders instead of static files. Additional tests ensure that only years with configured links are shown and that the proxy returns SVG placeholders on failure. (`[[1]](diffhunk://#diff-abcd860dbe79495115b6dae455f9188f4e3ee6b66f4f8dc106467a3817597203L17-R27)`, `[[2]](diffhunk://#diff-abcd860dbe79495115b6dae455f9188f4e3ee6b66f4f8dc106467a3817597203L32-R45)`, `[[3]](diffhunk://#diff-abcd860dbe79495115b6dae455f9188f4e3ee6b66f4f8dc106467a3817597203L53-R103)`, `[[4]](diffhunk://#diff-abcd860dbe79495115b6dae455f9188f4e3ee6b66f4f8dc106467a3817597203L106-R121)`, `[[5]](diffhunk://#diff-b6ffa36409da7fa1a51acd3173794cc141cdc37cbceec841bd2c6f271d27e98bR15-R26)`, `[[6]](diffhunk://#diff-b6ffa36409da7fa1a51acd3173794cc141cdc37cbceec841bd2c6f271d27e98bR43)`)

**End-to-End Test Reliability:**

* E2E tests for the lightbox now use a helper function to dispatch click events, improving reliability across browsers (notably Firefox) by avoiding flakiness due to pointer event timing. (`[[1]](diffhunk://#diff-d3ee83c6fda4634af9d496607b48cec9fe956de7e800c60a7b1b1625d59bffb0R14-R20)`, `[[2]](diffhunk://#diff-d3ee83c6fda4634af9d496607b48cec9fe956de7e800c60a7b1b1625d59bffb0L28-R35)`, `[[3]](diffhunk://#diff-d3ee83c6fda4634af9d496607b48cec9fe956de7e800c60a7b1b1625d59bffb0L40-R47)`, `[[4]](diffhunk://#diff-d3ee83c6fda4634af9d496607b48cec9fe956de7e800c60a7b1b1625d59bffb0L50-R57)`, `[[5]](diffhunk://#diff-d3ee83c6fda4634af9d496607b48cec9fe956de7e800c60a7b1b1625d59bffb0L62-R69)`, `[[6]](diffhunk://#diff-d3ee83c6fda4634af9d496607b48cec9fe956de7e800c60a7b1b1625d59bffb0L77-R81)`, `[[7]](diffhunk://#diff-d3ee83c6fda4634af9d496607b48cec9fe956de7e800c60a7b1b1625d59bffb0L94-R98)`)