### PR TITLE
Fix: Nextcloud photos not shown in Fotogalerie

### DIFF
--- a/app/Http/Controllers/PhotoGalleryController.php
+++ b/app/Http/Controllers/PhotoGalleryController.php
@@ -8,17 +8,6 @@ use Illuminate\Support\Facades\Log;
 
 class PhotoGalleryController extends Controller
 {
-    /**
-     * @var array<int, string>
-     */
-    private const ALLOWED_PROXY_IMAGE_CONTENT_TYPES = [
-        'image/jpeg',
-        'image/png',
-        'image/webp',
-        'image/gif',
-        'image/avif',
-    ];
-
     public function __construct(
         private readonly NextcloudGalleryService $galleryService,
     ) {}
@@ -165,9 +154,9 @@ SVG;
 
     private function proxiedImageContentType(string $photoUrl, string $responseContentType): string
     {
-        $normalizedContentType = strtolower(trim(explode(';', $responseContentType)[0] ?? ''));
+        $normalizedContentType = $this->galleryService->normalizeAllowedImageContentType($responseContentType);
 
-        if (in_array($normalizedContentType, self::ALLOWED_PROXY_IMAGE_CONTENT_TYPES, true)) {
+        if ($normalizedContentType !== null) {
             return $normalizedContentType;
         }
 

--- a/app/Http/Controllers/PhotoGalleryController.php
+++ b/app/Http/Controllers/PhotoGalleryController.php
@@ -35,7 +35,7 @@ class PhotoGalleryController extends Controller
             return $this->getFallbackPhotos($year);
         }
 
-        $photoUrls = $this->galleryService->photoUrls($baseUrl, 'nextcloud_gallery:'.$year.':'.sha1($baseUrl));
+        $photoUrls = $this->galleryService->photoUrls($baseUrl);
 
         if (empty($photoUrls)) {
             return $this->getFallbackPhotos($year);
@@ -124,7 +124,7 @@ SVG;
             return $this->placeholderResponse($year, $index);
         }
 
-        $photoUrl = $this->galleryService->photoUrlForIndex($baseUrl, $index, 'nextcloud_gallery:'.$year.':'.sha1($baseUrl));
+        $photoUrl = $this->galleryService->photoUrlForIndex($baseUrl, $index);
 
         if ($photoUrl === null) {
             return $this->placeholderResponse($year, $index);

--- a/app/Http/Controllers/PhotoGalleryController.php
+++ b/app/Http/Controllers/PhotoGalleryController.php
@@ -8,6 +8,17 @@ use Illuminate\Support\Facades\Log;
 
 class PhotoGalleryController extends Controller
 {
+    /**
+     * @var array<int, string>
+     */
+    private const ALLOWED_PROXY_IMAGE_CONTENT_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'image/gif',
+        'image/avif',
+    ];
+
     public function __construct(
         private readonly NextcloudGalleryService $galleryService,
     ) {}
@@ -156,7 +167,7 @@ SVG;
     {
         $normalizedContentType = strtolower(trim(explode(';', $responseContentType)[0] ?? ''));
 
-        if (str_starts_with($normalizedContentType, 'image/')) {
+        if (in_array($normalizedContentType, self::ALLOWED_PROXY_IMAGE_CONTENT_TYPES, true)) {
             return $normalizedContentType;
         }
 

--- a/app/Http/Controllers/PhotoGalleryController.php
+++ b/app/Http/Controllers/PhotoGalleryController.php
@@ -135,7 +135,7 @@ SVG;
 
             if ($response->successful()) {
                 return response($response->body(), 200)
-                    ->header('Content-Type', 'image/jpeg')
+                    ->header('Content-Type', $this->proxiedImageContentType($photoUrl, (string) $response->header('Content-Type')))
                     ->header('Cache-Control', 'public, max-age=86400'); // 1 Tag cachen
             }
         } catch (\Exception $e) {
@@ -150,5 +150,22 @@ SVG;
         return response($this->placeholderSvg($year, $index), 200)
             ->header('Content-Type', 'image/svg+xml')
             ->header('Cache-Control', 'public, max-age=86400');
+    }
+
+    private function proxiedImageContentType(string $photoUrl, string $responseContentType): string
+    {
+        $normalizedContentType = strtolower(trim(explode(';', $responseContentType)[0] ?? ''));
+
+        if (str_starts_with($normalizedContentType, 'image/')) {
+            return $normalizedContentType;
+        }
+
+        return match (strtolower(pathinfo((string) parse_url($photoUrl, PHP_URL_PATH), PATHINFO_EXTENSION))) {
+            'png' => 'image/png',
+            'webp' => 'image/webp',
+            'gif' => 'image/gif',
+            'avif' => 'image/avif',
+            default => 'image/jpeg',
+        };
     }
 }

--- a/app/Http/Controllers/PhotoGalleryController.php
+++ b/app/Http/Controllers/PhotoGalleryController.php
@@ -2,10 +2,16 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\NextcloudGalleryService;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 
 class PhotoGalleryController extends Controller
 {
+    public function __construct(
+        private readonly NextcloudGalleryService $galleryService,
+    ) {}
+
     public function index()
     {
         $photoBaseUrls = $this->photoBaseUrls();
@@ -23,56 +29,19 @@ class PhotoGalleryController extends Controller
      */
     private function getPhotosForYear(string $year, ?string $baseUrl = null): array
     {
-        $photoUrls = [];
-
         $baseUrl ??= $this->photoBaseUrls()[$year] ?? '';
 
         if (empty($baseUrl)) {
             return $this->getFallbackPhotos($year);
         }
 
-        // Fotos mit einer Schleife laden und abbrechen, wenn ein Foto nicht existiert
-        $maxTries = 5; // Sicherheitslimit
-        $index = 1;
+        $photoUrls = $this->galleryService->photoUrls($baseUrl, 'nextcloud_gallery:'.$year.':'.sha1($baseUrl));
 
-        while ($index <= $maxTries) {
-            $photoUrl = $baseUrl.$index.'.jpg';
-
-            if ($this->photoExists($photoUrl)) {
-                $photoUrls[] = $photoUrl;
-                $index++;
-            } else {
-                // Wenn ein Foto nicht existiert, brechen wir die Schleife ab
-                break;
-            }
-        }
-
-        // Cache die Anzahl der Fotos für zukünftige Anfragen
-        // (optional - könnte in einer Datenbank oder Cache gespeichert werden)
-        // Cache::put('photo_count_' . $year, count($photoUrls), now()->addDay());
-
-        // Wenn keine Fotos gefunden wurden, Fallback verwenden
         if (empty($photoUrls)) {
             return $this->getFallbackPhotos($year);
         }
 
         return $photoUrls;
-    }
-
-    /**
-     * Prüft, ob ein Foto unter der angegebenen URL existiert
-     */
-    private function photoExists(string $url): bool
-    {
-        try {
-            $response = Http::timeout(5)->head($url);
-
-            return $response->successful();
-        } catch (\Exception $e) {
-            \Log::error('Fehler beim Prüfen des Fotos: '.$e->getMessage());
-
-            return false;
-        }
     }
 
     /**
@@ -155,7 +124,11 @@ SVG;
             return $this->placeholderResponse($year, $index);
         }
 
-        $photoUrl = $baseUrl.$index.'.jpg';
+        $photoUrl = $this->galleryService->photoUrlForIndex($baseUrl, $index, 'nextcloud_gallery:'.$year.':'.sha1($baseUrl));
+
+        if ($photoUrl === null) {
+            return $this->placeholderResponse($year, $index);
+        }
 
         try {
             $response = Http::timeout(10)->get($photoUrl);
@@ -166,7 +139,7 @@ SVG;
                     ->header('Cache-Control', 'public, max-age=86400'); // 1 Tag cachen
             }
         } catch (\Exception $e) {
-            \Log::error('Fehler beim Proxy-Aufruf: '.$e->getMessage());
+            Log::error('Fehler beim Proxy-Aufruf: '.$e->getMessage());
         }
 
         return $this->placeholderResponse($year, $index);

--- a/app/Services/NextcloudGalleryService.php
+++ b/app/Services/NextcloudGalleryService.php
@@ -73,6 +73,19 @@ XML;
         return $this->photoUrls($galleryLink)[$index - 1] ?? null;
     }
 
+    public function normalizeAllowedImageContentType(string $contentType): ?string
+    {
+        $normalizedContentType = $this->normalizeContentType($contentType);
+
+        if ($normalizedContentType === null) {
+            return null;
+        }
+
+        return in_array($normalizedContentType, self::ALLOWED_IMAGE_CONTENT_TYPES, true)
+            ? $normalizedContentType
+            : null;
+    }
+
     private function cacheKey(string $galleryLink): string
     {
         return 'nextcloud_gallery:'.sha1($galleryLink);
@@ -312,9 +325,7 @@ XML;
 
     private function isImageResource(string $basename, string $contentType): bool
     {
-        $normalizedContentType = $this->normalizeContentType($contentType);
-
-        if ($normalizedContentType !== null && in_array($normalizedContentType, self::ALLOWED_IMAGE_CONTENT_TYPES, true)) {
+        if ($this->normalizeAllowedImageContentType($contentType) !== null) {
             return true;
         }
 
@@ -336,8 +347,9 @@ XML;
         }
 
         $query = parse_url($href, PHP_URL_QUERY);
+        $normalizedQuery = $this->normalizeQueryString($query);
 
-        return $origin.$path.($this->normalizeQueryString($query) !== null ? '?'.$this->normalizeQueryString($query) : '');
+        return $origin.$path.($normalizedQuery !== null ? '?'.$normalizedQuery : '');
     }
 
     private function normalizeQueryString(mixed $query): ?string

--- a/app/Services/NextcloudGalleryService.php
+++ b/app/Services/NextcloudGalleryService.php
@@ -15,6 +15,17 @@ class NextcloudGalleryService
 
     private const EMPTY_LISTING_CACHE_MINUTES = 2;
 
+    /**
+     * @var array<int, string>
+     */
+    private const ALLOWED_IMAGE_CONTENT_TYPES = [
+        'image/jpeg',
+        'image/png',
+        'image/webp',
+        'image/gif',
+        'image/avif',
+    ];
+
     private const PROPFIND_BODY = <<<'XML'
 <?xml version="1.0" encoding="UTF-8"?>
 <d:propfind xmlns:d="DAV:">
@@ -301,7 +312,9 @@ XML;
 
     private function isImageResource(string $basename, string $contentType): bool
     {
-        if (str_starts_with($contentType, 'image/')) {
+        $normalizedContentType = $this->normalizeContentType($contentType);
+
+        if ($normalizedContentType !== null && in_array($normalizedContentType, self::ALLOWED_IMAGE_CONTENT_TYPES, true)) {
             return true;
         }
 
@@ -398,5 +411,12 @@ XML;
     private function containsForbiddenXmlDeclarations(string $xml): bool
     {
         return preg_match('/<!DOCTYPE|<!ENTITY/i', $xml) === 1;
+    }
+
+    private function normalizeContentType(string $contentType): ?string
+    {
+        $normalizedContentType = strtolower(trim(explode(';', $contentType)[0] ?? ''));
+
+        return $normalizedContentType !== '' ? $normalizedContentType : null;
     }
 }

--- a/app/Services/NextcloudGalleryService.php
+++ b/app/Services/NextcloudGalleryService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use DateTimeInterface;
 use DOMDocument;
 use DOMXPath;
 use Illuminate\Support\Facades\Cache;
@@ -10,6 +11,10 @@ use Illuminate\Support\Facades\Log;
 
 class NextcloudGalleryService
 {
+    private const SUCCESSFUL_LISTING_CACHE_MINUTES = 30;
+
+    private const EMPTY_LISTING_CACHE_MINUTES = 2;
+
     /**
      * @return array<int, string>
      */
@@ -21,11 +26,21 @@ class NextcloudGalleryService
             return [];
         }
 
-        return Cache::remember(
-            $cacheKey ?? $this->cacheKey($galleryLink),
-            now()->addMinutes(30),
-            fn (): array => $this->fetchPhotoUrls($galleryLink),
-        );
+        $cacheKey ??= $this->cacheKey($galleryLink);
+
+        $cachedPhotoUrls = Cache::get($cacheKey);
+
+        if (is_array($cachedPhotoUrls)) {
+            return $cachedPhotoUrls;
+        }
+
+        $result = $this->fetchPhotoUrls($galleryLink);
+
+        if ($result['cache_until'] instanceof DateTimeInterface) {
+            Cache::put($cacheKey, $result['urls'], $result['cache_until']);
+        }
+
+        return $result['urls'];
     }
 
     public function photoUrlForIndex(string $galleryLink, int $index, ?string $cacheKey = null): ?string
@@ -48,7 +63,7 @@ class NextcloudGalleryService
     }
 
     /**
-     * @return array<int, string>
+     * @return array{urls: array<int, string>, cache_until: ?DateTimeInterface}
      */
     private function fetchPhotoUrls(string $galleryLink): array
     {
@@ -57,7 +72,10 @@ class NextcloudGalleryService
         $configuration = $this->resolveListingConfiguration($galleryLink);
 
         if ($configuration === null) {
-            return [];
+            return [
+                'urls' => [],
+                'cache_until' => null,
+            ];
         }
 
         try {
@@ -67,7 +85,10 @@ class NextcloudGalleryService
                 ->send('PROPFIND', $configuration['directory_url']);
 
             if (! $response->successful()) {
-                return [];
+                return [
+                    'urls' => [],
+                    'cache_until' => null,
+                ];
             }
         } catch (\Throwable $throwable) {
             Log::warning('Fehler beim Laden der Nextcloud-Fotogalerie', [
@@ -75,14 +96,31 @@ class NextcloudGalleryService
                 'message' => $throwable->getMessage(),
             ]);
 
-            return [];
+            return [
+                'urls' => [],
+                'cache_until' => null,
+            ];
         }
 
-        return $this->parsePhotoUrls(
+        $photoUrls = $this->parsePhotoUrls(
             $response->body(),
             $configuration['origin'],
             $configuration['filename_prefix'],
         );
+
+        if ($photoUrls === null) {
+            return [
+                'urls' => [],
+                'cache_until' => null,
+            ];
+        }
+
+        return [
+            'urls' => $photoUrls,
+            'cache_until' => empty($photoUrls)
+                ? now()->addMinutes(self::EMPTY_LISTING_CACHE_MINUTES)
+                : now()->addMinutes(self::SUCCESSFUL_LISTING_CACHE_MINUTES),
+        ];
     }
 
     /**
@@ -138,9 +176,9 @@ class NextcloudGalleryService
     }
 
     /**
-     * @return array<int, string>
+     * @return array<int, string>|null
      */
-    private function parsePhotoUrls(string $xml, string $origin, ?string $filenamePrefix): array
+    private function parsePhotoUrls(string $xml, string $origin, ?string $filenamePrefix): ?array
     {
         $dom = new DOMDocument('1.0', 'UTF-8');
 
@@ -150,7 +188,7 @@ class NextcloudGalleryService
         libxml_use_internal_errors($previousState);
 
         if (! $loaded) {
-            return [];
+            return null;
         }
 
         $xpath = new DOMXPath($dom);
@@ -180,7 +218,13 @@ class NextcloudGalleryService
                 continue;
             }
 
-            $urls[] = $this->toAbsoluteUrl($origin, $href);
+            $url = $this->toAbsoluteUrl($origin, $href);
+
+            if ($url === null) {
+                continue;
+            }
+
+            $urls[] = $url;
         }
 
         $urls = array_values(array_unique($urls));
@@ -207,12 +251,71 @@ class NextcloudGalleryService
         return in_array($extension, ['jpg', 'jpeg', 'png', 'webp', 'gif', 'avif'], true);
     }
 
-    private function toAbsoluteUrl(string $origin, string $href): string
+    private function toAbsoluteUrl(string $origin, string $href): ?string
     {
         if (preg_match('#^https?://#i', $href) === 1) {
-            return $href;
+            return $this->sameOriginDavUrl($origin, $href) ? $href : null;
         }
 
-        return $origin.'/'.ltrim($href, '/');
+        $path = $this->normalizeDavPath((string) parse_url($href, PHP_URL_PATH));
+
+        if ($path === null) {
+            return null;
+        }
+
+        $query = parse_url($href, PHP_URL_QUERY);
+
+        return $origin.$path.($query !== null ? '?'.$query : '');
+    }
+
+    private function sameOriginDavUrl(string $origin, string $href): bool
+    {
+        $originParts = parse_url($origin);
+        $hrefParts = parse_url($href);
+
+        if (! is_array($originParts) || ! is_array($hrefParts)) {
+            return false;
+        }
+
+        if (! isset($originParts['scheme'], $originParts['host'], $hrefParts['scheme'], $hrefParts['host'])) {
+            return false;
+        }
+
+        if (strtolower($originParts['scheme']) !== strtolower($hrefParts['scheme'])) {
+            return false;
+        }
+
+        if (strtolower($originParts['host']) !== strtolower($hrefParts['host'])) {
+            return false;
+        }
+
+        if ($this->normalizedPort($originParts) !== $this->normalizedPort($hrefParts)) {
+            return false;
+        }
+
+        return $this->normalizeDavPath((string) ($hrefParts['path'] ?? '')) !== null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $parts
+     */
+    private function normalizedPort(array $parts): int
+    {
+        if (isset($parts['port'])) {
+            return (int) $parts['port'];
+        }
+
+        return strtolower((string) ($parts['scheme'] ?? 'https')) === 'http' ? 80 : 443;
+    }
+
+    private function normalizeDavPath(string $path): ?string
+    {
+        $normalizedPath = '/'.ltrim($path, '/');
+
+        if (! str_starts_with($normalizedPath, '/public.php/dav/files/')) {
+            return null;
+        }
+
+        return $normalizedPath;
     }
 }

--- a/app/Services/NextcloudGalleryService.php
+++ b/app/Services/NextcloudGalleryService.php
@@ -28,7 +28,7 @@ XML;
     /**
      * @return array<int, string>
      */
-    public function photoUrls(string $galleryLink, ?string $cacheKey = null): array
+    public function photoUrls(string $galleryLink): array
     {
         $galleryLink = $this->sanitizeGalleryLink($galleryLink);
 
@@ -36,7 +36,7 @@ XML;
             return [];
         }
 
-        $cacheKey ??= $this->cacheKey($galleryLink);
+        $cacheKey = $this->cacheKey($galleryLink);
 
         $cachedPhotoUrls = Cache::get($cacheKey);
 
@@ -53,13 +53,13 @@ XML;
         return $result['urls'];
     }
 
-    public function photoUrlForIndex(string $galleryLink, int $index, ?string $cacheKey = null): ?string
+    public function photoUrlForIndex(string $galleryLink, int $index): ?string
     {
         if ($index < 1) {
             return null;
         }
 
-        return $this->photoUrls($galleryLink, $cacheKey)[$index - 1] ?? null;
+        return $this->photoUrls($galleryLink)[$index - 1] ?? null;
     }
 
     private function cacheKey(string $galleryLink): string
@@ -191,10 +191,16 @@ XML;
      */
     private function parsePhotoUrls(string $xml, string $origin, ?string $filenamePrefix): ?array
     {
+        if ($this->containsForbiddenXmlDeclarations($xml)) {
+            return null;
+        }
+
         $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->resolveExternals = false;
+        $dom->substituteEntities = false;
 
         $previousState = libxml_use_internal_errors(true);
-        $loaded = $dom->loadXML($xml);
+        $loaded = $dom->loadXML($xml, LIBXML_NONET);
         libxml_clear_errors();
         libxml_use_internal_errors($previousState);
 
@@ -328,5 +334,10 @@ XML;
         }
 
         return $normalizedPath;
+    }
+
+    private function containsForbiddenXmlDeclarations(string $xml): bool
+    {
+        return preg_match('/<!DOCTYPE|<!ENTITY/i', $xml) === 1;
     }
 }

