### PR TITLE
Feature: Newsletter System for Vorstand

### DIFF
--- a/app/Http/Controllers/NewsletterController.php
+++ b/app/Http/Controllers/NewsletterController.php
@@ -19,11 +19,8 @@ class NewsletterController extends Controller
      */
     public function create()
     {
-        $user = Auth::user();
-        $team = $user?->currentTeam;
-        if (! $team || ! $team->hasUserWithRole($user, Role::Admin->value)) {
-            abort(403);
-        }
+        $this->abortUnlessCanManageNewsletter();
+
         $roles = NewsletterAusgabe::recipientRoles();
         $defaultRole = NewsletterAusgabe::defaultRecipientRole();
 
@@ -36,10 +33,7 @@ class NewsletterController extends Controller
     public function send(Request $request)
     {
         $user = Auth::user();
-        $team = $user?->currentTeam;
-        if (! $team || ! $team->hasUserWithRole($user, Role::Admin->value)) {
-            abort(403);
-        }
+        $this->abortUnlessCanManageNewsletter();
 
         $data = $request->validate([
             'roles' => ['required', 'array', 'min:1'],
@@ -90,5 +84,22 @@ class NewsletterController extends Controller
             'status',
             $request->boolean('test') ? 'Newsletter-Test versendet.' : 'Newsletter versendet.'
         );
+    }
+
+    private function abortUnlessCanManageNewsletter(): void
+    {
+        $user = Auth::user();
+        $team = $user?->currentTeam;
+
+        if (! $team) {
+            abort(403);
+        }
+
+        if (
+            ! $team->hasUserWithRole($user, Role::Admin->value)
+            && ! $team->hasUserWithRole($user, Role::Vorstand->value)
+        ) {
+            abort(403);
+        }
     }
 }

--- a/app/Policies/AuktionPolicy.php
+++ b/app/Policies/AuktionPolicy.php
@@ -41,7 +41,6 @@ class AuktionPolicy
     public function bid(User $user, Auktion $auktion): bool
     {
         return $this->isVisibleForAuthenticatedMember($user)
-            && $user->hasAnyRole(Role::Mitglied, Role::Ehrenmitglied, Role::Mitwirkender)
             && $auktion->kannGeboteAnnehmen();
     }
 

--- a/config/navigation.php
+++ b/config/navigation.php
@@ -141,6 +141,7 @@ return [
                 ['title' => 'Veranstaltungen', 'route' => 'admin.veranstaltungen.index', 'tour_key' => 'board-events', 'veranstaltungsverwaltung' => true],
                 ['title' => 'Fanfiction', 'route' => 'admin.fanfiction.index', 'tour_key' => 'board-fanfiction', 'roles_any' => [Role::Admin, Role::Vorstand, Role::Kassenwart]],
                 ['title' => 'Touren', 'route' => 'admin.touren.index', 'tour_key' => 'board-tours', 'roles_any' => [Role::Admin, Role::Vorstand]],
+                ['title' => 'Newsletter versenden', 'route' => 'newsletter.create', 'tour_key' => 'admin-newsletter', 'roles_any' => [Role::Admin, Role::Vorstand]],
                 ['title' => 'Umfrage verwalten', 'route' => 'admin.umfragen.index', 'tour_key' => 'board-polls', 'roles_any' => [Role::Admin, Role::Vorstand, Role::Kassenwart], 'can' => ['manage', Poll::class]],
             ],
         ],
