### PR TITLE
Feature: Newsletter archive

### DIFF
--- a/app/Enums/NewsletterAusgabeStatus.php
+++ b/app/Enums/NewsletterAusgabeStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum NewsletterAusgabeStatus: string
+{
+    case Entwurf = 'entwurf';
+    case Veroeffentlicht = 'veroeffentlicht';
+}

--- a/app/Http/Controllers/NewsletterArchivAdminController.php
+++ b/app/Http/Controllers/NewsletterArchivAdminController.php
@@ -7,7 +7,6 @@ use App\Models\NewsletterAusgabe;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
@@ -48,7 +47,11 @@ class NewsletterArchivAdminController extends Controller
 
         $newsletterAusgabe->update([
             'subject' => $validated['subject'],
-            'slug' => $this->uniqueSlug($validated['slug'], $validated['subject'], $newsletterAusgabe),
+            'slug' => NewsletterAusgabe::generateUniqueSlug(
+                $validated['slug'],
+                $validated['subject'],
+                $newsletterAusgabe,
+            ),
             'recipient_roles' => $validated['recipient_roles'],
             'sent_at' => filled($validated['sent_at'] ?? null)
                 ? Carbon::parse($validated['sent_at'])
@@ -71,22 +74,5 @@ class NewsletterArchivAdminController extends Controller
         return redirect()
             ->route('newsletter.archiv.admin.edit', $newsletterAusgabe)
             ->with('status', 'Newsletter-Ausgabe veröffentlicht.');
-    }
-
-    private function uniqueSlug(string $slugInput, string $subject, ?NewsletterAusgabe $ignore = null): string
-    {
-        $baseSlug = Str::slug($slugInput) ?: Str::slug($subject) ?: 'newsletter';
-        $slug = $baseSlug;
-        $counter = 2;
-
-        while (NewsletterAusgabe::query()
-            ->when($ignore, fn ($query) => $query->whereKeyNot($ignore->getKey()))
-            ->where('slug', $slug)
-            ->exists()) {
-            $slug = "{$baseSlug}-{$counter}";
-            $counter++;
-        }
-
-        return $slug;
     }
 }

--- a/app/Http/Controllers/NewsletterArchivAdminController.php
+++ b/app/Http/Controllers/NewsletterArchivAdminController.php
@@ -40,7 +40,7 @@ class NewsletterArchivAdminController extends Controller
             'slug' => ['required', 'string', 'max:255'],
             'recipient_roles' => ['required', 'array', 'min:1'],
             'recipient_roles.*' => ['string', Rule::in(NewsletterAusgabe::recipientRoleValues())],
-            'sent_at' => ['required', 'date'],
+            'sent_at' => ['nullable', 'date'],
             'topics' => ['required', 'array', 'min:1'],
             'topics.*.title' => ['required', 'string', 'max:255'],
             'topics.*.content' => ['required', 'string'],
@@ -50,7 +50,9 @@ class NewsletterArchivAdminController extends Controller
             'subject' => $validated['subject'],
             'slug' => $this->uniqueSlug($validated['slug'], $validated['subject'], $newsletterAusgabe),
             'recipient_roles' => $validated['recipient_roles'],
-            'sent_at' => Carbon::parse($validated['sent_at']),
+            'sent_at' => filled($validated['sent_at'] ?? null)
+                ? Carbon::parse($validated['sent_at'])
+                : null,
             'topics' => $validated['topics'],
         ]);
 
@@ -68,7 +70,7 @@ class NewsletterArchivAdminController extends Controller
 
         return redirect()
             ->route('newsletter.archiv.admin.edit', $newsletterAusgabe)
-            ->with('status', 'Newsletter-Ausgabe veroeffentlicht.');
+            ->with('status', 'Newsletter-Ausgabe veröffentlicht.');
     }
 
     private function uniqueSlug(string $slugInput, string $subject, ?NewsletterAusgabe $ignore = null): string

--- a/app/Http/Controllers/NewsletterArchivAdminController.php
+++ b/app/Http/Controllers/NewsletterArchivAdminController.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\NewsletterAusgabeStatus;
+use App\Enums\Role;
+use App\Models\NewsletterAusgabe;
+use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+
+class NewsletterArchivAdminController extends Controller
+{
+    private const ROLES = [Role::Mitglied, Role::Ehrenmitglied, Role::Kassenwart, Role::Vorstand, Role::Admin];
+
+    public function index(): View
+    {
+        $newsletterAusgaben = NewsletterAusgabe::query()
+            ->orderByDesc('sent_at')
+            ->orderByDesc('created_at')
+            ->paginate(20);
+
+        return view('newsletter.archiv.admin.index', [
+            'newsletterAusgaben' => $newsletterAusgaben,
+        ]);
+    }
+
+    public function edit(NewsletterAusgabe $newsletterAusgabe): View
+    {
+        return view('newsletter.archiv.admin.edit', [
+            'newsletterAusgabe' => $newsletterAusgabe,
+            'roles' => self::ROLES,
+        ]);
+    }
+
+    public function update(Request $request, NewsletterAusgabe $newsletterAusgabe): RedirectResponse
+    {
+        $validated = $request->validate([
+            'subject' => ['required', 'string', 'max:255'],
+            'slug' => ['required', 'string', 'max:255'],
+            'recipient_roles' => ['required', 'array', 'min:1'],
+            'recipient_roles.*' => ['string', Rule::in(array_map(fn (Role $role) => $role->value, self::ROLES))],
+            'sent_at' => ['required', 'date'],
+            'topics' => ['required', 'array', 'min:1'],
+            'topics.*.title' => ['required', 'string', 'max:255'],
+            'topics.*.content' => ['required', 'string'],
+        ]);
+
+        $newsletterAusgabe->update([
+            'subject' => $validated['subject'],
+            'slug' => $this->uniqueSlug($validated['slug'], $validated['subject'], $newsletterAusgabe),
+            'recipient_roles' => $validated['recipient_roles'],
+            'sent_at' => Carbon::parse($validated['sent_at']),
+            'topics' => $validated['topics'],
+        ]);
+
+        return redirect()
+            ->route('newsletter.archiv.admin.edit', $newsletterAusgabe->fresh())
+            ->with('status', 'Archiv-Eintrag aktualisiert.');
+    }
+
+    public function publish(NewsletterAusgabe $newsletterAusgabe): RedirectResponse
+    {
+        $newsletterAusgabe->update([
+            'status' => NewsletterAusgabeStatus::Veroeffentlicht,
+            'published_at' => $newsletterAusgabe->published_at ?? now(),
+        ]);
+
+        return redirect()
+            ->route('newsletter.archiv.admin.edit', $newsletterAusgabe)
+            ->with('status', 'Newsletter-Ausgabe veroeffentlicht.');
+    }
+
+    private function uniqueSlug(string $slugInput, string $subject, ?NewsletterAusgabe $ignore = null): string
+    {
+        $baseSlug = Str::slug($slugInput) ?: Str::slug($subject) ?: 'newsletter';
+        $slug = $baseSlug;
+        $counter = 2;
+
+        while (NewsletterAusgabe::query()
+            ->when($ignore, fn ($query) => $query->whereKeyNot($ignore->getKey()))
+            ->where('slug', $slug)
+            ->exists()) {
+            $slug = "{$baseSlug}-{$counter}";
+            $counter++;
+        }
+
+        return $slug;
+    }
+}

--- a/app/Http/Controllers/NewsletterArchivAdminController.php
+++ b/app/Http/Controllers/NewsletterArchivAdminController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Enums\NewsletterAusgabeStatus;
-use App\Enums\Role;
 use App\Models\NewsletterAusgabe;
 use Carbon\Carbon;
 use Illuminate\Http\RedirectResponse;