--- a/app/Services/NextcloudGalleryService.php
+++ b/app/Services/NextcloudGalleryService.php
@@ -79,15 +79,51 @@ XML;
     {
         $galleryLink = $this->sanitizeGalleryLink($galleryLink);
 
-        $configuration = $this->resolveListingConfiguration($galleryLink);
+        $configurations = $this->resolveListingConfigurations($galleryLink);
 
-        if ($configuration === null) {
+        if ($configurations === []) {
             return [
                 'urls' => [],
                 'cache_until' => null,
             ];
         }
 
+        foreach ($configurations as $configuration) {
+            $attempt = $this->fetchListingAttempt($galleryLink, $configuration);
+
+            if ($attempt['status'] === 'not_found') {
+                continue;
+            }
+
+            if ($attempt['status'] === 'error') {
+                return [
+                    'urls' => [],
+                    'cache_until' => null,
+                ];
+            }
+
+            $photoUrls = $attempt['urls'];
+
+            return [
+                'urls' => $photoUrls,
+                'cache_until' => empty($photoUrls)
+                    ? now()->addMinutes(self::EMPTY_LISTING_CACHE_MINUTES)
+                    : now()->addMinutes(self::SUCCESSFUL_LISTING_CACHE_MINUTES),
+            ];
+        }
+
+        return [
+            'urls' => [],
+            'cache_until' => null,
+        ];
+    }
+
+    /**
+     * @param  array{directory_url: string, origin: string, filename_prefix: ?string}  $configuration
+     * @return array{status: 'success', urls: array<int, string>}|array{status: 'not_found'}|array{status: 'error'}
+     */
+    private function fetchListingAttempt(string $galleryLink, array $configuration): array
+    {
         try {
             $response = Http::timeout(10)
                 ->accept('application/xml, text/xml, */*')
@@ -95,22 +131,21 @@ XML;
                 ->withHeaders(['Depth' => '1'])
                 ->send('PROPFIND', $configuration['directory_url']);
 
+            if ($response->status() === 404) {
+                return ['status' => 'not_found'];
+            }
+
             if (! $response->successful()) {
-                return [
-                    'urls' => [],
-                    'cache_until' => null,
-                ];
+                return ['status' => 'error'];
             }
         } catch (\Throwable $throwable) {
             Log::warning('Fehler beim Laden der Nextcloud-Fotogalerie', [
                 'link' => $galleryLink,
+                'directory_url' => $configuration['directory_url'],
                 'message' => $throwable->getMessage(),
             ]);
 
-            return [
-                'urls' => [],
-                'cache_until' => null,
-            ];
+            return ['status' => 'error'];
         }
 
         $photoUrls = $this->parsePhotoUrls(
@@ -120,58 +155,54 @@ XML;
         );
 
         if ($photoUrls === null) {
-            return [
-                'urls' => [],
-                'cache_until' => null,
-            ];
+            return ['status' => 'error'];
         }
 
         return [
+            'status' => 'success',
             'urls' => $photoUrls,
-            'cache_until' => empty($photoUrls)
-                ? now()->addMinutes(self::EMPTY_LISTING_CACHE_MINUTES)
-                : now()->addMinutes(self::SUCCESSFUL_LISTING_CACHE_MINUTES),
         ];
     }
 
     /**
-     * @return array{directory_url: string, origin: string, filename_prefix: ?string}|null
+     * @return array<int, array{directory_url: string, origin: string, filename_prefix: ?string}>
      */
-    private function resolveListingConfiguration(string $galleryLink): ?array
+    private function resolveListingConfigurations(string $galleryLink): array
     {
         $parts = parse_url($galleryLink);
 
         if (! isset($parts['scheme'], $parts['host'], $parts['path'])) {
-            return null;
+            return [];
         }
 
         $origin = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
         $path = $parts['path'];
 
         if (preg_match('#^/s/([^/]+)/?$#', $path, $matches) === 1) {
-            return [
+            return [[
                 'directory_url' => $origin.'/public.php/dav/files/'.$matches[1].'/',
                 'origin' => $origin,
                 'filename_prefix' => null,
-            ];
+            ]];
         }
 
         if (preg_match('#^/public\.php/dav/files/([^/]+)(?:/(.*))?$#', $path, $matches) !== 1) {
-            return null;
+            return [];
         }
 
         $token = $matches[1];
         $suffix = $matches[2] ?? '';
 
         if ($suffix === '' || str_ends_with($path, '/')) {
-            return [
+            return [[
                 'directory_url' => $origin.'/public.php/dav/files/'.$token.'/'.ltrim($suffix, '/'),
                 'origin' => $origin,
                 'filename_prefix' => null,
-            ];
+            ]];
         }
 
-        $segments = explode('/', trim($suffix, '/'));
+        $normalizedSuffix = trim($suffix, '/');
+        $segments = explode('/', $normalizedSuffix);
         $filenamePrefix = array_pop($segments);
         $directoryPath = '/public.php/dav/files/'.$token.'/';
 
@@ -180,9 +211,16 @@ XML;
         }
 
         return [
-            'directory_url' => $origin.$directoryPath,
-            'origin' => $origin,
-            'filename_prefix' => $filenamePrefix,
+            [
+                'directory_url' => $origin.'/public.php/dav/files/'.$token.'/'.$normalizedSuffix.'/',
+                'origin' => $origin,
+                'filename_prefix' => null,
+            ],
+            [
+                'directory_url' => $origin.$directoryPath,
+                'origin' => $origin,
+                'filename_prefix' => $filenamePrefix,
+            ],
         ];
     }
 