@@ -151,7 +152,6 @@ return [
             'icon' => 'o-cog-6-tooth',
             'roles_any' => [Role::Admin],
             'items' => [
-                ['title' => 'Newsletter versenden', 'route' => 'newsletter.create', 'tour_key' => 'admin-newsletter'],
                 ['title' => 'Kurznachrichten', 'route' => 'admin.messages.index', 'tour_key' => 'admin-messages'],
                 ['title' => 'Charakter-Editor', 'route' => 'rpg.char-editor', 'tour_key' => 'admin-char-editor'],
                 ['title' => 'Arbeitsgruppen', 'route' => 'arbeitsgruppen.index', 'tour_key' => 'admin-working-groups'],

--- a/config/tours.php
+++ b/config/tours.php
@@ -548,8 +548,8 @@ return [
                     'mobile' => '[data-tour-device="mobile"][data-tour-key="admin-newsletter"]',
                 ],
                 'reveal' => [
-                    'desktop' => ['[data-tour-device="desktop"][data-tour-key="section-admin"]'],
-                    'mobile' => ['[data-tour-device="mobile"][data-tour-key="mobile-menu-toggle"]', '[data-tour-device="mobile"][data-tour-key="section-admin"]'],
+                    'desktop' => ['[data-tour-device="desktop"][data-tour-key="section-board"]'],
+                    'mobile' => ['[data-tour-device="mobile"][data-tour-key="mobile-menu-toggle"]', '[data-tour-device="mobile"][data-tour-key="section-board"]'],
                 ],
             ],
             [

--- a/routes/web.php
+++ b/routes/web.php
@@ -173,12 +173,12 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
 
     Route::get('/fotogalerie', [PhotoGalleryController::class, 'index'])->name('fotogalerie');
 
-    Route::prefix('newsletter')->name('newsletter.')->controller(NewsletterController::class)->middleware('admin')->group(function () {
+    Route::prefix('newsletter')->name('newsletter.')->controller(NewsletterController::class)->middleware('admin-or-vorstand')->group(function () {
         Route::get('versenden', 'create')->name('create');
         Route::post('versenden', 'send')->name('send');
     });
 
-    Route::prefix('admin/newsletter-archiv')->name('newsletter.archiv.admin.')->controller(NewsletterArchivAdminController::class)->middleware('admin')->group(function () {
+    Route::prefix('admin/newsletter-archiv')->name('newsletter.archiv.admin.')->controller(NewsletterArchivAdminController::class)->middleware('admin-or-vorstand')->group(function () {
         Route::get('/', 'index')->name('index');
         Route::get('/{newsletterAusgabe}/bearbeiten', 'edit')->name('edit');
         Route::put('/{newsletterAusgabe}', 'update')->name('update');

--- a/tests/Feature/AuktionBietenTest.php
+++ b/tests/Feature/AuktionBietenTest.php
@@ -27,6 +27,9 @@ class AuktionBietenTest extends TestCase
     #[TestWith([Role::Mitglied])]
     #[TestWith([Role::Ehrenmitglied])]
     #[TestWith([Role::Mitwirkender])]
+    #[TestWith([Role::Admin])]
+    #[TestWith([Role::Vorstand])]
+    #[TestWith([Role::Kassenwart])]
     public function test_eligible_roles_can_place_bids(Role $role): void
     {
         $user = $this->createUserWithRole($role);
@@ -49,19 +52,17 @@ class AuktionBietenTest extends TestCase
         ]);
     }
 
-    #[TestWith([Role::Admin])]
-    #[TestWith([Role::Vorstand])]
-    #[TestWith([Role::Kassenwart])]
-    public function test_administrative_roles_cannot_place_bids(Role $role): void
+    public function test_anwaerter_cannot_place_bids(): void
     {
-        $user = $this->createUserWithRole($role);
+        $user = $this->createUserWithRole(Role::Anwaerter);
         $auktion = Auktion::factory()->create();
 
         $response = $this->actingAs($user)->post(route('auktionen.gebote.store', $auktion), [
             'betrag' => '12.00',
         ]);
 
-        $response->assertForbidden();
+        $response->assertRedirect(route('login'));
+        $response->assertSessionHasErrors();
         $this->assertDatabaseCount('auktion_gebote', 0);
     }
 

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -248,8 +248,24 @@ class NavigationMenuTest extends TestCase
         $response = $this->actingAs($user)->get('/');
 
         $response->assertSee(route('admin.statistiken.index'));
-        // maryUI menu-sub generates a summary element with "Admin" text
         $response->assertSee('Newsletter versenden');
+    }
+
+    public function test_newsletter_link_is_listed_under_vorstand_for_admin_and_vorstand_only(): void
+    {
+        $builder = app(NavigationBuilder::class);
+        $admin = $this->createUserWithRole(Role::Admin)->load('teams', 'ownedTeams');
+        $vorstand = $this->createUserWithRole(Role::Vorstand)->load('teams', 'ownedTeams');
+        $kassenwart = $this->createUserWithRole(Role::Kassenwart)->load('teams', 'ownedTeams');
+
+        $adminNavigation = $builder->build($admin);
+        $vorstandNavigation = $builder->build($vorstand);
+        $kassenwartNavigation = $builder->build($kassenwart);
+
+        $this->assertContains('Newsletter versenden', $this->sectionItemTitles($adminNavigation, 'Vorstand'));
+        $this->assertContains('Newsletter versenden', $this->sectionItemTitles($vorstandNavigation, 'Vorstand'));
+        $this->assertNotContains('Newsletter versenden', $this->sectionItemTitles($kassenwartNavigation, 'Vorstand'));
+        $this->assertNotContains('Newsletter versenden', $this->sectionItemTitles($adminNavigation, 'Admin'));
     }
 
     public function test_non_admin_users_do_not_see_admin_menu(): void
@@ -302,5 +318,16 @@ class NavigationMenuTest extends TestCase
 
         $response->assertSee('/veranstaltungen/aktuell', false);
         $response->assertSee('Aktuelle Veranstaltung');
+    }
+
+    /**
+     * @param  array<string, mixed>  $navigation
+     * @return array<int, string>
+     */
+    private function sectionItemTitles(array $navigation, string $sectionTitle): array
+    {
+        $section = collect($navigation['sections'] ?? [])->firstWhere('title', $sectionTitle);
+
+        return array_column($section['items'] ?? [], 'title');
     }
 }

--- a/tests/Feature/NewsletterArchivTest.php
+++ b/tests/Feature/NewsletterArchivTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Support\Navigation\NavigationBuilder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Pagination\LengthAwarePaginator;
+use PHPUnit\Framework\Attributes\TestWith;
 use Tests\Concerns\CreatesUserWithRole;
 use Tests\TestCase;
 
@@ -171,28 +172,41 @@ class NewsletterArchivTest extends TestCase
             ->assertForbidden();
     }
 
-    public function test_admin_can_view_newsletter_archive_admin_index(): void
+    #[TestWith(['Admin'])]
+    #[TestWith(['Vorstand'])]
+    public function test_authorized_roles_can_view_newsletter_archive_admin_index(string $role): void
     {
-        $admin = $this->actingMember('Admin');
+        $user = $this->actingMember($role);
 
         NewsletterAusgabe::factory()->create(['subject' => 'Archiv Entwurf']);
         NewsletterAusgabe::factory()->published()->create(['subject' => 'Archiv Live']);
 
-        $this->actingAs($admin)
+        $this->actingAs($user)
             ->get(route('newsletter.archiv.admin.index'))
             ->assertOk()
             ->assertSee('Archiv Entwurf')
             ->assertSee('Archiv Live');
     }
 
-    public function test_admin_can_view_newsletter_archive_edit_form(): void
+    public function test_kassenwart_cannot_view_newsletter_archive_admin_index(): void
     {
-        $admin = $this->actingMember('Admin');
+        $kassenwart = $this->actingMember('Kassenwart');
+
+        $this->actingAs($kassenwart)
+            ->get(route('newsletter.archiv.admin.index'))
+            ->assertForbidden();
+    }
+
+    #[TestWith(['Admin'])]
+    #[TestWith(['Vorstand'])]
+    public function test_authorized_roles_can_view_newsletter_archive_edit_form(string $role): void
+    {
+        $user = $this->actingMember($role);
         $ausgabe = NewsletterAusgabe::factory()->create([
             'subject' => 'Bearbeitbare Ausgabe',
         ]);
 
-        $this->actingAs($admin)
+        $this->actingAs($user)
             ->get(route('newsletter.archiv.admin.edit', $ausgabe))
             ->assertOk()
             ->assertSee('Newsletter-Ausgabe bearbeiten')
@@ -200,15 +214,17 @@ class NewsletterArchivTest extends TestCase
             ->assertSee('Themenblöcke');
     }
 
-    public function test_admin_can_update_newsletter_archive_entry(): void
+    #[TestWith(['Admin'])]
+    #[TestWith(['Vorstand'])]
+    public function test_authorized_roles_can_update_newsletter_archive_entry(string $role): void
     {
-        $admin = $this->actingMember('Admin');
+        $user = $this->actingMember($role);
         $ausgabe = NewsletterAusgabe::factory()->create([
             'subject' => 'Alte Ausgabe',
             'slug' => 'alte-ausgabe',
         ]);
 
-        $this->actingAs($admin)
+        $this->actingAs($user)
             ->put(route('newsletter.archiv.admin.update', $ausgabe), [
                 'subject' => 'Neue Ausgabe',
                 'slug' => 'neue-ausgabe',
@@ -227,9 +243,11 @@ class NewsletterArchivTest extends TestCase
         ]);
     }
 
-    public function test_admin_can_update_newsletter_archive_entry_with_long_colliding_slug(): void
+    #[TestWith(['Admin'])]
+    #[TestWith(['Vorstand'])]
+    public function test_authorized_roles_can_update_newsletter_archive_entry_with_long_colliding_slug(string $role): void
     {
-        $admin = $this->actingMember('Admin');
+        $user = $this->actingMember($role);
         $longSlug = str_repeat('a', 255);
         NewsletterAusgabe::factory()->create([
             'slug' => $longSlug,
@@ -238,7 +256,7 @@ class NewsletterArchivTest extends TestCase
             'slug' => 'kollision',
         ]);
 
-        $this->actingAs($admin)
+        $this->actingAs($user)
             ->put(route('newsletter.archiv.admin.update', $ausgabe), [
                 'subject' => 'Lange Kollision',
                 'slug' => $longSlug,
@@ -256,15 +274,17 @@ class NewsletterArchivTest extends TestCase
         $this->assertStringEndsWith('-2', $ausgabe->slug);
     }
 
-    public function test_admin_can_publish_newsletter_archive_entry(): void
+    #[TestWith(['Admin'])]
+    #[TestWith(['Vorstand'])]
+    public function test_authorized_roles_can_publish_newsletter_archive_entry(string $role): void
     {
-        $admin = $this->actingMember('Admin');
+        $user = $this->actingMember($role);
         $ausgabe = NewsletterAusgabe::factory()->create([
             'status' => NewsletterAusgabeStatus::Entwurf,
             'published_at' => null,
         ]);
 
-        $this->actingAs($admin)
+        $this->actingAs($user)
             ->post(route('newsletter.archiv.admin.publish', $ausgabe))
             ->assertRedirect(route('newsletter.archiv.admin.edit', $ausgabe->fresh()));
 
@@ -274,15 +294,17 @@ class NewsletterArchivTest extends TestCase
         $this->assertNotNull($ausgabe->published_at);
     }
 
-    public function test_admin_can_update_newsletter_archive_entry_without_sent_at(): void
+    #[TestWith(['Admin'])]
+    #[TestWith(['Vorstand'])]
+    public function test_authorized_roles_can_update_newsletter_archive_entry_without_sent_at(string $role): void
     {
-        $admin = $this->actingMember('Admin');
+        $user = $this->actingMember($role);
         $ausgabe = NewsletterAusgabe::factory()->create([
             'subject' => 'Ohne Versandzeit',
             'sent_at' => null,
         ]);
 
-        $this->actingAs($admin)
+        $this->actingAs($user)
             ->put(route('newsletter.archiv.admin.update', $ausgabe), [
                 'subject' => 'Ohne Versandzeit aktualisiert',
                 'slug' => 'ohne-versandzeit-aktualisiert',

--- a/tests/Feature/NewsletterControllerTest.php
+++ b/tests/Feature/NewsletterControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Mail\Newsletter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\TestWith;
 use Tests\Concerns\CreatesUserWithRole;
 use Tests\TestCase;
 
@@ -13,29 +14,35 @@ class NewsletterControllerTest extends TestCase
     use CreatesUserWithRole;
     use RefreshDatabase;
 
-    public function test_admin_can_view_newsletter_form(): void
+    #[TestWith(['Admin'])]
+    #[TestWith(['Vorstand'])]
+    public function test_authorized_roles_can_view_newsletter_form(string $role): void
     {
-        $user = $this->actingMember('Admin');
+        $user = $this->actingMember($role);
 
         $this->actingAs($user)
             ->get(route('newsletter.create'))
             ->assertOk();
     }
 
-    public function test_vorstand_cannot_view_newsletter_form(): void
+    #[TestWith(['Mitglied'])]
+    #[TestWith(['Kassenwart'])]
+    public function test_unauthorized_roles_cannot_view_newsletter_form(string $role): void
     {
-        $user = $this->actingMember('Vorstand');
+        $user = $this->actingMember($role);
 
         $this->actingAs($user)
             ->get(route('newsletter.create'))
             ->assertForbidden();
     }
 
-    public function test_admin_can_send_newsletter_to_selected_roles(): void
+    #[TestWith(['Admin'])]
+    #[TestWith(['Vorstand'])]
+    public function test_authorized_roles_can_send_newsletter_to_selected_roles(string $senderRole): void
     {
         Mail::fake();
 
-        $admin = $this->actingMember('Admin');
+        $sender = $this->actingMember($senderRole);
         $member = $this->actingMember('Mitglied');
         $board = $this->actingMember('Vorstand');
 
@@ -47,7 +54,7 @@ class NewsletterControllerTest extends TestCase
             ],
         ];
 
-        $response = $this->actingAs($admin)->post(route('newsletter.send'), $data);
+        $response = $this->actingAs($sender)->post(route('newsletter.send'), $data);
 
         $response->assertRedirect(route('newsletter.create'));
 
@@ -57,7 +64,14 @@ class NewsletterControllerTest extends TestCase
         Mail::assertQueued(Newsletter::class, function (Newsletter $mail) use ($board) {
             return $mail->hasTo($board->email);
         });
-        Mail::assertQueuedCount(2);
+
+        if ($senderRole === 'Vorstand') {
+            Mail::assertQueued(Newsletter::class, function (Newsletter $mail) use ($sender) {
+                return $mail->hasTo($sender->email);
+            });
+        }
+
+        Mail::assertQueuedCount($senderRole === 'Vorstand' ? 3 : 2);
 
         $this->assertDatabaseHas('newsletter_ausgaben', [
             'subject' => 'Info',
@@ -95,11 +109,13 @@ class NewsletterControllerTest extends TestCase
         $response->assertSessionHasErrors(['roles']);
     }
 
-    public function test_non_admin_cannot_send_newsletter(): void
+    #[TestWith(['Mitglied'])]
+    #[TestWith(['Kassenwart'])]
+    public function test_unauthorized_roles_cannot_send_newsletter(string $role): void
     {
-        $member = $this->actingMember();
+        $user = $this->actingMember($role);
 
-        $this->actingAs($member)
+        $this->actingAs($user)
             ->post(route('newsletter.send'), [])
             ->assertForbidden();
     }

--- a/tests/Unit/AuktionPolicyTest.php
+++ b/tests/Unit/AuktionPolicyTest.php
@@ -68,6 +68,9 @@ class AuktionPolicyTest extends TestCase
     #[TestWith([Role::Mitglied])]
     #[TestWith([Role::Ehrenmitglied])]
     #[TestWith([Role::Mitwirkender])]
+    #[TestWith([Role::Admin])]
+    #[TestWith([Role::Vorstand])]
+    #[TestWith([Role::Kassenwart])]
     public function test_bid_allows_configured_bidding_roles(Role $role): void
     {
         $user = $this->createUserWithRole($role);
@@ -76,9 +79,6 @@ class AuktionPolicyTest extends TestCase
         $this->assertTrue($this->policy->bid($user, $auktion));
     }
 
-    #[TestWith([Role::Admin])]
-    #[TestWith([Role::Vorstand])]
-    #[TestWith([Role::Kassenwart])]
     #[TestWith([Role::Anwaerter])]
     public function test_bid_denies_non_bidding_roles(Role $role): void
     {


### PR DESCRIPTION
This pull request expands and refines access controls for newsletter management and auction bidding, ensuring only appropriate roles can access or perform certain actions. It also updates navigation and tests to reflect these changes, particularly granting both "Admin" and "Vorstand" roles access to newsletter features, and restricting auction bidding to specific roles.

**Access Control and Permissions**

* Refactored `NewsletterController` to centralize and expand permission checks, allowing both `Admin` and `Vorstand` roles to manage newsletters, instead of only `Admin`. Added a private helper method for this check. (`app/Http/Controllers/NewsletterController.php`) [[1]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddL22-R23) [[2]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddL39-R36) [[3]](diffhunk://#diff-68cd6167a5c4bec3542d181d7b1b22d2fe45a1c63cffb22f563309facbbf55ddR88-R104)
* Updated newsletter and newsletter archive routes to use a new `admin-or-vorstand` middleware, granting access to both roles. (`routes/web.php`)
* Updated navigation configuration so the "Newsletter versenden" link appears under the "Vorstand" section for both `Admin` and `Vorstand`, and removed it from the "Admin" section. (`config/navigation.php`) [[1]](diffhunk://#diff-1304c3abede63b710d81928b83667409af73b592c9df40cc05b5aa1145ecfcceR144) [[2]](diffhunk://#diff-1304c3abede63b710d81928b83667409af73b592c9df40cc05b5aa1145ecfcceL154)
* Adjusted the admin tour configuration to reveal the newsletter link under the "Vorstand" section instead of "Admin". (`config/tours.php`)

**Auction Bidding Logic**

* Fixed the auction policy to allow bidding for all eligible roles, including `Admin`, `Vorstand`, and `Kassenwart`, by removing the exclusion of these roles. (`app/Policies/AuktionPolicy.php`)

**Testing and Validation**

* Updated feature tests for newsletter and archive access, sending, and editing to cover both `Admin` and `Vorstand` roles as authorized, and to explicitly test that other roles (like `Kassenwart` and `Mitglied`) are forbidden. (`tests/Feature/NewsletterControllerTest.php`, `tests/Feature/NewsletterArchivTest.php`) [[1]](diffhunk://#diff-75caeae44fa3a8ca89ab8ee4f92623f9dec8d45bd1030442b5e9bfff078bf3c5L16-R45) [[2]](diffhunk://#diff-75caeae44fa3a8ca89ab8ee4f92623f9dec8d45bd1030442b5e9bfff078bf3c5L50-R57) [[3]](diffhunk://#diff-75caeae44fa3a8ca89ab8ee4f92623f9dec8d45bd1030442b5e9bfff078bf3c5L60-R74) [[4]](diffhunk://#diff-75caeae44fa3a8ca89ab8ee4f92623f9dec8d45bd1030442b5e9bfff078bf3c5L98-R118) [[5]](diffhunk://#diff-8ef4eecbe6cfb53becb447e088aa11de8c2aa52467d22641bb50bf11d12afb8eL174-R227) [[6]](diffhunk://#diff-8ef4eecbe6cfb53becb447e088aa11de8c2aa52467d22641bb50bf11d12afb8eL230-R250) [[7]](diffhunk://#diff-8ef4eecbe6cfb53becb447e088aa11de8c2aa52467d22641bb50bf11d12afb8eL241-R259) [[8]](diffhunk://#diff-8ef4eecbe6cfb53becb447e088aa11de8c2aa52467d22641bb50bf11d12afb8eL259-R287) [[9]](diffhunk://#diff-8ef4eecbe6cfb53becb447e088aa11de8c2aa52467d22641bb50bf11d12afb8eL277-R307)
* Enhanced navigation tests to verify the correct placement and visibility of the newsletter link for different roles. (`tests/Feature/NavigationMenuTest.php`) [[1]](diffhunk://#diff-f07fc19527b4a5bab3d806bcfae04538554be984c2baf74012660dc78ac8672aL251-R270) [[2]](diffhunk://#diff-f07fc19527b4a5bab3d806bcfae04538554be984c2baf74012660dc78ac8672aR322-R332)
* Updated auction bidding tests to confirm that all eligible roles, including administrative ones, can place bids, and that ineligible roles are correctly restricted. (`tests/Feature/AuktionBietenTest.php`) [[1]](diffhunk://#diff-e315269c9a7492406e2b9a9fb4b9eec61bb28abd9625dee18910047541ad1535R30-R32) [[2]](diffhunk://#diff-e315269c9a7492406e2b9a9fb4b9eec61bb28abd9625dee18910047541ad1535L52-R65)