### PR TITLE
Fix: Tour navigation not working

### DIFF
--- a/resources/js/tours/runner.js
+++ b/resources/js/tours/runner.js
@@ -19,6 +19,7 @@ const state = {
     stepIndex: 0,
     target: null,
     lastSyncedStepKey: null,
+    skippedStepKeys: new Set(),
 };
 
 const elementIds = {
@@ -113,7 +114,31 @@ function hideRunner(resetPayload = false) {
         state.steps = [];
         state.stepIndex = 0;
         state.lastSyncedStepKey = null;
+        state.skippedStepKeys.clear();
     }
+}
+
+function activeSteps(device) {
+    if (!state.payload) {
+        return [];
+    }
+
+    const steps = state.payload.steps.filter((step) => !state.skippedStepKeys.has(step?.key));
+
+    return filterReachableSteps(steps, device, document);
+}
+
+function skipHiddenStep(stepKey) {
+    state.skippedStepKeys.add(stepKey);
+    state.steps = state.steps.filter((step) => step?.key !== stepKey);
+
+    if (!state.payload) {
+        return state.steps;
+    }
+
+    state.payload.steps = state.payload.steps.filter((step) => step?.key !== stepKey);
+
+    return state.steps;
 }
 
 function updateHighlight(target) {
@@ -212,7 +237,7 @@ async function showCurrentStep() {
     }
 
     const device = detectTourDevice();
-    state.steps = filterReachableSteps(state.payload.steps, device, document);
+    state.steps = activeSteps(device);
 
     if (state.steps.length === 0) {
         hideRunner(false);
@@ -232,14 +257,15 @@ async function showCurrentStep() {
     const target = document.querySelector(selectorForStep(step, device));
 
     if (!(target instanceof HTMLElement) || !isElementVisible(target)) {
-        state.steps = state.steps.filter((candidate) => candidate.key !== step.key);
+        const fallbackIndex = state.stepIndex;
+        state.steps = skipHiddenStep(step.key);
 
         if (state.steps.length === 0) {
             hideRunner(false);
             return;
         }
 
-        state.stepIndex = Math.min(state.stepIndex, state.steps.length - 1);
+        state.stepIndex = Math.min(fallbackIndex, state.steps.length - 1);
         const fallbackStep = state.steps[state.stepIndex];
 
         if (fallbackStep && state.payload) {
@@ -262,6 +288,7 @@ async function showCurrentStep() {
 async function activateTour(payload) {
     state.payload = payload;
     state.lastSyncedStepKey = payload.current_step_key ?? null;
+    state.skippedStepKeys.clear();
 
     const templates = currentUrlTemplates();
 

--- a/resources/js/tours/runner.js
+++ b/resources/js/tours/runner.js
@@ -240,6 +240,13 @@ async function showCurrentStep() {
         }
 
         state.stepIndex = Math.min(state.stepIndex, state.steps.length - 1);
+        const fallbackStep = state.steps[state.stepIndex];
+
+        if (fallbackStep && state.payload) {
+            state.payload.current_step_key = fallbackStep.key;
+            state.lastSyncedStepKey = null;
+        }
+
         await showCurrentStep();
         return;
     }

--- a/tests/Vitest/tour-runner.test.js
+++ b/tests/Vitest/tour-runner.test.js
@@ -4,114 +4,157 @@ async function flushAsyncWork() {
     await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-describe('tour runner', () => {
-    it('springt bei unsichtbaren Schritten auf den naechsten sichtbaren Schritt', async () => {
-        document.body.innerHTML = `
-            <div
-                id="tour-runner-root"
-                data-tour-current-url="/tour/current"
-                data-tour-start-url-template="/tour/__TOUR_ASSIGNMENT__/start"
-                data-tour-progress-url-template="/tour/__TOUR_ASSIGNMENT__/progress"
-                data-tour-dismiss-url-template="/tour/__TOUR_ASSIGNMENT__/dismiss"
-                data-tour-complete-url-template="/tour/__TOUR_ASSIGNMENT__/complete"
-            >
-                <div id="tour-runner-backdrop" class="hidden"></div>
-                <div id="tour-runner-highlight" class="hidden"></div>
-                <section id="tour-runner-panel" class="hidden">
-                    <h2 id="tour-runner-title"></h2>
-                    <p id="tour-runner-description"></p>
-                    <p id="tour-runner-counter"></p>
-                    <span id="tour-runner-progress-label"></span>
-                    <div id="tour-runner-progress-bar"></div>
-                    <button id="tour-runner-back" type="button">Zurueck</button>
-                    <button id="tour-runner-skip" type="button">Spaeter</button>
-                    <button id="tour-runner-next" type="button">Weiter</button>
-                    <button id="tour-runner-complete" type="button" class="hidden">Tour abschliessen</button>
-                </section>
-            </div>
+function renderRunnerDom() {
+    document.body.innerHTML = `
+        <div
+            id="tour-runner-root"
+            data-tour-current-url="/tour/current"
+            data-tour-start-url-template="/tour/__TOUR_ASSIGNMENT__/start"
+            data-tour-progress-url-template="/tour/__TOUR_ASSIGNMENT__/progress"
+            data-tour-dismiss-url-template="/tour/__TOUR_ASSIGNMENT__/dismiss"
+            data-tour-complete-url-template="/tour/__TOUR_ASSIGNMENT__/complete"
+        >
+            <div id="tour-runner-backdrop" class="hidden"></div>
+            <div id="tour-runner-highlight" class="hidden"></div>
+            <section id="tour-runner-panel" class="hidden">
+                <h2 id="tour-runner-title"></h2>
+                <p id="tour-runner-description"></p>
+                <p id="tour-runner-counter"></p>
+                <span id="tour-runner-progress-label"></span>
+                <div id="tour-runner-progress-bar"></div>
+                <button id="tour-runner-back" type="button">Zurueck</button>
+                <button id="tour-runner-skip" type="button">Spaeter</button>
+                <button id="tour-runner-next" type="button">Weiter</button>
+                <button id="tour-runner-complete" type="button" class="hidden">Tour abschliessen</button>
+            </section>
+        </div>
 
-            <button id="visible-step-one">Erster Schritt</button>
-            <button id="hidden-step" style="display: none;">Versteckter Schritt</button>
-            <button id="visible-step-two">Sichtbarer Folgeschritt</button>
-        `;
+        <button id="visible-step-one">Erster Schritt</button>
+        <button id="hidden-step" style="display: none;">Versteckter Schritt</button>
+        <button id="visible-step-two">Sichtbarer Folgeschritt</button>
+    `;
+}
+
+function createPayload() {
+    return {
+        assignment_id: 7,
+        status: 'open',
+        current_step_key: 'dashboard',
+        steps: [
+            {
+                key: 'dashboard',
+                title: 'Dashboard',
+                description: 'Erster sichtbarer Schritt',
+                selectors: {
+                    desktop: '#visible-step-one',
+                    mobile: '#visible-step-one',
+                },
+            },
+            {
+                key: 'hidden-step',
+                title: 'Unsichtbarer Schritt',
+                description: 'Dieser Schritt bleibt unsichtbar',
+                selectors: {
+                    desktop: '#hidden-step',
+                    mobile: '#hidden-step',
+                },
+            },
+            {
+                key: 'visible-follow-up',
+                title: 'Sichtbarer Folgeschritt',
+                description: 'Naechster sichtbarer Schritt',
+                selectors: {
+                    desktop: '#visible-step-two',
+                    mobile: '#visible-step-two',
+                },
+            },
+        ],
+    };
+}
+
+function stubAxios(payload) {
+    const post = vi.fn().mockImplementation(async (url, body = {}) => {
+        if (url === '/tour/7/progress') {
+            return {
+                data: {
+                    tour: {
+                        ...payload,
+                        current_step_key: body.step_key,
+                    },
+                },
+            };
+        }
+
+        return { data: { tour: payload } };
+    });
+
+    window.axios = {
+        get: vi.fn().mockResolvedValue({ data: { tour: payload } }),
+        post,
+    };
+
+    return { post };
+}
+
+async function bootRunner(payload) {
+    Object.defineProperty(document, 'readyState', {
+        configurable: true,
+        value: 'loading',
+    });
+
+    const { initTourRunner } = await import('@/tours/runner');
+
+    Object.defineProperty(document, 'readyState', {
+        configurable: true,
+        value: 'complete',
+    });
+
+    await initTourRunner();
+}
+
+describe('tour runner', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        renderRunnerDom();
 
         HTMLElement.prototype.scrollIntoView = vi.fn();
         window.toast = vi.fn();
+    });
 
-        const payload = {
-            assignment_id: 7,
-            status: 'open',
-            current_step_key: 'dashboard',
-            steps: [
-                {
-                    key: 'dashboard',
-                    title: 'Dashboard',
-                    description: 'Erster sichtbarer Schritt',
-                    selectors: {
-                        desktop: '#visible-step-one',
-                        mobile: '#visible-step-one',
-                    },
-                },
-                {
-                    key: 'hidden-step',
-                    title: 'Unsichtbarer Schritt',
-                    description: 'Dieser Schritt bleibt unsichtbar',
-                    selectors: {
-                        desktop: '#hidden-step',
-                        mobile: '#hidden-step',
-                    },
-                },
-                {
-                    key: 'visible-follow-up',
-                    title: 'Sichtbarer Folgeschritt',
-                    description: 'Naechster sichtbarer Schritt',
-                    selectors: {
-                        desktop: '#visible-step-two',
-                        mobile: '#visible-step-two',
-                    },
-                },
-            ],
-        };
+    it('springt bei unsichtbaren Schritten auf den naechsten sichtbaren Schritt', async () => {
+        const payload = createPayload();
+        stubAxios(payload);
 
-        window.axios = {
-            get: vi.fn().mockResolvedValue({ data: { tour: payload } }),
-            post: vi.fn().mockImplementation(async (url, body = {}) => {
-                if (url === '/tour/7/progress') {
-                    return {
-                        data: {
-                            tour: {
-                                ...payload,
-                                current_step_key: body.step_key,
-                            },
-                        },
-                    };
-                }
-
-                return { data: { tour: payload } };
-            }),
-        };
-
-        Object.defineProperty(document, 'readyState', {
-            configurable: true,
-            value: 'loading',
-        });
-
-        const { initTourRunner } = await import('@/tours/runner');
-
-        Object.defineProperty(document, 'readyState', {
-            configurable: true,
-            value: 'complete',
-        });
-
-        await initTourRunner();
+        await bootRunner(payload);
         expect(document.getElementById('tour-runner-title')?.textContent).toBe('Dashboard');
 
         document.getElementById('tour-runner-next')?.click();
         await flushAsyncWork();
 
         expect(document.getElementById('tour-runner-title')?.textContent).toBe('Sichtbarer Folgeschritt');
+        expect(document.getElementById('tour-runner-counter')?.textContent).toBe('2 / 2');
         expect(window.axios.post).toHaveBeenLastCalledWith('/tour/7/progress', {
             step_key: 'visible-follow-up',
+        });
+    });
+
+    it('navigiert ueber uebersprungene unsichtbare Schritte auch rueckwaerts zum vorherigen sichtbaren Schritt', async () => {
+        const payload = createPayload();
+        const axios = stubAxios(payload);
+
+        await bootRunner(payload);
+
+        document.getElementById('tour-runner-next')?.click();
+        await flushAsyncWork();
+        expect(document.getElementById('tour-runner-title')?.textContent).toBe('Sichtbarer Folgeschritt');
+
+        document.getElementById('tour-runner-back')?.click();
+        await flushAsyncWork();
+
+        expect(document.getElementById('tour-runner-title')?.textContent).toBe('Dashboard');
+        expect(document.getElementById('tour-runner-counter')?.textContent).toBe('1 / 2');
+        expect(axios.post).toHaveBeenLastCalledWith('/tour/7/progress', {
+            step_key: 'dashboard',
         });
     });
 });

--- a/tests/Vitest/tour-runner.test.js
+++ b/tests/Vitest/tour-runner.test.js
@@ -1,0 +1,117 @@
+async function flushAsyncWork() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('tour runner', () => {
+    it('springt bei unsichtbaren Schritten auf den naechsten sichtbaren Schritt', async () => {
+        document.body.innerHTML = `
+            <div
+                id="tour-runner-root"
+                data-tour-current-url="/tour/current"
+                data-tour-start-url-template="/tour/__TOUR_ASSIGNMENT__/start"
+                data-tour-progress-url-template="/tour/__TOUR_ASSIGNMENT__/progress"
+                data-tour-dismiss-url-template="/tour/__TOUR_ASSIGNMENT__/dismiss"
+                data-tour-complete-url-template="/tour/__TOUR_ASSIGNMENT__/complete"
+            >
+                <div id="tour-runner-backdrop" class="hidden"></div>
+                <div id="tour-runner-highlight" class="hidden"></div>
+                <section id="tour-runner-panel" class="hidden">
+                    <h2 id="tour-runner-title"></h2>
+                    <p id="tour-runner-description"></p>
+                    <p id="tour-runner-counter"></p>
+                    <span id="tour-runner-progress-label"></span>
+                    <div id="tour-runner-progress-bar"></div>
+                    <button id="tour-runner-back" type="button">Zurueck</button>
+                    <button id="tour-runner-skip" type="button">Spaeter</button>
+                    <button id="tour-runner-next" type="button">Weiter</button>
+                    <button id="tour-runner-complete" type="button" class="hidden">Tour abschliessen</button>
+                </section>
+            </div>
+
+            <button id="visible-step-one">Erster Schritt</button>
+            <button id="hidden-step" style="display: none;">Versteckter Schritt</button>
+            <button id="visible-step-two">Sichtbarer Folgeschritt</button>
+        `;
+
+        HTMLElement.prototype.scrollIntoView = vi.fn();
+        window.toast = vi.fn();
+
+        const payload = {
+            assignment_id: 7,
+            status: 'open',
+            current_step_key: 'dashboard',
+            steps: [
+                {
+                    key: 'dashboard',
+                    title: 'Dashboard',
+                    description: 'Erster sichtbarer Schritt',
+                    selectors: {
+                        desktop: '#visible-step-one',
+                        mobile: '#visible-step-one',
+                    },
+                },
+                {
+                    key: 'hidden-step',
+                    title: 'Unsichtbarer Schritt',
+                    description: 'Dieser Schritt bleibt unsichtbar',
+                    selectors: {
+                        desktop: '#hidden-step',
+                        mobile: '#hidden-step',
+                    },
+                },
+                {
+                    key: 'visible-follow-up',
+                    title: 'Sichtbarer Folgeschritt',
+                    description: 'Naechster sichtbarer Schritt',
+                    selectors: {
+                        desktop: '#visible-step-two',
+                        mobile: '#visible-step-two',
+                    },
+                },
+            ],
+        };
+
+        window.axios = {
+            get: vi.fn().mockResolvedValue({ data: { tour: payload } }),
+            post: vi.fn().mockImplementation(async (url, body = {}) => {
+                if (url === '/tour/7/progress') {
+                    return {
+                        data: {
+                            tour: {
+                                ...payload,
+                                current_step_key: body.step_key,
+                            },
+                        },
+                    };
+                }
+
+                return { data: { tour: payload } };
+            }),
+        };
+
+        Object.defineProperty(document, 'readyState', {
+            configurable: true,
+            value: 'loading',
+        });
+
+        const { initTourRunner } = await import('@/tours/runner');
+
+        Object.defineProperty(document, 'readyState', {
+            configurable: true,
+            value: 'complete',
+        });
+
+        await initTourRunner();
+        expect(document.getElementById('tour-runner-title')?.textContent).toBe('Dashboard');
+
+        document.getElementById('tour-runner-next')?.click();
+        await flushAsyncWork();
+
+        expect(document.getElementById('tour-runner-title')?.textContent).toBe('Sichtbarer Folgeschritt');
+        expect(window.axios.post).toHaveBeenLastCalledWith('/tour/7/progress', {
+            step_key: 'visible-follow-up',
+        });
+    });
+});

--- a/tests/Vitest/tour-runner.test.js
+++ b/tests/Vitest/tour-runner.test.js
@@ -72,31 +72,49 @@ function createPayload() {
     };
 }
 
+function clonePayload(payload, overrides = {}) {
+    return {
+        ...payload,
+        ...overrides,
+        steps: payload.steps.map((step) => ({
+            ...step,
+            selectors: {
+                ...step.selectors,
+            },
+        })),
+    };
+}
+
 function stubAxios(payload) {
+    let currentStepKey = payload.current_step_key;
+
+    const responseFor = (stepKey = currentStepKey) => ({
+        data: {
+            tour: clonePayload(payload, {
+                current_step_key: stepKey,
+            }),
+        },
+    });
+
     const post = vi.fn().mockImplementation(async (url, body = {}) => {
         if (url === '/tour/7/progress') {
-            return {
-                data: {
-                    tour: {
-                        ...payload,
-                        current_step_key: body.step_key,
-                    },
-                },
-            };
+            currentStepKey = body.step_key;
+
+            return responseFor(currentStepKey);
         }
 
-        return { data: { tour: payload } };
+        return responseFor();
     });
 
     window.axios = {
-        get: vi.fn().mockResolvedValue({ data: { tour: payload } }),
+        get: vi.fn().mockImplementation(async () => responseFor()),
         post,
     };
 
     return { post };
 }
 
-async function bootRunner(payload) {
+async function bootRunner() {
     Object.defineProperty(document, 'readyState', {
         configurable: true,
         value: 'loading',
@@ -125,7 +143,7 @@ describe('tour runner', () => {
         const payload = createPayload();
         stubAxios(payload);
 
-        await bootRunner(payload);
+        await bootRunner();
         expect(document.getElementById('tour-runner-title')?.textContent).toBe('Dashboard');
 
         document.getElementById('tour-runner-next')?.click();
@@ -142,7 +160,7 @@ describe('tour runner', () => {
         const payload = createPayload();
         const axios = stubAxios(payload);
 
-        await bootRunner(payload);
+        await bootRunner();
 
         document.getElementById('tour-runner-next')?.click();
         await flushAsyncWork();


### PR DESCRIPTION
This pull request enhances the guided tour runner logic to better handle steps that are not visible in the DOM, ensuring a smoother user experience when navigating tours. It introduces a mechanism to track and skip hidden steps, updates the state management accordingly, and adds comprehensive tests to verify the new behavior.

**Tour runner logic improvements:**

* Added a `skippedStepKeys` set to the runner's state to keep track of steps that were skipped because their target elements are not visible. This ensures hidden steps are not revisited during navigation.
* Introduced `activeSteps` and `skipHiddenStep` helper functions to filter out skipped or unreachable steps and update the payload and state accordingly.
* Updated the main step rendering logic to use `activeSteps`, and when a step is hidden, it is now properly skipped and the next visible step is shown. The payload's `current_step_key` is also updated to reflect the new active step. [[1]](diffhunk://#diff-7be174212bb130e9a6a6fb7b77ab81422880a88111031a3745d2607143f3c90eL215-R240) [[2]](diffhunk://#diff-7be174212bb130e9a6a6fb7b77ab81422880a88111031a3745d2607143f3c90eL235-R275)
* Ensured that when a new tour is activated, the set of skipped steps is cleared to avoid carrying over skipped steps from previous tours.

**Testing enhancements:**

* Added a new test suite (`tour-runner.test.js`) to verify that the tour runner correctly skips hidden steps and allows navigation back and forth between visible steps, ensuring accurate step counters and payload updates.