@@ -331,6 +369,14 @@ XML;
 
         if (! str_starts_with($normalizedPath, '/public.php/dav/files/')) {
             return null;
+        }
+
+        foreach (explode('/', $normalizedPath) as $segment) {
+            $decodedSegment = rawurldecode($segment);
+
+            if ($decodedSegment === '.' || $decodedSegment === '..') {
+                return null;
+            }
         }
 
         return $normalizedPath;

--- a/app/Services/NextcloudGalleryService.php
+++ b/app/Services/NextcloudGalleryService.php
@@ -171,6 +171,10 @@ XML;
     {
         $parts = parse_url($galleryLink);
 
+        if (! is_array($parts)) {
+            return [];
+        }
+
         if (! isset($parts['scheme'], $parts['host'], $parts['path'])) {
             return [];
         }
@@ -320,7 +324,16 @@ XML;
 
         $query = parse_url($href, PHP_URL_QUERY);
 
-        return $origin.$path.($query !== null ? '?'.$query : '');
+        return $origin.$path.($this->normalizeQueryString($query) !== null ? '?'.$this->normalizeQueryString($query) : '');
+    }
+
+    private function normalizeQueryString(mixed $query): ?string
+    {
+        if (! is_string($query) || $query === '') {
+            return null;
+        }
+
+        return $query;
     }
 
     private function sameOriginDavUrl(string $origin, string $href): bool