@@ -14,8 +13,6 @@ use Illuminate\View\View;
 
 class NewsletterArchivAdminController extends Controller
 {
-    private const ROLES = [Role::Mitglied, Role::Ehrenmitglied, Role::Kassenwart, Role::Vorstand, Role::Admin];
-
     public function index(): View
     {
         $newsletterAusgaben = NewsletterAusgabe::query()
@@ -32,7 +29,7 @@ class NewsletterArchivAdminController extends Controller
     {
         return view('newsletter.archiv.admin.edit', [
             'newsletterAusgabe' => $newsletterAusgabe,
-            'roles' => self::ROLES,
+            'roles' => NewsletterAusgabe::recipientRoles(),
         ]);
     }
 
@@ -42,7 +39,7 @@ class NewsletterArchivAdminController extends Controller
             'subject' => ['required', 'string', 'max:255'],
             'slug' => ['required', 'string', 'max:255'],
             'recipient_roles' => ['required', 'array', 'min:1'],
-            'recipient_roles.*' => ['string', Rule::in(array_map(fn (Role $role) => $role->value, self::ROLES))],
+            'recipient_roles.*' => ['string', Rule::in(NewsletterAusgabe::recipientRoleValues())],
             'sent_at' => ['required', 'date'],
             'topics' => ['required', 'array', 'min:1'],
             'topics.*.title' => ['required', 'string', 'max:255'],

--- a/app/Http/Controllers/NewsletterArchivController.php
+++ b/app/Http/Controllers/NewsletterArchivController.php
@@ -23,10 +23,10 @@ class NewsletterArchivController extends Controller
 
     public function index(): View
     {
-        $this->authorizeMemberArea();
+        $role = $this->authorizeMemberArea();
 
         $ausgaben = NewsletterAusgabe::query()
-            ->published()
+            ->visibleInArchivFor($role)
             ->orderByDesc('published_at')
             ->orderByDesc('sent_at')
             ->paginate(12);
@@ -38,9 +38,9 @@ class NewsletterArchivController extends Controller
 
     public function show(NewsletterAusgabe $newsletterAusgabe): View
     {
-        $this->authorizeMemberArea();
+        $role = $this->authorizeMemberArea();
 
-        if ($newsletterAusgabe->status !== NewsletterAusgabeStatus::Veroeffentlicht) {
+        if (! $newsletterAusgabe->isVisibleInArchivFor($role)) {
             abort(404);
         }
 

--- a/app/Http/Controllers/NewsletterArchivController.php
+++ b/app/Http/Controllers/NewsletterArchivController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\NewsletterAusgabeStatus;
+use App\Http\Controllers\Concerns\MembersTeamAware;
+use App\Models\NewsletterAusgabe;
+use App\Services\UserRoleService;
+use Illuminate\View\View;
+
+class NewsletterArchivController extends Controller
+{
+    use MembersTeamAware;
+
+    public function __construct(
+        private readonly UserRoleService $userRoleService,
+    ) {}
+
+    protected function getUserRoleService(): UserRoleService
+    {
+        return $this->userRoleService;
+    }
+
+    public function index(): View
+    {
+        $this->authorizeMemberArea();
+
+        $ausgaben = NewsletterAusgabe::query()
+            ->published()
+            ->orderByDesc('published_at')
+            ->orderByDesc('sent_at')
+            ->paginate(12);
+
+        return view('newsletter.archiv.index', [
+            'ausgaben' => $ausgaben,
+        ]);
+    }
+
+    public function show(NewsletterAusgabe $newsletterAusgabe): View
+    {
+        $this->authorizeMemberArea();
+
+        if ($newsletterAusgabe->status !== NewsletterAusgabeStatus::Veroeffentlicht) {
+            abort(404);
+        }
+
+        return view('newsletter.archiv.show', [
+            'newsletterAusgabe' => $newsletterAusgabe,
+        ]);
+    }
+}

--- a/app/Http/Controllers/NewsletterArchivController.php
+++ b/app/Http/Controllers/NewsletterArchivController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Enums\NewsletterAusgabeStatus;
 use App\Http\Controllers\Concerns\MembersTeamAware;
 use App\Models\NewsletterAusgabe;
 use App\Services\UserRoleService;

--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\NewsletterAusgabeStatus;
 use App\Enums\Role;
 use App\Mail\Newsletter;
+use App\Models\NewsletterAusgabe;
 use App\Models\Team;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -76,6 +78,17 @@ class NewsletterController extends Controller
 
         foreach ($recipients as $recipient) {
             Mail::to($recipient->email)->queue(new Newsletter($data['subject'], $data['topics']));
+        }
+
+        if (! $request->boolean('test')) {
+            NewsletterAusgabe::query()->create([
+                'subject' => $data['subject'],
+                'topics' => $data['topics'],
+                'recipient_roles' => $data['roles'],
+                'status' => NewsletterAusgabeStatus::Entwurf,
+                'sent_at' => now(),
+                'created_by' => $user?->id,
+            ]);
         }
 
         return redirect()->route('newsletter.create')->with(

--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -15,11 +15,6 @@ use Illuminate\Validation\Rule;
 class NewsletterController extends Controller
 {
     /**
-     * Default role pre-selected on the form. Members are the usual audience.
-     */
-    private const DEFAULT_ROLE = Role::Mitglied;
-
-    /**
      * Display the newsletter form.
      */
     public function create()

--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -15,11 +15,6 @@ use Illuminate\Validation\Rule;
 class NewsletterController extends Controller
 {
     /**
-     * Roles that can receive newsletters.
-     */
-    private const ROLES = [Role::Mitglied, Role::Ehrenmitglied, Role::Kassenwart, Role::Vorstand, Role::Admin];
-
-    /**
      * Default role pre-selected on the form. Members are the usual audience.
      */
     private const DEFAULT_ROLE = Role::Mitglied;
@@ -34,8 +29,8 @@ class NewsletterController extends Controller
         if (! $team || ! $team->hasUserWithRole($user, Role::Admin->value)) {
             abort(403);
         }
-        $roles = self::ROLES;
-        $defaultRole = self::DEFAULT_ROLE;
+        $roles = NewsletterAusgabe::recipientRoles();
+        $defaultRole = NewsletterAusgabe::defaultRecipientRole();
 
         return view('newsletter.versenden', compact('roles', 'defaultRole'));
     }
@@ -53,7 +48,7 @@ class NewsletterController extends Controller
 
         $data = $request->validate([
             'roles' => ['required', 'array'],
-            'roles.*' => ['string', Rule::in(array_map(fn (Role $r) => $r->value, self::ROLES))],
+            'roles.*' => ['string', Rule::in(NewsletterAusgabe::recipientRoleValues())],
             'subject' => ['required', 'string'],
             'topics' => ['required', 'array', 'min:1'],
             'topics.*.title' => ['required', 'string'],

--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -42,7 +42,7 @@ class NewsletterController extends Controller
         }
 
         $data = $request->validate([
-            'roles' => ['required', 'array'],
+            'roles' => ['required', 'array', 'min:1'],
             'roles.*' => ['string', Rule::in(NewsletterAusgabe::recipientRoleValues())],
             'subject' => ['required', 'string'],
             'topics' => ['required', 'array', 'min:1'],
@@ -64,6 +64,11 @@ class NewsletterController extends Controller
                 return redirect()->route('newsletter.create')
                     ->with('status', 'Keine Admin-Empfänger gefunden.');
             }
+        }
+
+        if ($recipients->isEmpty()) {
+            return redirect()->route('newsletter.create')
+                ->with('status', 'Keine Empfänger für die ausgewählten Rollen gefunden.');
         }
 
         foreach ($recipients as $recipient) {

--- a/app/Models/NewsletterAusgabe.php
+++ b/app/Models/NewsletterAusgabe.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\NewsletterAusgabeStatus;
+use App\Enums\Role;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -75,5 +76,48 @@ class NewsletterAusgabe extends Model
     public function scopeDraft(Builder $query): Builder
     {
         return $query->where('status', NewsletterAusgabeStatus::Entwurf->value);
+    }
+
+    public function scopeVisibleInArchivFor(Builder $query, Role $role): Builder
+    {
+        return $query
+            ->published()
+            ->whereJsonContains('recipient_roles', $role->value);
+    }
+
+    public function isVisibleInArchivFor(Role $role): bool
+    {
+        return $this->status === NewsletterAusgabeStatus::Veroeffentlicht
+            && in_array($role->value, $this->recipient_roles ?? [], true);
+    }
+
+    /**
+     * @return array<int, Role>
+     */
+    public static function recipientRoles(): array
+    {
+        return [
+            Role::Mitglied,
+            Role::Ehrenmitglied,
+            Role::Kassenwart,
+            Role::Vorstand,
+            Role::Admin,
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function recipientRoleValues(): array
+    {
+        return array_map(
+            fn (Role $role): string => $role->value,
+            self::recipientRoles(),
+        );
+    }
+
+    public static function defaultRecipientRole(): Role
+    {
+        return Role::Mitglied;
     }
 }

--- a/app/Models/NewsletterAusgabe.php
+++ b/app/Models/NewsletterAusgabe.php
@@ -74,15 +74,26 @@ class NewsletterAusgabe extends Model
 
     public function scopeVisibleInArchivFor(Builder $query, Role $role): Builder
     {
-        return $query
-            ->published()
-            ->whereJsonContains('recipient_roles', $role->value);
+        $query->published();
+
+        if (self::hasArchivBypassRole($role)) {
+            return $query;
+        }
+
+        return $query->whereJsonContains('recipient_roles', $role->value);
     }
 
     public function isVisibleInArchivFor(Role $role): bool
     {
-        return $this->status === NewsletterAusgabeStatus::Veroeffentlicht
-            && in_array($role->value, $this->recipient_roles ?? [], true);
+        if ($this->status !== NewsletterAusgabeStatus::Veroeffentlicht) {
+            return false;
+        }
+
+        if (self::hasArchivBypassRole($role)) {
+            return true;
+        }
+
+        return in_array($role->value, $this->recipient_roles ?? [], true);
     }
 
     /**
@@ -154,5 +165,10 @@ class NewsletterAusgabe extends Model
             ->when($ignore, fn (Builder $query) => $query->whereKeyNot($ignore->getKey()))
             ->where('slug', $slug)
             ->exists();
+    }
+
+    private static function hasArchivBypassRole(Role $role): bool
+    {
+        return in_array($role, [Role::Kassenwart, Role::Vorstand, Role::Admin], true);
     }
 }

--- a/app/Models/NewsletterAusgabe.php
+++ b/app/Models/NewsletterAusgabe.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\NewsletterAusgabeStatus;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+class NewsletterAusgabe extends Model
+{
+    use HasFactory;
+
+    protected $table = 'newsletter_ausgaben';
+
+    protected $fillable = [
+        'subject',
+        'slug',
+        'topics',
+        'recipient_roles',
+        'status',
+        'sent_at',
+        'published_at',
+        'created_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'topics' => 'array',
+            'recipient_roles' => 'array',
+            'status' => NewsletterAusgabeStatus::class,
+            'sent_at' => 'datetime',
+            'published_at' => 'datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (NewsletterAusgabe $newsletterAusgabe) {
+            if (filled($newsletterAusgabe->slug)) {
+                return;
+            }
+
+            $baseSlug = Str::slug($newsletterAusgabe->subject) ?: 'newsletter';
+            $slug = $baseSlug;
+            $counter = 2;
+
+            while (static::query()->where('slug', $slug)->exists()) {
+                $slug = "{$baseSlug}-{$counter}";
+                $counter++;
+            }
+
+            $newsletterAusgabe->slug = $slug;
+        });
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query->where('status', NewsletterAusgabeStatus::Veroeffentlicht->value);
+    }
+
+    public function scopeDraft(Builder $query): Builder
+    {
+        return $query->where('status', NewsletterAusgabeStatus::Entwurf->value);
+    }
+}

--- a/app/Models/NewsletterAusgabe.php
+++ b/app/Models/NewsletterAusgabe.php
@@ -14,6 +14,10 @@ class NewsletterAusgabe extends Model
 {
     use HasFactory;
 
+    private const FALLBACK_SLUG = 'newsletter';
+
+    private const MAX_SLUG_LENGTH = 255;
+
     protected $table = 'newsletter_ausgaben';
 
     protected $fillable = [
@@ -41,20 +45,10 @@ class NewsletterAusgabe extends Model
     protected static function booted(): void
     {
         static::creating(function (NewsletterAusgabe $newsletterAusgabe) {
-            if (filled($newsletterAusgabe->slug)) {
-                return;
-            }
-
-            $baseSlug = Str::slug($newsletterAusgabe->subject) ?: 'newsletter';
-            $slug = $baseSlug;
-            $counter = 2;
-
-            while (static::query()->where('slug', $slug)->exists()) {
-                $slug = "{$baseSlug}-{$counter}";
-                $counter++;
-            }
-
-            $newsletterAusgabe->slug = $slug;
+            $newsletterAusgabe->slug = static::generateUniqueSlug(
+                $newsletterAusgabe->slug,
+                $newsletterAusgabe->subject,
+            );
         });
     }
 
@@ -119,5 +113,46 @@ class NewsletterAusgabe extends Model
     public static function defaultRecipientRole(): Role
     {
         return Role::Mitglied;
+    }
+
+    public static function generateUniqueSlug(?string $preferredSlug, ?string $fallbackSubject = null, ?self $ignore = null): string
+    {
+        $baseSlug = static::baseSlug($preferredSlug, $fallbackSubject);
+        $slug = static::truncateSlug($baseSlug);
+        $counter = 2;
+
+        while (static::slugExists($slug, $ignore)) {
+            $suffix = '-'.$counter;
+            $slug = static::truncateSlug($baseSlug, strlen($suffix)).$suffix;
+            $counter++;
+        }
+
+        return $slug;
+    }
+
+    private static function baseSlug(?string $preferredSlug, ?string $fallbackSubject = null): string
+    {
+        $baseSlug = Str::slug((string) $preferredSlug);
+
+        if ($baseSlug === '') {
+            $baseSlug = Str::slug((string) $fallbackSubject);
+        }
+
+        return $baseSlug !== '' ? $baseSlug : self::FALLBACK_SLUG;
+    }
+
+    private static function truncateSlug(string $slug, int $reservedSuffixLength = 0): string
+    {
+        $maxLength = max(1, self::MAX_SLUG_LENGTH - $reservedSuffixLength);
+
+        return rtrim(Str::substr($slug, 0, $maxLength), '-');
+    }
+
+    private static function slugExists(string $slug, ?self $ignore = null): bool
+    {
+        return static::query()
+            ->when($ignore, fn (Builder $query) => $query->whereKeyNot($ignore->getKey()))
+            ->where('slug', $slug)
+            ->exists();
     }
 }

--- a/app/Models/NewsletterAusgabe.php
+++ b/app/Models/NewsletterAusgabe.php
@@ -64,12 +64,12 @@ class NewsletterAusgabe extends Model
 
     public function scopePublished(Builder $query): Builder
     {
-        return $query->where('status', NewsletterAusgabeStatus::Veroeffentlicht->value);
+        return $query->where('status', NewsletterAusgabeStatus::Veroeffentlicht);
     }
 
     public function scopeDraft(Builder $query): Builder
     {
-        return $query->where('status', NewsletterAusgabeStatus::Entwurf->value);
+        return $query->where('status', NewsletterAusgabeStatus::Entwurf);
     }
 
     public function scopeVisibleInArchivFor(Builder $query, Role $role): Builder

--- a/config/navigation.php
+++ b/config/navigation.php
@@ -69,6 +69,7 @@ return [
             'title' => 'Verein',
             'icon' => 'o-building-office-2',
             'items' => [
+                ['title' => 'Newsletter-Archiv', 'route' => 'newsletter.archiv.index'],
                 ['title' => 'Protokolle', 'route' => 'protokolle'],
                 ['title' => 'Satzung', 'route' => 'satzung'],
                 ['title' => 'Kassenstand', 'route' => 'kassenstand.index'],

--- a/database/factories/NewsletterAusgabeFactory.php
+++ b/database/factories/NewsletterAusgabeFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\NewsletterAusgabeStatus;
+use App\Models\NewsletterAusgabe;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<NewsletterAusgabe>
+ */
+class NewsletterAusgabeFactory extends Factory
+{
+    protected $model = NewsletterAusgabe::class;
+
+    public function definition(): array
+    {
+        return [
+            'subject' => fake()->sentence(3),
+            'topics' => [
+                [
+                    'title' => fake()->sentence(2),
+                    'content' => fake()->paragraph(),
+                ],
+            ],
+            'recipient_roles' => ['Mitglied'],
+            'status' => NewsletterAusgabeStatus::Entwurf,
+            'sent_at' => now(),
+            'published_at' => null,
+            'created_by' => User::factory(),
+        ];
+    }
+
+    public function published(): static
+    {
+        return $this->state(fn () => [
+            'status' => NewsletterAusgabeStatus::Veroeffentlicht,
+            'published_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_05_17_120000_create_newsletter_ausgaben_table.php
+++ b/database/migrations/2026_05_17_120000_create_newsletter_ausgaben_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Enums\NewsletterAusgabeStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('newsletter_ausgaben', function (Blueprint $table) {
+            $table->id();
+            $table->string('subject');
+            $table->string('slug')->unique();
+            $table->json('topics');
+            $table->json('recipient_roles');
+            $table->string('status')->default(NewsletterAusgabeStatus::Entwurf->value);
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('newsletter_ausgaben');
+    }
+};

--- a/database/migrations/2026_05_17_130000_add_listing_indexes_to_newsletter_ausgaben_table.php
+++ b/database/migrations/2026_05_17_130000_add_listing_indexes_to_newsletter_ausgaben_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('newsletter_ausgaben', function (Blueprint $table) {
+            $table->index(
+                ['status', 'published_at', 'sent_at'],
+                'newsletter_ausgaben_status_published_at_sent_at_index'
+            );
+            $table->index(
+                ['sent_at', 'created_at'],
+                'newsletter_ausgaben_sent_at_created_at_index'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('newsletter_ausgaben', function (Blueprint $table) {
+            $table->dropIndex('newsletter_ausgaben_status_published_at_sent_at_index');
+            $table->dropIndex('newsletter_ausgaben_sent_at_created_at_index');
+        });
+    }
+};

--- a/resources/views/newsletter/archiv/admin/edit.blade.php
+++ b/resources/views/newsletter/archiv/admin/edit.blade.php
@@ -1,0 +1,135 @@
+<x-app-layout title="Newsletter-Archiv bearbeiten">
+    <x-member-page class="max-w-5xl space-y-8">
+        @if (session('status'))
+            <x-alert icon="o-check-circle" class="alert-success mb-4" dismissible>
+                {{ session('status') }}
+            </x-alert>
+        @endif
+
+        <x-ui.page-header
+            eyebrow="Adminbereich"
+            title="Newsletter-Ausgabe bearbeiten"
+            description="Pflege Betreff, Slug, Versandzeit und Themenbloecke des Archiv-Eintrags."
+        >
+            <x-slot:actions>
+                <div class="flex flex-wrap gap-2">
+                    @if ($newsletterAusgabe->status === \App\Enums\NewsletterAusgabeStatus::Veroeffentlicht)
+                        <x-badge value="Veroeffentlicht" class="badge-success" icon="o-check-circle" />
+                        <x-button label="Im Archiv ansehen" link="{{ route('newsletter.archiv.show', $newsletterAusgabe) }}" class="btn-ghost btn-sm" icon="o-arrow-top-right-on-square" />
+                    @else
+                        <x-badge value="Entwurf" class="badge-warning" icon="o-pencil-square" />
+                    @endif
+                </div>
+            </x-slot:actions>
+        </x-ui.page-header>
+
+        <x-ui.panel title="Stammdaten" description="Der Eintrag kann redaktionell angepasst werden, bevor er fuer Mitglieder freigeschaltet wird.">
+            <form
+                method="POST"
+                action="{{ route('newsletter.archiv.admin.update', $newsletterAusgabe) }}"
+                x-data="newsletterArchivForm({ topics: @js(old('topics', $newsletterAusgabe->topics ?? [])) })"
+                class="space-y-6"
+            >
+                @csrf
+                @method('PUT')
+
+                <div class="grid gap-4 md:grid-cols-2">
+                    <x-input name="subject" label="Betreff" :value="old('subject', $newsletterAusgabe->subject)" required />
+                    <x-input name="slug" label="Slug" :value="old('slug', $newsletterAusgabe->slug)" required />
+                    <x-input
+                        name="sent_at"
+                        type="datetime-local"
+                        label="Versendet am"
+                        :value="old('sent_at', optional($newsletterAusgabe->sent_at)->format('Y-m-d\TH:i'))"
+                        required
+                    />
+                </div>
+
+                <div>
+                    <label class="label">
+                        <span class="label-text">Zielgruppen</span>
+                    </label>
+                    <div class="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                        @foreach ($roles as $role)
+                            <x-checkbox
+                                name="recipient_roles[]"
+                                :value="$role->value"
+                                :checked="in_array($role->value, old('recipient_roles', $newsletterAusgabe->recipient_roles ?? []), true)"
+                                :label="$role->value"
+                            />
+                        @endforeach
+                    </div>
+                </div>
+
+                <div class="space-y-4">
+                    <div class="flex items-center justify-between gap-3">
+                        <div>
+                            <h2 class="text-lg font-semibold">Themenbloecke</h2>
+                            <p class="text-sm text-base-content/70">Die Reihenfolge hier entspricht der Darstellung im Archiv und in der Mailansicht.</p>
+                        </div>
+                        <x-button type="button" label="Thema hinzufuegen" class="btn-ghost btn-sm" icon="o-plus" @click="addTopic" />
+                    </div>
+
+                    <template x-for="(topic, index) in topics" :key="index">
+                        <x-ui.panel class="bg-base-200/70 shadow-none">
+                            <div class="space-y-3">
+                                <div class="flex justify-end" x-show="topics.length > 1">
+                                    <x-button type="button" label="Entfernen" class="btn-ghost btn-xs" icon="o-trash" @click="removeTopic(index)" />
+                                </div>
+                                <div>
+                                    <label class="label" x-bind:for="'topic-title-' + index">
+                                        <span class="label-text">Thema</span>
+                                    </label>
+                                    <input x-bind:id="'topic-title-' + index" x-bind:name="'topics[' + index + '][title]'" x-model="topic.title" type="text" class="input input-bordered w-full" required>
+                                </div>
+                                <div>
+                                    <label class="label" x-bind:for="'topic-content-' + index">
+                                        <span class="label-text">Text</span>
+                                    </label>
+                                    <textarea x-bind:id="'topic-content-' + index" x-bind:name="'topics[' + index + '][content]'" x-model="topic.content" class="textarea textarea-bordered w-full" rows="6" required></textarea>
+                                </div>
+                            </div>
+                        </x-ui.panel>
+                    </template>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                    <x-button type="submit" label="Aenderungen speichern" class="btn-primary" icon="o-check" />
+                    <x-button type="button" label="Zur Uebersicht" link="{{ route('newsletter.archiv.admin.index') }}" class="btn-ghost" icon="o-arrow-left" />
+                </div>
+            </form>
+
+            @if ($newsletterAusgabe->status !== \App\Enums\NewsletterAusgabeStatus::Veroeffentlicht)
+                <form method="POST" action="{{ route('newsletter.archiv.admin.publish', $newsletterAusgabe) }}" class="mt-4">
+                    @csrf
+                    <x-button type="submit" label="Jetzt veroeffentlichen" class="btn-secondary" icon="o-paper-airplane" />
+                </form>
+            @endif
+        </x-ui.panel>
+    </x-member-page>
+
+    <script>
+        function newsletterArchivForm({ topics }) {
+            const initialTopics = Array.isArray(topics) && topics.length > 0
+                ? topics.map((topic) => ({
+                    title: topic.title ?? '',
+                    content: topic.content ?? '',
+                }))
+                : [{ title: '', content: '' }];
+
+            return {
+                topics: initialTopics,
+                addTopic() {
+                    this.topics.push({ title: '', content: '' });
+                },
+                removeTopic(index) {
+                    if (this.topics.length === 1) {
+                        return;
+                    }
+
+                    this.topics.splice(index, 1);
+                },
+            };
+        }
+    </script>
+</x-app-layout>

--- a/resources/views/newsletter/archiv/admin/edit.blade.php
+++ b/resources/views/newsletter/archiv/admin/edit.blade.php
@@ -9,12 +9,12 @@
         <x-ui.page-header
             eyebrow="Adminbereich"
             title="Newsletter-Ausgabe bearbeiten"
-            description="Pflege Betreff, Slug, Versandzeit und Themenbloecke des Archiv-Eintrags."
+            description="Pflege Betreff, Slug, Versandzeit und Themenblöcke des Archiv-Eintrags."
         >
             <x-slot:actions>
                 <div class="flex flex-wrap gap-2">
                     @if ($newsletterAusgabe->status === \App\Enums\NewsletterAusgabeStatus::Veroeffentlicht)
-                        <x-badge value="Veroeffentlicht" class="badge-success" icon="o-check-circle" />
+                        <x-badge value="Veröffentlicht" class="badge-success" icon="o-check-circle" />
                         <x-button label="Im Archiv ansehen" link="{{ route('newsletter.archiv.show', $newsletterAusgabe) }}" class="btn-ghost btn-sm" icon="o-arrow-top-right-on-square" />
                     @else
                         <x-badge value="Entwurf" class="badge-warning" icon="o-pencil-square" />
@@ -23,7 +23,7 @@
             </x-slot:actions>
         </x-ui.page-header>
 
-        <x-ui.panel title="Stammdaten" description="Der Eintrag kann redaktionell angepasst werden, bevor er fuer Mitglieder freigeschaltet wird.">
+        <x-ui.panel title="Stammdaten" description="Der Eintrag kann redaktionell angepasst werden, bevor er für Mitglieder freigeschaltet wird.">
             <form
                 method="POST"
                 action="{{ route('newsletter.archiv.admin.update', $newsletterAusgabe) }}"
@@ -41,7 +41,6 @@
                         type="datetime-local"
                         label="Versendet am"
                         :value="old('sent_at', optional($newsletterAusgabe->sent_at)->format('Y-m-d\TH:i'))"
-                        required
                     />
                 </div>
 
@@ -64,10 +63,10 @@
                 <div class="space-y-4">
                     <div class="flex items-center justify-between gap-3">
                         <div>
-                            <h2 class="text-lg font-semibold">Themenbloecke</h2>
+                            <h2 class="text-lg font-semibold">Themenblöcke</h2>
                             <p class="text-sm text-base-content/70">Die Reihenfolge hier entspricht der Darstellung im Archiv und in der Mailansicht.</p>
                         </div>
-                        <x-button type="button" label="Thema hinzufuegen" class="btn-ghost btn-sm" icon="o-plus" @click="addTopic" />
+                        <x-button type="button" label="Thema hinzufügen" class="btn-ghost btn-sm" icon="o-plus" @click="addTopic" />
                     </div>
 
                     <template x-for="(topic, index) in topics" :key="index">
@@ -94,15 +93,15 @@
                 </div>
 
                 <div class="flex flex-wrap gap-2">
-                    <x-button type="submit" label="Aenderungen speichern" class="btn-primary" icon="o-check" />
-                    <x-button type="button" label="Zur Uebersicht" link="{{ route('newsletter.archiv.admin.index') }}" class="btn-ghost" icon="o-arrow-left" />
+                    <x-button type="submit" label="Änderungen speichern" class="btn-primary" icon="o-check" />
+                    <x-button type="button" label="Zur Übersicht" link="{{ route('newsletter.archiv.admin.index') }}" class="btn-ghost" icon="o-arrow-left" />
                 </div>
             </form>
 
             @if ($newsletterAusgabe->status !== \App\Enums\NewsletterAusgabeStatus::Veroeffentlicht)
                 <form method="POST" action="{{ route('newsletter.archiv.admin.publish', $newsletterAusgabe) }}" class="mt-4">
                     @csrf
-                    <x-button type="submit" label="Jetzt veroeffentlichen" class="btn-secondary" icon="o-paper-airplane" />
+                    <x-button type="submit" label="Jetzt veröffentlichen" class="btn-secondary" icon="o-paper-airplane" />
                 </form>
             @endif
         </x-ui.panel>

--- a/resources/views/newsletter/archiv/admin/index.blade.php
+++ b/resources/views/newsletter/archiv/admin/index.blade.php
@@ -1,0 +1,64 @@
+<x-app-layout title="Newsletter-Archiv verwalten">
+    <x-member-page class="max-w-6xl space-y-8">
+        @if (session('status'))
+            <x-alert icon="o-check-circle" class="alert-success mb-4" dismissible>
+                {{ session('status') }}
+            </x-alert>
+        @endif
+
+        <x-ui.page-header
+            eyebrow="Adminbereich"
+            title="Newsletter-Archiv verwalten"
+            description="Hier pruefst du Archiv-Entwuerfe, pflegst Inhalte nach und gibst Ausgaben fuer das Mitgliederarchiv frei."
+        >
+            <x-slot:actions>
+                <x-button label="Newsletter versenden" link="{{ route('newsletter.create') }}" class="btn-primary btn-sm" icon="o-paper-airplane" />
+            </x-slot:actions>
+        </x-ui.page-header>
+
+        @if ($newsletterAusgaben->isEmpty())
+            <x-ui.panel>
+                <div class="py-12 text-center">
+                    <x-icon name="o-envelope" class="mx-auto h-12 w-12 text-base-content/50" />
+                    <h2 class="mt-4 text-lg font-semibold">Noch keine Archiv-Eintraege</h2>
+                    <p class="mt-2 text-sm text-base-content/70">Nach dem ersten echten Newsletter-Versand wird hier automatisch ein Entwurf angelegt.</p>
+                </div>
+            </x-ui.panel>
+        @else
+            <div class="space-y-6">
+                @foreach ($newsletterAusgaben as $newsletterAusgabe)
+                    <x-ui.panel>
+                        <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                            <div class="space-y-2">
+                                <div class="flex flex-wrap items-center gap-2">
+                                    <h2 class="text-xl font-semibold">{{ $newsletterAusgabe->subject }}</h2>
+                                    @if ($newsletterAusgabe->status === \App\Enums\NewsletterAusgabeStatus::Veroeffentlicht)
+                                        <x-badge value="Veroeffentlicht" class="badge-success" icon="o-check-circle" />
+                                    @else
+                                        <x-badge value="Entwurf" class="badge-warning" icon="o-pencil-square" />
+                                    @endif
+                                </div>
+                                <p class="text-sm text-base-content/70">Slug: {{ $newsletterAusgabe->slug }}</p>
+                                <p class="text-sm text-base-content/70">Versand: {{ optional($newsletterAusgabe->sent_at)->format('d.m.Y H:i') ?? 'Unbekannt' }}</p>
+                            </div>
+
+                            <div class="flex flex-wrap gap-2">
+                                <x-button label="Bearbeiten" link="{{ route('newsletter.archiv.admin.edit', $newsletterAusgabe) }}" class="btn-primary btn-sm" icon="o-pencil-square" />
+                                @if ($newsletterAusgabe->status !== \App\Enums\NewsletterAusgabeStatus::Veroeffentlicht)
+                                    <form method="POST" action="{{ route('newsletter.archiv.admin.publish', $newsletterAusgabe) }}">
+                                        @csrf
+                                        <x-button type="submit" label="Veroeffentlichen" class="btn-secondary btn-sm" icon="o-check" />
+                                    </form>
+                                @endif
+                            </div>
+                        </div>
+                    </x-ui.panel>
+                @endforeach
+            </div>
+
+            <div>
+                {{ $newsletterAusgaben->links() }}
+            </div>
+        @endif
+    </x-member-page>
+</x-app-layout>

--- a/resources/views/newsletter/archiv/admin/index.blade.php
+++ b/resources/views/newsletter/archiv/admin/index.blade.php
@@ -9,7 +9,7 @@
         <x-ui.page-header
             eyebrow="Adminbereich"
             title="Newsletter-Archiv verwalten"
-            description="Hier pruefst du Archiv-Entwuerfe, pflegst Inhalte nach und gibst Ausgaben fuer das Mitgliederarchiv frei."
+            description="Hier prüfst du Archiv-Entwürfe, pflegst Inhalte nach und gibst Ausgaben für das Mitgliederarchiv frei."
         >
             <x-slot:actions>
                 <x-button label="Newsletter versenden" link="{{ route('newsletter.create') }}" class="btn-primary btn-sm" icon="o-paper-airplane" />
@@ -20,7 +20,7 @@
             <x-ui.panel>
                 <div class="py-12 text-center">
                     <x-icon name="o-envelope" class="mx-auto h-12 w-12 text-base-content/50" />
-                    <h2 class="mt-4 text-lg font-semibold">Noch keine Archiv-Eintraege</h2>
+                    <h2 class="mt-4 text-lg font-semibold">Noch keine Archiv-Einträge</h2>
                     <p class="mt-2 text-sm text-base-content/70">Nach dem ersten echten Newsletter-Versand wird hier automatisch ein Entwurf angelegt.</p>
                 </div>
             </x-ui.panel>
@@ -33,7 +33,7 @@
                                 <div class="flex flex-wrap items-center gap-2">
                                     <h2 class="text-xl font-semibold">{{ $newsletterAusgabe->subject }}</h2>
                                     @if ($newsletterAusgabe->status === \App\Enums\NewsletterAusgabeStatus::Veroeffentlicht)
-                                        <x-badge value="Veroeffentlicht" class="badge-success" icon="o-check-circle" />
+                                        <x-badge value="Veröffentlicht" class="badge-success" icon="o-check-circle" />
                                     @else
                                         <x-badge value="Entwurf" class="badge-warning" icon="o-pencil-square" />
                                     @endif
@@ -47,7 +47,7 @@
                                 @if ($newsletterAusgabe->status !== \App\Enums\NewsletterAusgabeStatus::Veroeffentlicht)
                                     <form method="POST" action="{{ route('newsletter.archiv.admin.publish', $newsletterAusgabe) }}">
                                         @csrf
-                                        <x-button type="submit" label="Veroeffentlichen" class="btn-secondary btn-sm" icon="o-check" />
+                                        <x-button type="submit" label="Veröffentlichen" class="btn-secondary btn-sm" icon="o-check" />
                                     </form>
                                 @endif
                             </div>

--- a/resources/views/newsletter/archiv/index.blade.php
+++ b/resources/views/newsletter/archiv/index.blade.php
@@ -1,9 +1,9 @@
-<x-app-layout title="Newsletter-Archiv – Offizieller MADDRAX Fanclub e. V." description="Archivierte Vereinsnewsletter fuer Mitglieder.">
+<x-app-layout title="Newsletter-Archiv – Offizieller MADDRAX Fanclub e. V." description="Archivierte Vereinsnewsletter für Mitglieder.">
     <x-member-page class="max-w-6xl space-y-8">
         <x-ui.page-header
             eyebrow="Verein"
             title="Newsletter-Archiv"
-            description="Hier findest du alle veroeffentlichten Vereinsnewsletter im Webformat, chronologisch sortiert und dauerhaft im Mitgliederbereich verfuegbar."
+            description="Hier findest du alle veröffentlichten Vereinsnewsletter im Webformat, chronologisch sortiert und dauerhaft im Mitgliederbereich verfügbar."
         >
             <x-slot:actions>
                 <div class="flex flex-wrap gap-2">
@@ -17,7 +17,7 @@
             <x-ui.panel>
                 <div class="py-12 text-center">
                     <x-icon name="o-envelope" class="mx-auto h-12 w-12 text-base-content/50" />
-                    <h2 class="mt-4 text-lg font-semibold">Noch keine veroeffentlichten Newsletter</h2>
+                    <h2 class="mt-4 text-lg font-semibold">Noch keine veröffentlichten Newsletter</h2>
                     <p class="mt-2 text-sm text-base-content/70">Sobald die erste Ausgabe freigegeben ist, erscheint sie hier automatisch im Archiv.</p>
                 </div>
             </x-ui.panel>
@@ -49,7 +49,7 @@
                                     <p class="font-medium text-base-content">{{ $firstTopic['title'] }}</p>
                                     <p>{{ \Illuminate\Support\Str::limit($firstTopic['content'] ?? '', 220) }}</p>
                                 @else
-                                    <p>Diese Ausgabe enthaelt aktuell noch keine Themenbloecke.</p>
+                                    <p>Diese Ausgabe enthält aktuell noch keine Themenblöcke.</p>
                                 @endif
                             </div>
 

--- a/resources/views/newsletter/archiv/index.blade.php
+++ b/resources/views/newsletter/archiv/index.blade.php
@@ -47,8 +47,8 @@
 
                             <div class="space-y-2 text-sm leading-relaxed text-base-content/80">
                                 @if ($firstTopic)
-                                    <p class="font-medium text-base-content">{{ $firstTopic['title'] }}</p>
-                                    <p>{{ \Illuminate\Support\Str::limit($firstTopic['content'] ?? '', 220) }}</p>
+                                    <p class="font-medium text-base-content">{{ data_get($firstTopic, 'title', 'Ohne Titel') }}</p>
+                                    <p>{{ \Illuminate\Support\Str::limit(data_get($firstTopic, 'content', ''), 220) }}</p>
                                 @else
                                     <p>Diese Ausgabe enthält aktuell noch keine Themenblöcke.</p>
                                 @endif

--- a/resources/views/newsletter/archiv/index.blade.php
+++ b/resources/views/newsletter/archiv/index.blade.php
@@ -1,0 +1,70 @@
+<x-app-layout title="Newsletter-Archiv – Offizieller MADDRAX Fanclub e. V." description="Archivierte Vereinsnewsletter fuer Mitglieder.">
+    <x-member-page class="max-w-6xl space-y-8">
+        <x-ui.page-header
+            eyebrow="Verein"
+            title="Newsletter-Archiv"
+            description="Hier findest du alle veroeffentlichten Vereinsnewsletter im Webformat, chronologisch sortiert und dauerhaft im Mitgliederbereich verfuegbar."
+        >
+            <x-slot:actions>
+                <div class="flex flex-wrap gap-2">
+                    <span class="badge badge-primary badge-outline rounded-full px-3 py-3">{{ $ausgaben->total() }} Ausgaben</span>
+                    <span class="badge badge-outline rounded-full px-3 py-3">Mitgliederbereich</span>
+                </div>
+            </x-slot:actions>
+        </x-ui.page-header>
+
+        @if ($ausgaben->isEmpty())
+            <x-ui.panel>
+                <div class="py-12 text-center">
+                    <x-icon name="o-envelope" class="mx-auto h-12 w-12 text-base-content/50" />
+                    <h2 class="mt-4 text-lg font-semibold">Noch keine veroeffentlichten Newsletter</h2>
+                    <p class="mt-2 text-sm text-base-content/70">Sobald die erste Ausgabe freigegeben ist, erscheint sie hier automatisch im Archiv.</p>
+                </div>
+            </x-ui.panel>
+        @else
+            <section class="grid gap-6 lg:grid-cols-2">
+                @foreach ($ausgaben as $ausgabe)
+                    @php
+                        $firstTopic = $ausgabe->topics[0] ?? null;
+                    @endphp
+
+                    <x-ui.panel class="h-full">
+                        <div class="flex h-full flex-col gap-4">
+                            <div class="flex items-start justify-between gap-4">
+                                <div>
+                                    <h2 class="text-xl font-semibold">
+                                        <a href="{{ route('newsletter.archiv.show', $ausgabe) }}" class="transition hover:text-primary" wire:navigate>
+                                            {{ $ausgabe->subject }}
+                                        </a>
+                                    </h2>
+                                    <p class="mt-2 text-sm text-base-content/70">
+                                        Versand: {{ optional($ausgabe->sent_at)->format('d.m.Y H:i') ?? 'Unbekannt' }}
+                                    </p>
+                                </div>
+                                <x-badge value="{{ count($ausgabe->topics ?? []) }} Themen" class="badge-ghost" icon="o-document-text" />
+                            </div>
+
+                            <div class="space-y-2 text-sm leading-relaxed text-base-content/80">
+                                @if ($firstTopic)
+                                    <p class="font-medium text-base-content">{{ $firstTopic['title'] }}</p>
+                                    <p>{{ Str::limit($firstTopic['content'] ?? '', 220) }}</p>
+                                @else
+                                    <p>Diese Ausgabe enthaelt aktuell noch keine Themenbloecke.</p>
+                                @endif
+                            </div>
+
+                            <div class="mt-auto flex items-center justify-between gap-3 border-t border-base-content/10 pt-4 text-sm">
+                                <span class="text-base-content/65">Zielgruppen: {{ implode(', ', $ausgabe->recipient_roles ?? []) }}</span>
+                                <x-button label="Zur Ausgabe" link="{{ route('newsletter.archiv.show', $ausgabe) }}" wire:navigate class="btn-primary btn-sm" icon="o-arrow-right" />
+                            </div>
+                        </div>
+                    </x-ui.panel>
+                @endforeach
+            </section>
+
+            <div>
+                {{ $ausgaben->links() }}
+            </div>
+        @endif
+    </x-member-page>
+</x-app-layout>

--- a/resources/views/newsletter/archiv/index.blade.php
+++ b/resources/views/newsletter/archiv/index.blade.php
@@ -25,7 +25,8 @@
             <section class="grid gap-6 lg:grid-cols-2">
                 @foreach ($ausgaben as $ausgabe)
                     @php
-                        $firstTopic = $ausgabe->topics[0] ?? null;
+                        $topics = $ausgabe->topics ?? [];
+                        $firstTopic = $topics[0] ?? null;
                     @endphp
 
                     <x-ui.panel class="h-full">

--- a/resources/views/newsletter/archiv/index.blade.php
+++ b/resources/views/newsletter/archiv/index.blade.php
@@ -47,7 +47,7 @@
                             <div class="space-y-2 text-sm leading-relaxed text-base-content/80">
                                 @if ($firstTopic)
                                     <p class="font-medium text-base-content">{{ $firstTopic['title'] }}</p>
-                                    <p>{{ Str::limit($firstTopic['content'] ?? '', 220) }}</p>
+                                    <p>{{ \Illuminate\Support\Str::limit($firstTopic['content'] ?? '', 220) }}</p>
                                 @else
                                     <p>Diese Ausgabe enthaelt aktuell noch keine Themenbloecke.</p>
                                 @endif

--- a/resources/views/newsletter/archiv/show.blade.php
+++ b/resources/views/newsletter/archiv/show.blade.php
@@ -1,0 +1,30 @@
+<x-app-layout title="{{ $newsletterAusgabe->subject }} – Newsletter-Archiv" description="Archivierte Newsletter-Ausgabe im Mitgliederbereich.">
+    <x-member-page class="max-w-4xl space-y-8">
+        <x-ui.page-header
+            eyebrow="Newsletter-Archiv"
+            title="{{ $newsletterAusgabe->subject }}"
+            description="Archivierte Vereinsausgabe vom {{ optional($newsletterAusgabe->sent_at)->format('d.m.Y H:i') ?? 'unbekannten Zeitpunkt' }}."
+        >
+            <x-slot:actions>
+                <div class="flex flex-wrap gap-2">
+                    <x-badge value="{{ count($newsletterAusgabe->topics ?? []) }} Themen" class="badge-primary badge-outline" icon="o-document-text" />
+                    <x-badge value="{{ implode(', ', $newsletterAusgabe->recipient_roles ?? []) }}" class="badge-ghost" icon="o-user-group" />
+                </div>
+            </x-slot:actions>
+        </x-ui.page-header>
+
+        <div class="flex justify-end">
+            <x-button label="Zurueck zum Archiv" link="{{ route('newsletter.archiv.index') }}" wire:navigate class="btn-ghost btn-sm" icon="o-arrow-left" />
+        </div>
+
+        <section class="space-y-6">
+            @foreach ($newsletterAusgabe->topics ?? [] as $topic)
+                <x-ui.panel :title="$topic['title'] ?? 'Ohne Titel'">
+                    <div class="prose max-w-none text-base-content dark:prose-invert">
+                        <p>{!! nl2br(e($topic['content'] ?? '')) !!}</p>
+                    </div>
+                </x-ui.panel>
+            @endforeach
+        </section>
+    </x-member-page>
+</x-app-layout>

--- a/resources/views/newsletter/archiv/show.blade.php
+++ b/resources/views/newsletter/archiv/show.blade.php
@@ -14,7 +14,7 @@
         </x-ui.page-header>
 
         <div class="flex justify-end">
-            <x-button label="Zurueck zum Archiv" link="{{ route('newsletter.archiv.index') }}" wire:navigate class="btn-ghost btn-sm" icon="o-arrow-left" />
+            <x-button label="Zurück zum Archiv" link="{{ route('newsletter.archiv.index') }}" wire:navigate class="btn-ghost btn-sm" icon="o-arrow-left" />
         </div>
 
         <section class="space-y-6">

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,8 @@ use App\Http\Controllers\MeetingController;
 use App\Http\Controllers\MitgliederController;
 use App\Http\Controllers\MitgliederKarteController;
 use App\Http\Controllers\MitgliedschaftController;
+use App\Http\Controllers\NewsletterArchivAdminController;
+use App\Http\Controllers\NewsletterArchivController;
 use App\Http\Controllers\NewsletterController;
 use App\Http\Controllers\PageController;
 use App\Http\Controllers\PhotoGalleryController;
@@ -172,6 +174,13 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
     Route::prefix('newsletter')->name('newsletter.')->controller(NewsletterController::class)->middleware('admin')->group(function () {
         Route::get('versenden', 'create')->name('create');
         Route::post('versenden', 'send')->name('send');
+    });
+
+    Route::prefix('admin/newsletter-archiv')->name('newsletter.archiv.admin.')->controller(NewsletterArchivAdminController::class)->middleware('admin')->group(function () {
+        Route::get('/', 'index')->name('index');
+        Route::get('/{newsletterAusgabe}/bearbeiten', 'edit')->name('edit');
+        Route::put('/{newsletterAusgabe}', 'update')->name('update');
+        Route::post('/{newsletterAusgabe}/veroeffentlichen', 'publish')->name('publish');
     });
 
     Route::prefix('admin/messages')->name('admin.messages.')->controller(AdminMessageController::class)->middleware('admin')->group(function () {
@@ -366,6 +375,11 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::post('/{fanfiction}/kommentar', [FanfictionCommentController::class, 'store'])->name('comments.store');
         Route::put('/kommentar/{comment}', [FanfictionCommentController::class, 'update'])->name('comments.update');
         Route::delete('/kommentar/{comment}', [FanfictionCommentController::class, 'destroy'])->name('comments.destroy');
+    });
+
+    Route::prefix('newsletter-archiv')->name('newsletter.archiv.')->controller(NewsletterArchivController::class)->group(function () {
+        Route::get('/', 'index')->name('index');
+        Route::get('/{newsletterAusgabe}', 'show')->name('show');
     });
 
     Route::prefix('rezensionen')->name('reviews.')->group(function () {

--- a/tests/Feature/NewsletterArchivSchemaTest.php
+++ b/tests/Feature/NewsletterArchivSchemaTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class NewsletterArchivSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_newsletter_ausgaben_table_has_indexes_for_archive_listings(): void
+    {
+        if (DB::getDriverName() !== 'sqlite') {
+            $this->markTestSkipped('Dieser Test prueft SQLite-Indexmetadaten.');
+        }
+
+        $indexNames = collect(DB::select("PRAGMA index_list('newsletter_ausgaben')"))
+            ->pluck('name')
+            ->all();
+
+        $this->assertContains('newsletter_ausgaben_status_published_at_sent_at_index', $indexNames);
+        $this->assertContains('newsletter_ausgaben_sent_at_created_at_index', $indexNames);
+
+        $memberListingColumns = collect(DB::select("PRAGMA index_info('newsletter_ausgaben_status_published_at_sent_at_index')"))
+            ->pluck('name')
+            ->all();
+        $adminListingColumns = collect(DB::select("PRAGMA index_info('newsletter_ausgaben_sent_at_created_at_index')"))
+            ->pluck('name')
+            ->all();
+
+        $this->assertSame(['status', 'published_at', 'sent_at'], $memberListingColumns);
+        $this->assertSame(['sent_at', 'created_at'], $adminListingColumns);
+    }
+}

--- a/tests/Feature/NewsletterArchivTest.php
+++ b/tests/Feature/NewsletterArchivTest.php
@@ -45,6 +45,26 @@ class NewsletterArchivTest extends TestCase
             ->assertSee('Diese Ausgabe enthält aktuell noch keine Themenblöcke.');
     }
 
+    public function test_newsletter_archive_index_view_handles_missing_topic_title_defensively(): void
+    {
+        $ausgabe = NewsletterAusgabe::factory()->published()->make([
+            'subject' => 'Thema ohne Titel',
+            'slug' => 'thema-ohne-titel',
+            'topics' => [
+                [
+                    'content' => 'Nur Inhalt ohne Überschrift',
+                ],
+            ],
+        ]);
+
+        $this->view('newsletter.archiv.index', [
+            'ausgaben' => new LengthAwarePaginator(collect([$ausgabe]), 1, 12),
+        ])
+            ->assertSee('Thema ohne Titel')
+            ->assertSee('Ohne Titel')
+            ->assertSee('Nur Inhalt ohne Überschrift');
+    }
+
     public function test_mitglied_can_view_published_newsletter_detail(): void
     {
         $mitglied = $this->actingMember();

--- a/tests/Feature/NewsletterArchivTest.php
+++ b/tests/Feature/NewsletterArchivTest.php
@@ -68,6 +68,34 @@ class NewsletterArchivTest extends TestCase
             ->assertNotFound();
     }
 
+    public function test_mitglied_cannot_view_vorstand_only_newsletter_archive_entry(): void
+    {
+        $mitglied = $this->actingMember();
+        $vorstandIntern = NewsletterAusgabe::factory()->published()->create([
+            'subject' => 'Nur fuer Vorstand',
+            'recipient_roles' => ['Vorstand'],
+        ]);
+        $mitgliedIntern = NewsletterAusgabe::factory()->published()->create([
+            'subject' => 'Fuer Mitglieder',
+            'recipient_roles' => ['Mitglied'],
+        ]);
+
+        $this->actingAs($mitglied)
+            ->get(route('newsletter.archiv.index'))
+            ->assertOk()
+            ->assertSee('Fuer Mitglieder')
+            ->assertDontSee('Nur fuer Vorstand');
+
+        $this->actingAs($mitglied)
+            ->get(route('newsletter.archiv.show', $vorstandIntern))
+            ->assertNotFound();
+
+        $this->actingAs($mitglied)
+            ->get(route('newsletter.archiv.show', $mitgliedIntern))
+            ->assertOk()
+            ->assertSee('Fuer Mitglieder');
+    }
+
     public function test_guest_is_redirected_from_newsletter_archive(): void
     {
         $ausgabe = NewsletterAusgabe::factory()->published()->create();

--- a/tests/Feature/NewsletterArchivTest.php
+++ b/tests/Feature/NewsletterArchivTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\NewsletterAusgabeStatus;
+use App\Models\NewsletterAusgabe;
+use App\Models\User;
+use App\Support\Navigation\NavigationBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUserWithRole;
+use Tests\TestCase;
+
+class NewsletterArchivTest extends TestCase
+{
+    use CreatesUserWithRole;
+    use RefreshDatabase;
+
+    public function test_mitglied_can_view_published_newsletter_archive_index(): void
+    {
+        $mitglied = $this->actingMember();
+        $ausgabe = NewsletterAusgabe::factory()->published()->create([
+            'subject' => 'Newsletter Mai 2026',
+        ]);
+
+        $this->actingAs($mitglied)
+            ->get(route('newsletter.archiv.index'))
+            ->assertOk()
+            ->assertSee('Newsletter Mai 2026')
+            ->assertSee(route('newsletter.archiv.show', $ausgabe), false);
+    }
+
+    public function test_mitglied_can_view_published_newsletter_detail(): void
+    {
+        $mitglied = $this->actingMember();
+        $ausgabe = NewsletterAusgabe::factory()->published()->create([
+            'subject' => 'Detailausgabe',
+            'topics' => [
+                [
+                    'title' => 'Rundschau',
+                    'content' => "Erste Zeile\nZweite Zeile",
+                ],
+            ],
+        ]);
+
+        $this->actingAs($mitglied)
+            ->get(route('newsletter.archiv.show', $ausgabe))
+            ->assertOk()
+            ->assertSee('Detailausgabe')
+            ->assertSee('Rundschau')
+            ->assertSee('Erste Zeile<br />', false)
+            ->assertSee('Zweite Zeile');
+    }
+
+    public function test_mitglieder_do_not_see_drafts_in_archive(): void
+    {
+        $mitglied = $this->actingMember();
+        $entwurf = NewsletterAusgabe::factory()->create([
+            'subject' => 'Interner Entwurf',
+        ]);
+
+        $this->actingAs($mitglied)
+            ->get(route('newsletter.archiv.index'))
+            ->assertOk()
+            ->assertDontSee('Interner Entwurf');
+
+        $this->actingAs($mitglied)
+            ->get(route('newsletter.archiv.show', $entwurf))
+            ->assertNotFound();
+    }
+
+    public function test_guest_is_redirected_from_newsletter_archive(): void
+    {
+        $ausgabe = NewsletterAusgabe::factory()->published()->create();
+
+        $this->get(route('newsletter.archiv.index'))
+            ->assertRedirect(route('login'));
+
+        $this->get(route('newsletter.archiv.show', $ausgabe))
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_authenticated_non_member_cannot_view_newsletter_archive(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('newsletter.archiv.index'))
+            ->assertForbidden();
+    }
+
+    public function test_admin_can_view_newsletter_archive_admin_index(): void
+    {
+        $admin = $this->actingMember('Admin');
+
+        NewsletterAusgabe::factory()->create(['subject' => 'Archiv Entwurf']);
+        NewsletterAusgabe::factory()->published()->create(['subject' => 'Archiv Live']);
+
+        $this->actingAs($admin)
+            ->get(route('newsletter.archiv.admin.index'))
+            ->assertOk()
+            ->assertSee('Archiv Entwurf')
+            ->assertSee('Archiv Live');
+    }
+
+    public function test_admin_can_view_newsletter_archive_edit_form(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $ausgabe = NewsletterAusgabe::factory()->create([
+            'subject' => 'Bearbeitbare Ausgabe',
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('newsletter.archiv.admin.edit', $ausgabe))
+            ->assertOk()
+            ->assertSee('Newsletter-Ausgabe bearbeiten')
+            ->assertSee('Bearbeitbare Ausgabe')
+            ->assertSee('Themenbloecke');
+    }
+
+    public function test_admin_can_update_newsletter_archive_entry(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $ausgabe = NewsletterAusgabe::factory()->create([
+            'subject' => 'Alte Ausgabe',
+            'slug' => 'alte-ausgabe',
+        ]);
+
+        $this->actingAs($admin)
+            ->put(route('newsletter.archiv.admin.update', $ausgabe), [
+                'subject' => 'Neue Ausgabe',
+                'slug' => 'neue-ausgabe',
+                'recipient_roles' => ['Mitglied', 'Vorstand'],
+                'sent_at' => '2026-05-17 12:00',
+                'topics' => [
+                    ['title' => 'Update', 'content' => 'Archivtext'],
+                ],
+            ])
+            ->assertRedirect(route('newsletter.archiv.admin.edit', $ausgabe->fresh()));
+
+        $this->assertDatabaseHas('newsletter_ausgaben', [
+            'id' => $ausgabe->id,
+            'subject' => 'Neue Ausgabe',
+            'slug' => 'neue-ausgabe',
+        ]);
+    }
+
+    public function test_admin_can_publish_newsletter_archive_entry(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $ausgabe = NewsletterAusgabe::factory()->create([
+            'status' => NewsletterAusgabeStatus::Entwurf,
+            'published_at' => null,
+        ]);
+
+        $this->actingAs($admin)
+            ->post(route('newsletter.archiv.admin.publish', $ausgabe))
+            ->assertRedirect(route('newsletter.archiv.admin.edit', $ausgabe->fresh()));
+
+        $ausgabe->refresh();
+
+        $this->assertSame(NewsletterAusgabeStatus::Veroeffentlicht, $ausgabe->status);
+        $this->assertNotNull($ausgabe->published_at);
+    }
+
+    public function test_navigation_builder_places_newsletter_archive_only_in_authenticated_verein_section(): void
+    {
+        $mitglied = $this->createUserWithRole('Mitglied');
+        $builder = app(NavigationBuilder::class);
+
+        $guestNavigation = $builder->build(null);
+        $authNavigation = $builder->build($mitglied->load('teams', 'ownedTeams'));
+
+        $guestVereinItems = $this->sectionItemTitles($guestNavigation, 'Verein');
+        $authVereinItems = $this->sectionItemTitles($authNavigation, 'Verein');
+
+        $this->assertNotContains('Newsletter-Archiv', $guestVereinItems);
+        $this->assertContains('Newsletter-Archiv', $authVereinItems);
+        $this->assertSame(
+            array_search('Protokolle', $authVereinItems, true) - 1,
+            array_search('Newsletter-Archiv', $authVereinItems, true)
+        );
+    }
+
+    public function test_newsletter_ausgaben_generate_unique_slugs_from_subject(): void
+    {
+        $ersteAusgabe = NewsletterAusgabe::factory()->create([
+            'subject' => 'Doppelter Betreff',
+            'slug' => null,
+        ]);
+        $zweiteAusgabe = NewsletterAusgabe::factory()->create([
+            'subject' => 'Doppelter Betreff',
+            'slug' => null,
+        ]);
+
+        $this->assertSame('doppelter-betreff', $ersteAusgabe->slug);
+        $this->assertSame('doppelter-betreff-2', $zweiteAusgabe->slug);
+    }
+
+    /**
+     * @param  array<string, mixed>  $navigation
+     * @return array<int, string>
+     */
+    private function sectionItemTitles(array $navigation, string $sectionTitle): array
+    {
+        $section = collect($navigation['sections'] ?? [])->firstWhere('title', $sectionTitle);
+
+        return collect($section['items'] ?? [])->pluck('title')->all();
+    }
+}

--- a/tests/Feature/NewsletterArchivTest.php
+++ b/tests/Feature/NewsletterArchivTest.php
@@ -112,6 +112,25 @@ class NewsletterArchivTest extends TestCase
             ->assertSee('Fuer Mitglieder');
     }
 
+    public function test_admin_can_view_published_newsletter_archive_entry_even_when_not_recipient(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $mitgliedIntern = NewsletterAusgabe::factory()->published()->create([
+            'subject' => 'Nur für Mitglieder sichtbar',
+            'recipient_roles' => ['Mitglied'],
+        ]);
+
+        $this->actingAs($admin)
+            ->get(route('newsletter.archiv.index'))
+            ->assertOk()
+            ->assertSee('Nur für Mitglieder sichtbar');
+
+        $this->actingAs($admin)
+            ->get(route('newsletter.archiv.show', $mitgliedIntern))
+            ->assertOk()
+            ->assertSee('Nur für Mitglieder sichtbar');
+    }
+
     public function test_guest_is_redirected_from_newsletter_archive(): void
     {
         $ausgabe = NewsletterAusgabe::factory()->published()->create();

--- a/tests/Feature/NewsletterArchivTest.php
+++ b/tests/Feature/NewsletterArchivTest.php
@@ -7,6 +7,7 @@ use App\Models\NewsletterAusgabe;
 use App\Models\User;
 use App\Support\Navigation\NavigationBuilder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Tests\Concerns\CreatesUserWithRole;
 use Tests\TestCase;
 
@@ -27,6 +28,21 @@ class NewsletterArchivTest extends TestCase
             ->assertOk()
             ->assertSee('Newsletter Mai 2026')
             ->assertSee(route('newsletter.archiv.show', $ausgabe), false);
+    }
+
+    public function test_newsletter_archive_index_view_handles_null_topics_defensively(): void
+    {
+        $ausgabe = NewsletterAusgabe::factory()->published()->make([
+            'subject' => 'Ohne Themen',
+            'slug' => 'ohne-themen',
+            'topics' => null,
+        ]);
+
+        $this->view('newsletter.archiv.index', [
+            'ausgaben' => new LengthAwarePaginator(collect([$ausgabe]), 1, 12),
+        ])
+            ->assertSee('Ohne Themen')
+            ->assertSee('Diese Ausgabe enthält aktuell noch keine Themenblöcke.');
     }
 
     public function test_mitglied_can_view_published_newsletter_detail(): void

--- a/tests/Feature/NewsletterArchivTest.php
+++ b/tests/Feature/NewsletterArchivTest.php
@@ -142,7 +142,7 @@ class NewsletterArchivTest extends TestCase
             ->assertOk()
             ->assertSee('Newsletter-Ausgabe bearbeiten')
             ->assertSee('Bearbeitbare Ausgabe')
-            ->assertSee('Themenbloecke');
+            ->assertSee('Themenblöcke');
     }
 
     public function test_admin_can_update_newsletter_archive_entry(): void
@@ -188,6 +188,32 @@ class NewsletterArchivTest extends TestCase
 
         $this->assertSame(NewsletterAusgabeStatus::Veroeffentlicht, $ausgabe->status);
         $this->assertNotNull($ausgabe->published_at);
+    }
+
+    public function test_admin_can_update_newsletter_archive_entry_without_sent_at(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $ausgabe = NewsletterAusgabe::factory()->create([
+            'subject' => 'Ohne Versandzeit',
+            'sent_at' => null,
+        ]);
+
+        $this->actingAs($admin)
+            ->put(route('newsletter.archiv.admin.update', $ausgabe), [
+                'subject' => 'Ohne Versandzeit aktualisiert',
+                'slug' => 'ohne-versandzeit-aktualisiert',
+                'recipient_roles' => ['Mitglied'],
+                'sent_at' => '',
+                'topics' => [
+                    ['title' => 'Update', 'content' => 'Weiter ohne Zeitpunkt'],
+                ],
+            ])
+            ->assertRedirect(route('newsletter.archiv.admin.edit', $ausgabe->fresh()));
+
+        $ausgabe->refresh();
+
+        $this->assertSame('Ohne Versandzeit aktualisiert', $ausgabe->subject);
+        $this->assertNull($ausgabe->sent_at);
     }
 
     public function test_navigation_builder_places_newsletter_archive_only_in_authenticated_verein_section(): void

--- a/tests/Feature/NewsletterArchivTest.php
+++ b/tests/Feature/NewsletterArchivTest.php
@@ -172,6 +172,35 @@ class NewsletterArchivTest extends TestCase
         ]);
     }
 
+    public function test_admin_can_update_newsletter_archive_entry_with_long_colliding_slug(): void
+    {
+        $admin = $this->actingMember('Admin');
+        $longSlug = str_repeat('a', 255);
+        NewsletterAusgabe::factory()->create([
+            'slug' => $longSlug,
+        ]);
+        $ausgabe = NewsletterAusgabe::factory()->create([
+            'slug' => 'kollision',
+        ]);
+
+        $this->actingAs($admin)
+            ->put(route('newsletter.archiv.admin.update', $ausgabe), [
+                'subject' => 'Lange Kollision',
+                'slug' => $longSlug,
+                'recipient_roles' => ['Mitglied'],
+                'sent_at' => '2026-05-17 12:00',
+                'topics' => [
+                    ['title' => 'Update', 'content' => 'Langer Slug mit Suffix'],
+                ],
+            ])
+            ->assertRedirect(route('newsletter.archiv.admin.edit', $ausgabe->fresh()));
+
+        $ausgabe->refresh();
+
+        $this->assertLessThanOrEqual(255, strlen($ausgabe->slug));
+        $this->assertStringEndsWith('-2', $ausgabe->slug);
+    }
+
     public function test_admin_can_publish_newsletter_archive_entry(): void
     {
         $admin = $this->actingMember('Admin');
@@ -248,6 +277,24 @@ class NewsletterArchivTest extends TestCase
 
         $this->assertSame('doppelter-betreff', $ersteAusgabe->slug);
         $this->assertSame('doppelter-betreff-2', $zweiteAusgabe->slug);
+    }
+
+    public function test_newsletter_ausgaben_truncate_generated_slugs_to_database_limit(): void
+    {
+        $longSubject = str_repeat('Extrem langer Newsletter Betreff ', 20);
+
+        $ersteAusgabe = NewsletterAusgabe::factory()->create([
+            'subject' => $longSubject,
+            'slug' => null,
+        ]);
+        $zweiteAusgabe = NewsletterAusgabe::factory()->create([
+            'subject' => $longSubject,
+            'slug' => null,
+        ]);
+
+        $this->assertLessThanOrEqual(255, strlen($ersteAusgabe->slug));
+        $this->assertLessThanOrEqual(255, strlen($zweiteAusgabe->slug));
+        $this->assertStringEndsWith('-2', $zweiteAusgabe->slug);
     }
 
     /**

--- a/tests/Feature/NewsletterControllerTest.php
+++ b/tests/Feature/NewsletterControllerTest.php
@@ -77,6 +77,24 @@ class NewsletterControllerTest extends TestCase
         $response->assertSessionHasErrors(['roles', 'subject', 'topics']);
     }
 
+    public function test_send_validation_rejects_empty_roles_array(): void
+    {
+        $admin = $this->actingMember('Admin');
+
+        $response = $this->actingAs($admin)
+            ->from(route('newsletter.create'))
+            ->post(route('newsletter.send'), [
+                'roles' => [],
+                'subject' => 'Info',
+                'topics' => [
+                    ['title' => 'A', 'content' => 'B'],
+                ],
+            ]);
+
+        $response->assertRedirect(route('newsletter.create'));
+        $response->assertSessionHasErrors(['roles']);
+    }
+
     public function test_non_admin_cannot_send_newsletter(): void
     {
         $member = $this->actingMember();
@@ -116,6 +134,29 @@ class NewsletterControllerTest extends TestCase
             return $mail->hasTo($member->email);
         });
 
+        $this->assertDatabaseCount('newsletter_ausgaben', 0);
+    }
+
+    public function test_newsletter_is_not_archived_when_selected_roles_have_no_recipients(): void
+    {
+        Mail::fake();
+
+        $admin = $this->actingMember('Admin');
+
+        $data = [
+            'roles' => ['Ehrenmitglied'],
+            'subject' => 'Info',
+            'topics' => [
+                ['title' => 'A', 'content' => 'B'],
+            ],
+        ];
+
+        $this->actingAs($admin)
+            ->post(route('newsletter.send'), $data)
+            ->assertRedirect(route('newsletter.create'))
+            ->assertSessionHas('status', 'Keine Empfänger für die ausgewählten Rollen gefunden.');
+
+        Mail::assertNothingQueued();
         $this->assertDatabaseCount('newsletter_ausgaben', 0);
     }
 }

--- a/tests/Feature/NewsletterControllerTest.php
+++ b/tests/Feature/NewsletterControllerTest.php
@@ -58,6 +58,11 @@ class NewsletterControllerTest extends TestCase
             return $mail->hasTo($board->email);
         });
         Mail::assertQueuedCount(2);
+
+        $this->assertDatabaseHas('newsletter_ausgaben', [
+            'subject' => 'Info',
+            'status' => 'entwurf',
+        ]);
     }
 
     public function test_send_validation_errors(): void
@@ -110,5 +115,7 @@ class NewsletterControllerTest extends TestCase
         Mail::assertNotQueued(Newsletter::class, function (Newsletter $mail) use ($member) {
             return $mail->hasTo($member->email);
         });
+
+        $this->assertDatabaseCount('newsletter_ausgaben', 0);
     }
 }


### PR DESCRIPTION
This pull request introduces a comprehensive newsletter archive feature. It adds a new `NewsletterAusgabe` model with associated database migrations, controllers for both admin and user-facing newsletter archive management, and updates to the newsletter sending logic. The changes centralize newsletter issue management, status handling, and role-based visibility, while also improving maintainability and consistency.

**Newsletter Archive Feature:**

* Added the `NewsletterAusgabe` model to represent newsletter issues, including logic for slugs, status, role-based visibility, and utility methods for recipient roles and unique slugs. (`app/Models/NewsletterAusgabe.php`)
* Introduced new database migrations to create the `newsletter_ausgaben` table and add listing indexes for efficient querying. (`database/migrations/2026_05_17_120000_create_newsletter_ausgaben_table.php`, `database/migrations/2026_05_17_130000_add_listing_indexes_to_newsletter_ausgaben_table.php`) [[1]](diffhunk://#diff-5dad343b012ec4f9cfcedbf4594ed72ee5e48afecf46f595d27cfb63fd1e0d6eR1-R30) [[2]](diffhunk://#diff-f3d488541b9f4175abccce197ad0f299c24528cef5e690d3783e417123c295feR1-R30)
* Added a factory for `NewsletterAusgabe` to support testing and seeding. (`database/factories/NewsletterAusgabeFactory.php`)
* Created the `NewsletterAusgabeStatus` enum to manage newsletter issue statuses (draft, published). (`app/Enums/NewsletterAusgabeStatus.php`)

**Controllers and Admin Interface:**

* Implemented `NewsletterArchivAdminController` for admin management of newsletter issues (listing, editing, updating, publishing) and `NewsletterArchivController` for user-facing archive browsing with role-based access. (`app/Http/Controllers/NewsletterArchivAdminController.php`, `app/Http/Controllers/NewsletterArchivController.php`) [[1]](diffhunk://#diff-1377f25f430db74c0fc63c7ccf36540699b510e6fd2280a581c292e426fde70bR1-R78) [[2]](diffhunk://#diff-9a63bedb8d8cc22c855cfe53605aaa06357d77c02a7dbddef7568b4d39e9be84R1-R50)
* Updated the navigation config to include a link to the newsletter archive. (`config/navigation.php`)

**Newsletter Sending Logic:**

* Refactored `NewsletterController` to use the new `NewsletterAusgabe` model for recipient roles and to store sent newsletters as issues, including status and metadata. (`app/Http/Controllers/NewsletterController.php`) [[1]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddR5-R8) [[2]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddL15-L24) [[3]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddL35-R28) [[4]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddL53-R46) [[5]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddR69-R88)

These changes lay the foundation for a robust, role-aware newsletter archive and streamline newsletter management for both administrators and users.