--- a/app/Services/NextcloudGalleryService.php
+++ b/app/Services/NextcloudGalleryService.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace App\Services;
+
+use DOMDocument;
+use DOMXPath;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class NextcloudGalleryService
+{
+    /**
+     * @return array<int, string>
+     */
+    public function photoUrls(string $galleryLink, ?string $cacheKey = null): array
+    {
+        $galleryLink = $this->sanitizeGalleryLink($galleryLink);
+
+        if ($galleryLink === '') {
+            return [];
+        }
+
+        return Cache::remember(
+            $cacheKey ?? $this->cacheKey($galleryLink),
+            now()->addMinutes(30),
+            fn (): array => $this->fetchPhotoUrls($galleryLink),
+        );
+    }
+
+    public function photoUrlForIndex(string $galleryLink, int $index, ?string $cacheKey = null): ?string
+    {
+        if ($index < 1) {
+            return null;
+        }
+
+        return $this->photoUrls($galleryLink, $cacheKey)[$index - 1] ?? null;
+    }
+
+    private function cacheKey(string $galleryLink): string
+    {
+        return 'nextcloud_gallery:'.sha1($galleryLink);
+    }
+
+    private function sanitizeGalleryLink(string $galleryLink): string
+    {
+        return trim($galleryLink, " \t\n\r\0\x0B\"'");
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function fetchPhotoUrls(string $galleryLink): array
+    {
+        $galleryLink = $this->sanitizeGalleryLink($galleryLink);
+
+        $configuration = $this->resolveListingConfiguration($galleryLink);
+
+        if ($configuration === null) {
+            return [];
+        }
+
+        try {
+            $response = Http::timeout(10)
+                ->accept('application/xml, text/xml, */*')
+                ->withHeaders(['Depth' => '1'])
+                ->send('PROPFIND', $configuration['directory_url']);
+
+            if (! $response->successful()) {
+                return [];
+            }
+        } catch (\Throwable $throwable) {
+            Log::warning('Fehler beim Laden der Nextcloud-Fotogalerie', [
+                'link' => $galleryLink,
+                'message' => $throwable->getMessage(),
+            ]);
+
+            return [];
+        }
+
+        return $this->parsePhotoUrls(
+            $response->body(),
+            $configuration['origin'],
+            $configuration['filename_prefix'],
+        );
+    }
+
+    /**
+     * @return array{directory_url: string, origin: string, filename_prefix: ?string}|null
+     */
+    private function resolveListingConfiguration(string $galleryLink): ?array
+    {
+        $parts = parse_url($galleryLink);
+
+        if (! isset($parts['scheme'], $parts['host'], $parts['path'])) {
+            return null;
+        }
+
+        $origin = $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '');
+        $path = $parts['path'];
+
+        if (preg_match('#^/s/([^/]+)/?$#', $path, $matches) === 1) {
+            return [
+                'directory_url' => $origin.'/public.php/dav/files/'.$matches[1].'/',
+                'origin' => $origin,
+                'filename_prefix' => null,
+            ];
+        }
+
+        if (preg_match('#^/public\.php/dav/files/([^/]+)(?:/(.*))?$#', $path, $matches) !== 1) {
+            return null;
+        }
+
+        $token = $matches[1];
+        $suffix = $matches[2] ?? '';
+
+        if ($suffix === '' || str_ends_with($path, '/')) {
+            return [
+                'directory_url' => $origin.'/public.php/dav/files/'.$token.'/'.ltrim($suffix, '/'),
+                'origin' => $origin,
+                'filename_prefix' => null,
+            ];
+        }
+
+        $segments = explode('/', trim($suffix, '/'));
+        $filenamePrefix = array_pop($segments);
+        $directoryPath = '/public.php/dav/files/'.$token.'/';
+
+        if ($segments !== []) {
+            $directoryPath .= implode('/', $segments).'/';
+        }
+
+        return [
+            'directory_url' => $origin.$directoryPath,
+            'origin' => $origin,
+            'filename_prefix' => $filenamePrefix,
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function parsePhotoUrls(string $xml, string $origin, ?string $filenamePrefix): array
+    {
+        $dom = new DOMDocument('1.0', 'UTF-8');
+
+        $previousState = libxml_use_internal_errors(true);
+        $loaded = $dom->loadXML($xml);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousState);
+
+        if (! $loaded) {
+            return [];
+        }
+
+        $xpath = new DOMXPath($dom);
+        $xpath->registerNamespace('d', 'DAV:');
+
+        $urls = [];
+
+        foreach ($xpath->query('/d:multistatus/d:response') as $response) {
+            $href = trim((string) $xpath->evaluate('string(d:href)', $response));
+
+            if ($href === '' || str_ends_with($href, '/')) {
+                continue;
+            }
+
+            $basename = basename(rawurldecode((string) parse_url($href, PHP_URL_PATH)));
+
+            if ($filenamePrefix !== null && ! str_starts_with($basename, $filenamePrefix)) {
+                continue;
+            }
+
+            $contentType = strtolower(trim((string) $xpath->evaluate(
+                'string(d:propstat[d:status[contains(., "200")]]/d:prop/d:getcontenttype)',
+                $response,
+            )));
+
+            if (! $this->isImageResource($basename, $contentType)) {
+                continue;
+            }
+
+            $urls[] = $this->toAbsoluteUrl($origin, $href);
+        }
+
+        $urls = array_values(array_unique($urls));
+
+        usort(
+            $urls,
+            static fn (string $left, string $right): int => strnatcasecmp(
+                basename(rawurldecode((string) parse_url($left, PHP_URL_PATH))),
+                basename(rawurldecode((string) parse_url($right, PHP_URL_PATH))),
+            ),
+        );
+
+        return $urls;
+    }
+
+    private function isImageResource(string $basename, string $contentType): bool
+    {
+        if (str_starts_with($contentType, 'image/')) {
+            return true;
+        }
+
+        $extension = strtolower(pathinfo($basename, PATHINFO_EXTENSION));
+
+        return in_array($extension, ['jpg', 'jpeg', 'png', 'webp', 'gif', 'avif'], true);
+    }
+
+    private function toAbsoluteUrl(string $origin, string $href): string
+    {
+        if (preg_match('#^https?://#i', $href) === 1) {
+            return $href;
+        }
+
+        return $origin.'/'.ltrim($href, '/');
+    }
+}

--- a/app/Services/NextcloudGalleryService.php
+++ b/app/Services/NextcloudGalleryService.php
@@ -15,6 +15,16 @@ class NextcloudGalleryService
 
     private const EMPTY_LISTING_CACHE_MINUTES = 2;
 
+    private const PROPFIND_BODY = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<d:propfind xmlns:d="DAV:">
+    <d:prop>
+        <d:resourcetype/>
+        <d:getcontenttype/>
+    </d:prop>
+</d:propfind>
+XML;
+
     /**
      * @return array<int, string>
      */
@@ -81,6 +91,7 @@ class NextcloudGalleryService
         try {
             $response = Http::timeout(10)
                 ->accept('application/xml, text/xml, */*')
+                ->withBody(self::PROPFIND_BODY, 'application/xml')
                 ->withHeaders(['Depth' => '1'])
                 ->send('PROPFIND', $configuration['directory_url']);
 

--- a/config/services.php
+++ b/config/services.php
@@ -37,9 +37,9 @@ return [
     'nextcloud' => [
         'links' => [
             '2026' => env('NEXTCLOUD_LINK_2026', ''),
-            '2025' => env('NEXTCLOUD_LINK_2025', 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto'),
-            '2024' => env('NEXTCLOUD_LINK_2024', 'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto'),
-            '2023' => env('NEXTCLOUD_LINK_2023', 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto'),
+            '2025' => env('NEXTCLOUD_LINK_2025', 'https://cloud.maddrax-fanclub.de/s/jnGa6sEecKa3fiX'),
+            '2024' => env('NEXTCLOUD_LINK_2024', 'https://cloud.maddrax-fanclub.de/s/tztWY5ML5XMRWPw'),
+            '2023' => env('NEXTCLOUD_LINK_2023', 'https://cloud.maddrax-fanclub.de/s/jjpfnJbgStE8LcQ'),
         ],
     ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3005,9 +3005,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001792",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-            "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+            "version": "1.0.30001793",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/tests/Feature/PhotoGalleryControllerTest.php
+++ b/tests/Feature/PhotoGalleryControllerTest.php
@@ -18,19 +18,21 @@ class PhotoGalleryControllerTest extends TestCase
     {
         parent::setUp();
 
-        config()->set('services.nextcloud.links', [
-            '2026' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto',
-            '2025' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto',
-            '2024' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto',
-            '2023' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto',
-        ]);
+        config(['services.nextcloud.links' => [
+            '2026' => 'https://cloud.maddrax-fanclub.de/s/fotos2026Token',
+            '2025' => 'https://cloud.maddrax-fanclub.de/s/jnGa6sEecKa3fiX',
+            '2024' => 'https://cloud.maddrax-fanclub.de/s/tztWY5ML5XMRWPw',
+            '2023' => 'https://cloud.maddrax-fanclub.de/s/jjpfnJbgStE8LcQ',
+        ]]);
     }
 
     public function test_index_loads_photos_for_years(): void
     {
         Http::fake([
-            'cloud.maddrax-fanclub.de/*1.jpg' => Http::response('', 200),
-            'cloud.maddrax-fanclub.de/*2.jpg' => Http::response('', 404),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/' => Http::response($this->propfindResponse('fotos2026Token', ['Foto10.jpg', 'Foto2.jpg', 'Foto1.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/' => Http::response($this->propfindResponse('jnGa6sEecKa3fiX', ['Foto1.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/' => Http::response($this->propfindResponse('tztWY5ML5XMRWPw', ['Foto1.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/' => Http::response($this->propfindResponse('jjpfnJbgStE8LcQ', ['Foto1.jpg']), 207),
         ]);
 
         $this->actingAs($this->actingMember());
@@ -43,6 +45,8 @@ class PhotoGalleryControllerTest extends TestCase
 
         $photos = $response->viewData('photos');
         $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto1.jpg', $photos['2026'][0]);
+        $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto2.jpg', $photos['2026'][1]);
+        $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto10.jpg', $photos['2026'][2]);
         $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto1.jpg', $photos['2025'][0]);
         $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto1.jpg', $photos['2024'][0]);
         $this->assertEquals('https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto1.jpg', $photos['2023'][0]);
@@ -51,7 +55,7 @@ class PhotoGalleryControllerTest extends TestCase
     public function test_index_uses_fallback_when_no_photos_found(): void
     {
         Http::fake([
-            'cloud.maddrax-fanclub.de/*1.jpg' => Http::response('', 404),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/*/' => Http::response($this->propfindResponse('leer', ['notizen.txt'], includeImages: false), 207),
         ]);
 
         $this->actingAs($this->actingMember());
@@ -70,16 +74,16 @@ class PhotoGalleryControllerTest extends TestCase
 
     public function test_index_filters_years_without_configured_links(): void
     {
-        config()->set('services.nextcloud.links', [
+        config(['services.nextcloud.links' => [
             '2026' => '',
-            '2025' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto',
+            '2025' => 'https://cloud.maddrax-fanclub.de/s/jnGa6sEecKa3fiX',
             '2024' => '',
-            '2023' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto',
-        ]);
+            '2023' => 'https://cloud.maddrax-fanclub.de/s/jjpfnJbgStE8LcQ',
+        ]]);
 
         Http::fake([
-            'cloud.maddrax-fanclub.de/*1.jpg' => Http::response('', 200),
-            'cloud.maddrax-fanclub.de/*2.jpg' => Http::response('', 404),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/' => Http::response($this->propfindResponse('jnGa6sEecKa3fiX', ['Foto1.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/' => Http::response($this->propfindResponse('jjpfnJbgStE8LcQ', ['Foto1.jpg']), 207),
         ]);
 
         $this->actingAs($this->actingMember());
@@ -97,7 +101,8 @@ class PhotoGalleryControllerTest extends TestCase
     public function test_proxy_image_returns_remote_file(): void
     {
         Http::fake([
-            'cloud.maddrax-fanclub.de/*Foto1.jpg' => Http::response('img', 200, ['Content-Type' => 'image/jpeg']),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/' => Http::response($this->propfindResponse('fotos2026Token', ['Foto1.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto1.jpg' => Http::response('img', 200, ['Content-Type' => 'image/jpeg']),
         ]);
 
         $response = app(PhotoGalleryController::class)->proxyImage('2026', 1);
@@ -110,7 +115,8 @@ class PhotoGalleryControllerTest extends TestCase
     public function test_proxy_image_returns_placeholder_on_failure(): void
     {
         Http::fake([
-            'cloud.maddrax-fanclub.de/*Foto1.jpg' => Http::response('', 404),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/' => Http::response($this->propfindResponse('fotos2026Token', ['Foto1.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto1.jpg' => Http::response('', 404),
         ]);
 
         $response = app(PhotoGalleryController::class)->proxyImage('2026', 1);
@@ -119,5 +125,45 @@ class PhotoGalleryControllerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('image/svg+xml', $response->headers->get('Content-Type'));
         $this->assertStringContainsString('2026', $response->getContent());
+    }
+
+    private function propfindResponse(string $token, array $files, bool $includeImages = true): string
+    {
+        $responses = [<<<XML
+<d:response>
+    <d:href>/public.php/dav/files/{$token}/</d:href>
+    <d:propstat>
+        <d:prop>
+            <d:resourcetype><d:collection/></d:resourcetype>
+        </d:prop>
+        <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+</d:response>
+XML];
+
+        foreach ($files as $file) {
+            $contentType = $includeImages ? 'image/jpeg' : 'text/plain';
+
+            $responses[] = <<<XML
+<d:response>
+    <d:href>/public.php/dav/files/{$token}/{$file}</d:href>
+    <d:propstat>
+        <d:prop>
+            <d:getcontenttype>{$contentType}</d:getcontenttype>
+        </d:prop>
+        <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+</d:response>
+XML;
+        }
+
+        $items = implode('', $responses);
+
+        return <<<XML
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+    {$items}
+</d:multistatus>
+XML;
     }
 }

--- a/tests/Feature/PhotoGalleryControllerTest.php
+++ b/tests/Feature/PhotoGalleryControllerTest.php
@@ -101,14 +101,28 @@ class PhotoGalleryControllerTest extends TestCase
     public function test_proxy_image_returns_remote_file(): void
     {
         Http::fake([
-            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/' => Http::response($this->propfindResponse('fotos2026Token', ['Foto1.jpg']), 207),
-            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto1.jpg' => Http::response('img', 200, ['Content-Type' => 'image/jpeg']),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/' => Http::response($this->propfindResponse('fotos2026Token', ['Foto1.webp']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto1.webp' => Http::response('img', 200, ['Content-Type' => 'image/webp; charset=binary']),
         ]);
 
         $response = app(PhotoGalleryController::class)->proxyImage('2026', 1);
 
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('image/jpeg', $response->headers->get('Content-Type'));
+        $this->assertEquals('image/webp', $response->headers->get('Content-Type'));
+        $this->assertEquals('img', $response->getContent());
+    }
+
+    public function test_proxy_image_falls_back_to_extension_based_content_type_when_remote_type_is_invalid(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/' => Http::response($this->propfindResponse('fotos2026Token', ['Foto1.png']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto1.png' => Http::response('img', 200, ['Content-Type' => 'application/octet-stream']),
+        ]);
+
+        $response = app(PhotoGalleryController::class)->proxyImage('2026', 1);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('image/png', $response->headers->get('Content-Type'));
         $this->assertEquals('img', $response->getContent());
     }
 

--- a/tests/Feature/PhotoGalleryControllerTest.php
+++ b/tests/Feature/PhotoGalleryControllerTest.php
@@ -126,6 +126,20 @@ class PhotoGalleryControllerTest extends TestCase
         $this->assertEquals('img', $response->getContent());
     }
 
+    public function test_proxy_image_does_not_forward_non_whitelisted_image_content_types(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/' => Http::response($this->propfindResponse('fotos2026Token', ['Foto1.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto1.jpg' => Http::response('img', 200, ['Content-Type' => 'image/svg+xml']),
+        ]);
+
+        $response = app(PhotoGalleryController::class)->proxyImage('2026', 1);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('image/jpeg', $response->headers->get('Content-Type'));
+        $this->assertEquals('img', $response->getContent());
+    }
+
     public function test_proxy_image_returns_placeholder_on_failure(): void
     {
         Http::fake([

--- a/tests/Feature/PhotoGalleryPageTest.php
+++ b/tests/Feature/PhotoGalleryPageTest.php
@@ -16,19 +16,21 @@ class PhotoGalleryPageTest extends TestCase
     {
         parent::setUp();
 
-        config()->set('services.nextcloud.links', [
-            '2026' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/Foto',
-            '2025' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/Foto',
-            '2024' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/Foto',
-            '2023' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/Foto',
-        ]);
+        config(['services.nextcloud.links' => [
+            '2026' => 'https://cloud.maddrax-fanclub.de/s/fotos2026Token',
+            '2025' => 'https://cloud.maddrax-fanclub.de/s/jnGa6sEecKa3fiX',
+            '2024' => 'https://cloud.maddrax-fanclub.de/s/tztWY5ML5XMRWPw',
+            '2023' => 'https://cloud.maddrax-fanclub.de/s/jjpfnJbgStE8LcQ',
+        ]]);
     }
 
     public function test_photo_gallery_page_shows_context_and_year_overview(): void
     {
         Http::fake([
-            'cloud.maddrax-fanclub.de/*1.jpg' => Http::response('', 200),
-            'cloud.maddrax-fanclub.de/*2.jpg' => Http::response('', 404),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/fotos2026Token/' => Http::response($this->propfindResponse('fotos2026Token', ['Foto1.jpg', 'Foto2.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/jnGa6sEecKa3fiX/' => Http::response($this->propfindResponse('jnGa6sEecKa3fiX', ['Foto1.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/tztWY5ML5XMRWPw/' => Http::response($this->propfindResponse('tztWY5ML5XMRWPw', ['Foto1.jpg']), 207),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/jjpfnJbgStE8LcQ/' => Http::response($this->propfindResponse('jjpfnJbgStE8LcQ', ['Foto1.jpg']), 207),
         ]);
 
         $this->actingAs($this->actingMember());
@@ -42,5 +44,44 @@ class PhotoGalleryPageTest extends TestCase
         $response->assertSeeText('Hinweise zur Galerie');
         $response->assertSeeText('Fotos 2026');
         $response->assertSeeText('Fotos 2025');
+        $response->assertSeeText('5 Bilder');
+    }
+
+    private function propfindResponse(string $token, array $files): string
+    {
+        $responses = [<<<XML
+<d:response>
+    <d:href>/public.php/dav/files/{$token}/</d:href>
+    <d:propstat>
+        <d:prop>
+            <d:resourcetype><d:collection/></d:resourcetype>
+        </d:prop>
+        <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+</d:response>
+XML];
+
+        foreach ($files as $file) {
+            $responses[] = <<<XML
+<d:response>
+    <d:href>/public.php/dav/files/{$token}/{$file}</d:href>
+    <d:propstat>
+        <d:prop>
+            <d:getcontenttype>image/jpeg</d:getcontenttype>
+        </d:prop>
+        <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+</d:response>
+XML;
+        }
+
+        $items = implode('', $responses);
+
+        return <<<XML
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+    {$items}
+</d:multistatus>
+XML;
     }
 }

--- a/tests/Unit/Services/NextcloudGalleryServiceTest.php
+++ b/tests/Unit/Services/NextcloudGalleryServiceTest.php
@@ -175,6 +175,25 @@ class NextcloudGalleryServiceTest extends TestCase
         ], $photos);
     }
 
+    #[Test]
+    public function photo_urls_reject_doctype_responses_and_do_not_cache_them(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::sequence()
+                ->push($this->propfindResponseWithDoctype('shareToken', ['Foto1.jpg']), 207)
+                ->push($this->propfindResponse('shareToken', ['Foto1.jpg']), 207),
+        ]);
+
+        $service = app(NextcloudGalleryService::class);
+
+        $this->assertSame([], $service->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken'));
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
+        ], $service->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken'));
+
+        Http::assertSentCount(2);
+    }
+
     private function propfindResponse(string $token, array $files): string
     {
         $entries = array_map(
@@ -186,6 +205,17 @@ class NextcloudGalleryServiceTest extends TestCase
         );
 
         return $this->propfindResponseWithEntries('/public.php/dav/files/'.$token.'/', $entries);
+    }
+
+    private function propfindResponseWithDoctype(string $token, array $files): string
+    {
+        $xml = $this->propfindResponse($token, $files);
+
+        return str_replace(
+            '<?xml version="1.0"?>',
+            "<?xml version=\"1.0\"?>\n<!DOCTYPE multistatus [<!ELEMENT multistatus ANY>]>",
+            $xml,
+        );
     }
 
     /**

--- a/tests/Unit/Services/NextcloudGalleryServiceTest.php
+++ b/tests/Unit/Services/NextcloudGalleryServiceTest.php
@@ -102,6 +102,17 @@ class NextcloudGalleryServiceTest extends TestCase
     }
 
     #[Test]
+    public function photo_urls_ignore_malformed_gallery_links_without_http_requests(): void
+    {
+        Http::fake();
+
+        $photos = app(NextcloudGalleryService::class)->photoUrls('http://example.com:bad/path');
+
+        $this->assertSame([], $photos);
+        Http::assertNothingSent();
+    }
+
+    #[Test]
     public function photo_urls_cache_the_resolved_listing(): void
     {
         Http::fake([
@@ -233,6 +244,28 @@ class NextcloudGalleryServiceTest extends TestCase
 
         $this->assertSame([
             'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto3.jpg',
+        ], $photos);
+    }
+
+    #[Test]
+    public function photo_urls_do_not_append_trailing_question_mark_for_empty_query_parts(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
+                $this->propfindResponseWithEntries('/public.php/dav/files/shareToken/', [
+                    [
+                        'href' => '/public.php/dav/files/shareToken/Foto1.jpg?#fragment',
+                        'contentType' => 'image/jpeg',
+                    ],
+                ]),
+                207,
+            ),
+        ]);
+
+        $photos = app(NextcloudGalleryService::class)->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken');
+
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
         ], $photos);
     }
 

--- a/tests/Unit/Services/NextcloudGalleryServiceTest.php
+++ b/tests/Unit/Services/NextcloudGalleryServiceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Services;
 
 use App\Services\NextcloudGalleryService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -36,6 +37,15 @@ class NextcloudGalleryServiceTest extends TestCase
             'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto2.jpg',
             'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto10.jpg',
         ], $photos);
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->method() === 'PROPFIND'
+                && $request->url() === 'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/'
+                && in_array('1', $request->header('Depth'), true)
+                && str_contains($request->header('Content-Type')[0] ?? '', 'application/xml')
+                && str_contains($request->body(), '<d:resourcetype/>')
+                && str_contains($request->body(), '<d:getcontenttype/>');
+        });
     }
 
     #[Test]

--- a/tests/Unit/Services/NextcloudGalleryServiceTest.php
+++ b/tests/Unit/Services/NextcloudGalleryServiceTest.php
@@ -79,6 +79,50 @@ class NextcloudGalleryServiceTest extends TestCase
     }
 
     #[Test]
+    public function photo_urls_do_not_cache_transient_failures(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::sequence()
+                ->push('', 503)
+                ->push($this->propfindResponse('shareToken', ['Foto1.jpg']), 207),
+        ]);
+
+        $service = app(NextcloudGalleryService::class);
+
+        $this->assertSame([], $service->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken'));
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
+        ], $service->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken'));
+
+        Http::assertSentCount(2);
+    }
+
+    #[Test]
+    public function photo_urls_cache_empty_listings_only_briefly(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::sequence()
+                ->push($this->propfindResponse('shareToken', ['Hinweis.txt']), 207)
+                ->push($this->propfindResponse('shareToken', ['Foto1.jpg']), 207),
+        ]);
+
+        $service = app(NextcloudGalleryService::class);
+
+        $this->assertSame([], $service->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken'));
+        $this->assertSame([], $service->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken'));
+
+        Http::assertSentCount(1);
+
+        $this->travel(121)->seconds();
+
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
+        ], $service->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken'));
+
+        Http::assertSentCount(2);
+    }
+
+    #[Test]
     public function photo_urls_trim_accidental_quotes_from_links(): void
     {
         Http::fake([
@@ -95,11 +139,53 @@ class NextcloudGalleryServiceTest extends TestCase
         ], $photos);
     }
 
+    #[Test]
+    public function photo_urls_ignore_external_absolute_hrefs(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
+                $this->propfindResponseWithEntries('/public.php/dav/files/shareToken/', [
+                    [
+                        'href' => 'https://evil.example/steal.jpg',
+                        'contentType' => 'image/jpeg',
+                    ],
+                    [
+                        'href' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
+                        'contentType' => 'image/jpeg',
+                    ],
+                ]),
+                207,
+            ),
+        ]);
+
+        $photos = app(NextcloudGalleryService::class)->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken');
+
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
+        ], $photos);
+    }
+
     private function propfindResponse(string $token, array $files): string
+    {
+        $entries = array_map(
+            fn (string $file): array => [
+                'href' => '/public.php/dav/files/'.$token.'/'.$file,
+                'contentType' => str_ends_with(strtolower($file), '.txt') ? 'text/plain' : 'image/jpeg',
+            ],
+            $files,
+        );
+
+        return $this->propfindResponseWithEntries('/public.php/dav/files/'.$token.'/', $entries);
+    }
+
+    /**
+     * @param  array<int, array{href: string, contentType: string}>  $entries
+     */
+    private function propfindResponseWithEntries(string $collectionHref, array $entries): string
     {
         $responses = [<<<XML
 <d:response>
-    <d:href>/public.php/dav/files/{$token}/</d:href>
+    <d:href>{$collectionHref}</d:href>
     <d:propstat>
         <d:prop>
             <d:resourcetype><d:collection/></d:resourcetype>
@@ -109,15 +195,13 @@ class NextcloudGalleryServiceTest extends TestCase
 </d:response>
 XML];
 
-        foreach ($files as $file) {
-            $contentType = str_ends_with(strtolower($file), '.txt') ? 'text/plain' : 'image/jpeg';
-
+        foreach ($entries as $entry) {
             $responses[] = <<<XML
 <d:response>
-    <d:href>/public.php/dav/files/{$token}/{$file}</d:href>
+    <d:href>{$entry['href']}</d:href>
     <d:propstat>
         <d:prop>
-            <d:getcontenttype>{$contentType}</d:getcontenttype>
+            <d:getcontenttype>{$entry['contentType']}</d:getcontenttype>
         </d:prop>
         <d:status>HTTP/1.1 200 OK</d:status>
     </d:propstat>

--- a/tests/Unit/Services/NextcloudGalleryServiceTest.php
+++ b/tests/Unit/Services/NextcloudGalleryServiceTest.php
@@ -52,6 +52,7 @@ class NextcloudGalleryServiceTest extends TestCase
     public function photo_urls_support_legacy_dav_prefix_links(): void
     {
         Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto/' => Http::response('', 404),
             'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
                 $this->propfindResponse('shareToken', [
                     'Banner1.jpg',
@@ -68,6 +69,36 @@ class NextcloudGalleryServiceTest extends TestCase
             'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
             'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto2.jpg',
         ], $photos);
+
+        Http::assertSentCount(2);
+    }
+
+    #[Test]
+    public function photo_urls_treat_suffix_without_trailing_slash_as_directory_before_prefix_fallback(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/some-folder/' => Http::response(
+                $this->propfindResponseWithEntries('/public.php/dav/files/shareToken/some-folder/', [
+                    [
+                        'href' => '/public.php/dav/files/shareToken/some-folder/Foto1.jpg',
+                        'contentType' => 'image/jpeg',
+                    ],
+                ]),
+                207,
+            ),
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
+                $this->propfindResponse('shareToken', ['Foto9.jpg']),
+                207,
+            ),
+        ]);
+
+        $photos = app(NextcloudGalleryService::class)->photoUrls('https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/some-folder');
+
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/some-folder/Foto1.jpg',
+        ], $photos);
+
+        Http::assertSentCount(1);
     }
 
     #[Test]
@@ -172,6 +203,36 @@ class NextcloudGalleryServiceTest extends TestCase
 
         $this->assertSame([
             'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
+        ], $photos);
+    }
+
+    #[Test]
+    public function photo_urls_ignore_traversal_segments_in_dav_hrefs(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
+                $this->propfindResponseWithEntries('/public.php/dav/files/shareToken/', [
+                    [
+                        'href' => '/public.php/dav/files/shareToken/../other-token/Foto1.jpg',
+                        'contentType' => 'image/jpeg',
+                    ],
+                    [
+                        'href' => 'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/%2E%2E/other-token/Foto2.jpg',
+                        'contentType' => 'image/jpeg',
+                    ],
+                    [
+                        'href' => '/public.php/dav/files/shareToken/Foto3.jpg',
+                        'contentType' => 'image/jpeg',
+                    ],
+                ]),
+                207,
+            ),
+        ]);
+
+        $photos = app(NextcloudGalleryService::class)->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken');
+
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto3.jpg',
         ], $photos);
     }
 

--- a/tests/Unit/Services/NextcloudGalleryServiceTest.php
+++ b/tests/Unit/Services/NextcloudGalleryServiceTest.php
@@ -218,6 +218,32 @@ class NextcloudGalleryServiceTest extends TestCase
     }
 
     #[Test]
+    public function photo_urls_ignore_non_whitelisted_image_content_types(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
+                $this->propfindResponseWithEntries('/public.php/dav/files/shareToken/', [
+                    [
+                        'href' => '/public.php/dav/files/shareToken/vector.svg',
+                        'contentType' => 'image/svg+xml; charset=utf-8',
+                    ],
+                    [
+                        'href' => '/public.php/dav/files/shareToken/Foto1.webp',
+                        'contentType' => 'image/webp; charset=binary',
+                    ],
+                ]),
+                207,
+            ),
+        ]);
+
+        $photos = app(NextcloudGalleryService::class)->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken');
+
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.webp',
+        ], $photos);
+    }
+
+    #[Test]
     public function photo_urls_ignore_traversal_segments_in_dav_hrefs(): void
     {
         Http::fake([

--- a/tests/Unit/Services/NextcloudGalleryServiceTest.php
+++ b/tests/Unit/Services/NextcloudGalleryServiceTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\NextcloudGalleryService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+#[CoversClass(NextcloudGalleryService::class)]
+class NextcloudGalleryServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function photo_urls_resolve_share_links_and_sort_images_naturally(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
+                $this->propfindResponse('shareToken', [
+                    'Foto10.jpg',
+                    'Foto2.jpg',
+                    'Foto1.jpg',
+                    'Hinweis.txt',
+                ]),
+                207,
+            ),
+        ]);
+
+        $photos = app(NextcloudGalleryService::class)->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken');
+
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto2.jpg',
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto10.jpg',
+        ], $photos);
+    }
+
+    #[Test]
+    public function photo_urls_support_legacy_dav_prefix_links(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
+                $this->propfindResponse('shareToken', [
+                    'Banner1.jpg',
+                    'Foto2.jpg',
+                    'Foto1.jpg',
+                ]),
+                207,
+            ),
+        ]);
+
+        $photos = app(NextcloudGalleryService::class)->photoUrls('https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto');
+
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto2.jpg',
+        ], $photos);
+    }
+
+    #[Test]
+    public function photo_urls_cache_the_resolved_listing(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
+                $this->propfindResponse('shareToken', ['Foto1.jpg']),
+                207,
+            ),
+        ]);
+
+        $service = app(NextcloudGalleryService::class);
+
+        $service->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken');
+        $service->photoUrls('https://cloud.maddrax-fanclub.de/s/shareToken');
+
+        Http::assertSentCount(1);
+    }
+
+    #[Test]
+    public function photo_urls_trim_accidental_quotes_from_links(): void
+    {
+        Http::fake([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/' => Http::response(
+                $this->propfindResponse('shareToken', ['Foto1.jpg']),
+                207,
+            ),
+        ]);
+
+        $photos = app(NextcloudGalleryService::class)->photoUrls("'https://cloud.maddrax-fanclub.de/s/shareToken'");
+
+        $this->assertSame([
+            'https://cloud.maddrax-fanclub.de/public.php/dav/files/shareToken/Foto1.jpg',
+        ], $photos);
+    }
+
+    private function propfindResponse(string $token, array $files): string
+    {
+        $responses = [<<<XML
+<d:response>
+    <d:href>/public.php/dav/files/{$token}/</d:href>
+    <d:propstat>
+        <d:prop>
+            <d:resourcetype><d:collection/></d:resourcetype>
+        </d:prop>
+        <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+</d:response>
+XML];
+
+        foreach ($files as $file) {
+            $contentType = str_ends_with(strtolower($file), '.txt') ? 'text/plain' : 'image/jpeg';
+
+            $responses[] = <<<XML
+<d:response>
+    <d:href>/public.php/dav/files/{$token}/{$file}</d:href>
+    <d:propstat>
+        <d:prop>
+            <d:getcontenttype>{$contentType}</d:getcontenttype>
+        </d:prop>
+        <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+</d:response>
+XML;
+        }
+
+        $items = implode('', $responses);
+
+        return <<<XML
+<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+    {$items}
+</d:multistatus>
+XML;
+    }
+}


### PR DESCRIPTION
This pull request refactors how the photo gallery retrieves and proxies images from Nextcloud, centralizing logic into the `NextcloudGalleryService` and improving how image content types are handled. It also updates configuration and tests to match the new Nextcloud share link format and enhances test coverage for edge cases.

Key changes:

**Photo retrieval and proxy logic refactor:**
* The `PhotoGalleryController` now delegates photo URL retrieval and index-based lookup to the `NextcloudGalleryService`, removing manual looping and existence checks for images. (`app/Http/Controllers/PhotoGalleryController.php`) [[1]](diffhunk://#diff-811c5f12e9b7316d0554815260842f2b2afa0e5ef0708befb4736c6c65f1ff28R5-R14) [[2]](diffhunk://#diff-811c5f12e9b7316d0554815260842f2b2afa0e5ef0708befb4736c6c65f1ff28L26-L77)
* A new method, `proxiedImageContentType`, determines the correct `Content-Type` for proxied images, preferring allowed types from the remote response or falling back to file extension heuristics. (`app/Http/Controllers/PhotoGalleryController.php`) [[1]](diffhunk://#diff-811c5f12e9b7316d0554815260842f2b2afa0e5ef0708befb4736c6c65f1ff28L158-R142) [[2]](diffhunk://#diff-811c5f12e9b7316d0554815260842f2b2afa0e5ef0708befb4736c6c65f1ff28R154-R170)

**Configuration updates:**
* Nextcloud share links in `config/services.php` and related tests are updated to use the `/s/{token}` format instead of the older `/public.php/dav/files/{token}/Foto` path. (`config/services.php`, `tests/Feature/PhotoGalleryControllerTest.php`, `tests/Feature/PhotoGalleryPageTest.php`) [[1]](diffhunk://#diff-a7bf72e66282b81a3685555cf2fa6fbb80ba61953539e8d6e80b603eb58e0709L40-R42) [[2]](diffhunk://#diff-abcd860dbe79495115b6dae455f9188f4e3ee6b66f4f8dc106467a3817597203L21-R35) [[3]](diffhunk://#diff-b6ffa36409da7fa1a51acd3173794cc141cdc37cbceec841bd2c6f271d27e98bL19-R33)

**Testing improvements:**
* Test cases now mock Nextcloud WebDAV PROPFIND responses to simulate file listings and content types, enabling more robust and realistic testing of the gallery logic. (`tests/Feature/PhotoGalleryControllerTest.php`, `tests/Feature/PhotoGalleryPageTest.php`) [[1]](diffhunk://#diff-abcd860dbe79495115b6dae455f9188f4e3ee6b66f4f8dc106467a3817597203L21-R35) [[2]](diffhunk://#diff-b6ffa36409da7fa1a51acd3173794cc141cdc37cbceec841bd2c6f271d27e98bL19-R33) [[3]](diffhunk://#diff-abcd860dbe79495115b6dae455f9188f4e3ee6b66f4f8dc106467a3817597203R157-R196) [[4]](diffhunk://#diff-b6ffa36409da7fa1a51acd3173794cc141cdc37cbceec841bd2c6f271d27e98bR47-R85)
* Additional tests verify correct handling of various image content types, fallback logic when remote types are invalid, and that only whitelisted image types are proxied. (`tests/Feature/PhotoGalleryControllerTest.php`)

These changes improve maintainability, robustness, and correctness of the photo gallery’s integration with Nextcloud.