### PR TITLE
Fix: Modal background not shown

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -122,6 +122,53 @@ jobs:
           DB_DATABASE: database/database.sqlite
         run: php vendor/bin/phpunit --group large
 
+  browser_preview:
+    runs-on: ubuntu-latest
+    name: PHP 8.5 Browser Preview Regression
+    env:
+      APP_KEY: ${{ secrets.APP_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        with:
+          php-version: '8.5'
+      - name: Copy .env
+        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-8.5-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.5-composer-
+            ${{ runner.os }}-php-8.5-
+            ${{ runner.os }}-
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-php-8.5-composer-cache-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.5-composer-cache-
+            ${{ runner.os }}-php-8.5-
+            ${{ runner.os }}-
+      - name: Install Dependencies
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+      - name: Directory Permissions
+        run: chmod -R 777 storage bootstrap/cache
+      - name: Create Database
+        run: |
+          mkdir -p database
+          touch database/database.sqlite
+      - name: Setup Node.js and build assets
+        uses: ./.github/actions/build-assets
+      - name: Execute Pest browser preview regression
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: database/database.sqlite
+        run: ./vendor/bin/pest tests/Browser/ModalBackdropPreviewTest.php
+
   coverage:
     needs:
       - tests

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -163,6 +163,10 @@ jobs:
           touch database/database.sqlite
       - name: Setup Node.js and build assets
         uses: ./.github/actions/build-assets
+      - name: Install Playwright browser dependencies
+        run: npx playwright install-deps chromium
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
       - name: Execute Pest browser preview regression
         env:
           DB_CONNECTION: sqlite

--- a/README.md
+++ b/README.md
@@ -156,14 +156,19 @@ Das Admin-Dashboard ist nur für Benutzer mit den Rollen `Admin`, `Vorstand` ode
 | Zweck                        | Befehl |
 |------------------------------|--------|
 | PHPUnit-Tests                | `php artisan test` |
+| Pest-Browser-Regression      | `./vendor/bin/pest tests/Browser/ModalBackdropPreviewTest.php` |
 | JavaScript-Tests (Jest)      | `npm run test` |
 | Komponenten-Tests (Vitest)   | `npm run test:vitest` |
 | End-to-End- & Accessibility-Checks | `npm run test:e2e` |
 | End-to-End-Checks mit Docker-PHP 8.5 | `npm run test:e2e:docker` |
+| Modal-Screenshot-Export mit Docker | `npm run test:e2e:modal-screenshots:docker` |
 | Code-Style (Laravel Pint)    | `./vendor/bin/pint` |
 
 Die Playwright-Suite setzt eine laufende Anwendung (lokal oder in CI) voraus und führt zusätzlich axe-core-Prüfungen für Barrierefreiheit durch.
 Für Windows- oder Docker-Setups ohne passendes lokales PHP kann die Suite mit `npm run test:e2e:docker` in einem kleinen PHP-8.5-Container mit SQLite-Support gestartet werden.
+Der Export der Modal-Vorschau-Screenshots ist bewusst an `PLAYWRIGHT_CAPTURE_MODAL_SCREENSHOTS=1` gekoppelt; das Docker-Skript `npm run test:e2e:modal-screenshots:docker` setzt diese Flag automatisch, während normale CI- und lokale Playwright-Läufe keine dauerhaften Screenshot-Artefakte erzeugen.
+
+Die lokale Pest-Browser-Regression benötigt aktuell noch den Pest-5-Stack und `symfony/process` aus unreleasten Branches. Ein Rückfall auf stabile Pest-4-Releases ist im Projekt derzeit nicht möglich, weil das stabile `pestphp/pest-plugin-laravel` nur Laravel 11/12 unterstützt, nicht aber Laravel 13. Sobald es stabile 5.x-Tags für diesen Stack gibt, können die Commit-Referenzen in `composer.json` entfallen.
 
 ## Deployment
 

--- a/composer.json
+++ b/composer.json
@@ -48,15 +48,15 @@
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.9",
-        "pestphp/pest": "5.x-dev",
-        "pestphp/pest-plugin": "5.x-dev",
-        "pestphp/pest-plugin-arch": "5.x-dev",
-        "pestphp/pest-plugin-browser": "5.x-dev",
-        "pestphp/pest-plugin-laravel": "5.x-dev",
-        "pestphp/pest-plugin-mutate": "5.x-dev",
-        "pestphp/pest-plugin-profanity": "5.x-dev",
+        "pestphp/pest": "5.x-dev#4d550cecfd17b85a2eac939cea0e338b38c3b2da",
+        "pestphp/pest-plugin": "5.x-dev#7f837d8162e854d1cdae388371f3a8875ae1615b",
+        "pestphp/pest-plugin-arch": "5.x-dev#e152889f90b9bc6e8b9545ec5329682e0fa0d842",
+        "pestphp/pest-plugin-browser": "5.x-dev#25271f0cfd2359b52a6b2accc17a31ea13d5da24",
+        "pestphp/pest-plugin-laravel": "5.x-dev#3dd5713e5f90cd6648e5a0621207459639dd6a62",
+        "pestphp/pest-plugin-mutate": "5.x-dev#c61cb58ddfb552918a90f6e117800c389b580bbc",
+        "pestphp/pest-plugin-profanity": "5.x-dev#73aa4c14735b8f0682e06205b35b8481dd8628a9",
         "phpunit/phpunit": "13.1.8",
-        "symfony/process": "8.1.x-dev"
+        "symfony/process": "8.1.x-dev#93d6507ad72e3f2df1cc8d41bbbc431fef1b7b74"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,15 @@
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.9",
-        "phpunit/phpunit": "^13.0"
+        "pestphp/pest": "5.x-dev",
+        "pestphp/pest-plugin": "5.x-dev",
+        "pestphp/pest-plugin-arch": "5.x-dev",
+        "pestphp/pest-plugin-browser": "5.x-dev",
+        "pestphp/pest-plugin-laravel": "5.x-dev",
+        "pestphp/pest-plugin-mutate": "5.x-dev",
+        "pestphp/pest-plugin-profanity": "5.x-dev",
+        "phpunit/phpunit": "13.1.8",
+        "symfony/process": "8.1.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "297d2e5ed29270c51f2335a4f4ad617b",
+    "content-hash": "b15113e5cbe87b6558830f4d70edd77b",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -1012,16 +1012,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "47ba23c7a55247e2e1b7407aca90e9bbed0d9d86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/47ba23c7a55247e2e1b7407aca90e9bbed0d9d86",
+                "reference": "47ba23c7a55247e2e1b7407aca90e9bbed0d9d86",
                 "shasum": ""
             },
             "require": {
@@ -1039,8 +1039,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.3.2",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1118,7 +1119,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.3"
             },
             "funding": [
                 {
@@ -1134,20 +1135,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-05-20T22:59:19+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/09e8a212562fb1fb6a512c4156ed71525969d6c2",
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2",
                 "shasum": ""
             },
             "require": {
@@ -1155,7 +1156,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1201,7 +1202,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.4.1"
             },
             "funding": [
                 {
@@ -1217,20 +1218,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-05-20T22:57:30+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/73ab136360b5dfd858006eae9795e8fe43c80361",
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361",
                 "shasum": ""
             },
             "require": {
@@ -1245,9 +1246,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1318,7 +1319,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.1"
             },
             "funding": [
                 {
@@ -1334,7 +1335,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-05-20T09:27:36+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -1725,16 +1726,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v13.9.0",
+            "version": "v13.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "a0c6ad03b380287015287d8d5a0fa2459e2332fd"
+                "reference": "4148042bf6ee01edd05408f1f66d91b231f85c25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/a0c6ad03b380287015287d8d5a0fa2459e2332fd",
-                "reference": "a0c6ad03b380287015287d8d5a0fa2459e2332fd",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/4148042bf6ee01edd05408f1f66d91b231f85c25",
+                "reference": "4148042bf6ee01edd05408f1f66d91b231f85c25",
                 "shasum": ""
             },
             "require": {
@@ -1945,7 +1946,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-05-13T15:38:40+00:00"
+            "time": "2026-05-20T11:46:02+00:00"
         },
         {
             "name": "laravel/jetstream",
@@ -2083,16 +2084,16 @@
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.17",
+            "version": "v0.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818"
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/6a82ac19a28b916ae0885828795dbd4c59d9a818",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/a19af51bb144bf87f08397921fa619f85c7d4e72",
+                "reference": "a19af51bb144bf87f08397921fa619f85c7d4e72",
                 "shasum": ""
             },
             "require": {
@@ -2136,9 +2137,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.17"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.18"
             },
-            "time": "2026-04-20T16:07:33+00:00"
+            "time": "2026-05-19T00:47:18+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -5135,16 +5136,16 @@
         },
         {
             "name": "robsontenorio/mary",
-            "version": "2.8.2",
+            "version": "2.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robsontenorio/mary.git",
-                "reference": "fee6e23a158c54c682b5dd5d7c9377ba4889761a"
+                "reference": "e32a3ba1be5f1d86e4b7181004d7b606c025fbfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/fee6e23a158c54c682b5dd5d7c9377ba4889761a",
-                "reference": "fee6e23a158c54c682b5dd5d7c9377ba4889761a",
+                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/e32a3ba1be5f1d86e4b7181004d7b606c025fbfc",
+                "reference": "e32a3ba1be5f1d86e4b7181004d7b606c025fbfc",
                 "shasum": ""
             },
             "require": {
@@ -5209,7 +5210,7 @@
             ],
             "support": {
                 "issues": "https://github.com/robsontenorio/mary/issues",
-                "source": "https://github.com/robsontenorio/mary/tree/2.8.2"
+                "source": "https://github.com/robsontenorio/mary/tree/2.8.3"
             },
             "funding": [
                 {
@@ -5217,7 +5218,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-17T13:40:53+00:00"
+            "time": "2026-05-21T18:42:50+00:00"
         },
         {
             "name": "spatie/browsershot",
@@ -6669,16 +6670,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v8.0.11",
+            "version": "v8.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "20d3680373f4b791903c09e74b45402b4aeda71c"
+                "reference": "c00291734c59c05c54c5a3abc2ab18e99b070157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/20d3680373f4b791903c09e74b45402b4aeda71c",
-                "reference": "20d3680373f4b791903c09e74b45402b4aeda71c",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/c00291734c59c05c54c5a3abc2ab18e99b070157",
+                "reference": "c00291734c59c05c54c5a3abc2ab18e99b070157",
                 "shasum": ""
             },
             "require": {
@@ -6749,7 +6750,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v8.0.11"
+                "source": "https://github.com/symfony/http-kernel/tree/v8.0.12"
             },
             "funding": [
                 {
@@ -6769,20 +6770,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T18:07:14+00:00"
+            "time": "2026-05-20T09:47:36+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v8.0.8",
+            "version": "v8.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "ca5f6edaf8780ece814404b58a4482b22b509c56"
+                "reference": "5266d594e83593dff3492b5655ff6e8f38d67cfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/ca5f6edaf8780ece814404b58a4482b22b509c56",
-                "reference": "ca5f6edaf8780ece814404b58a4482b22b509c56",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/5266d594e83593dff3492b5655ff6e8f38d67cfc",
+                "reference": "5266d594e83593dff3492b5655ff6e8f38d67cfc",
                 "shasum": ""
             },
             "require": {
@@ -6829,7 +6830,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v8.0.8"
+                "source": "https://github.com/symfony/mailer/tree/v8.0.12"
             },
             "funding": [
                 {
@@ -6849,20 +6850,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-20T07:22:03+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v8.0.9",
+            "version": "v8.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "a9fcb293650c054b62a5b406f4e92e7b711ea333"
+                "reference": "7d9a72bbf0a9cb169ed1cbbbbbf709a592207fc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/a9fcb293650c054b62a5b406f4e92e7b711ea333",
-                "reference": "a9fcb293650c054b62a5b406f4e92e7b711ea333",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/7d9a72bbf0a9cb169ed1cbbbbbf709a592207fc1",
+                "reference": "7d9a72bbf0a9cb169ed1cbbbbbf709a592207fc1",
                 "shasum": ""
             },
             "require": {
@@ -6915,7 +6916,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v8.0.9"
+                "source": "https://github.com/symfony/mime/tree/v8.0.12"
             },
             "funding": [
                 {
@@ -6935,7 +6936,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T15:02:55+00:00"
+            "time": "2026-05-20T07:22:03+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -7839,21 +7840,22 @@
         },
         {
             "name": "symfony/process",
-            "version": "v8.0.11",
+            "version": "8.1.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0"
+                "reference": "93d6507ad72e3f2df1cc8d41bbbc431fef1b7b74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/26d89e459f037d2873300605d0a07e7a8ef84db0",
-                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0",
+                "url": "https://api.github.com/repos/symfony/process/zipball/93d6507ad72e3f2df1cc8d41bbbc431fef1b7b74",
+                "reference": "93d6507ad72e3f2df1cc8d41bbbc431fef1b7b74",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -7880,7 +7882,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.11"
+                "source": "https://github.com/symfony/process/tree/8.1"
             },
             "funding": [
                 {
@@ -7900,7 +7902,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-11T16:56:32+00:00"
+            "time": "2026-05-11T16:58:04+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -8071,16 +8073,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v8.0.9",
+            "version": "v8.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "75d1bd8e5da3424e4db2fc3ff0222cb4d0c73038"
+                "reference": "c7f22a665faa3e5212b8f042e0c5831a6b85492f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/75d1bd8e5da3424e4db2fc3ff0222cb4d0c73038",
-                "reference": "75d1bd8e5da3424e4db2fc3ff0222cb4d0c73038",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/c7f22a665faa3e5212b8f042e0c5831a6b85492f",
+                "reference": "c7f22a665faa3e5212b8f042e0c5831a6b85492f",
                 "shasum": ""
             },
             "require": {
@@ -8127,7 +8129,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v8.0.9"
+                "source": "https://github.com/symfony/routing/tree/v8.0.12"
             },
             "funding": [
                 {
@@ -8147,7 +8149,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T15:02:55+00:00"
+            "time": "2026-05-20T07:22:03+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -9289,16 +9291,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.3.0",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9007ea6f45ecf352a9422b36644e4bfc039b9155",
+                "reference": "9007ea6f45ecf352a9422b36644e4bfc039b9155",
                 "shasum": ""
             },
             "require": {
@@ -9314,7 +9316,11 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
+                    "dev-master": "2.0-dev",
                     "dev-feature/2-0": "2.0-dev"
                 }
             },
@@ -9345,12 +9351,1379 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.0"
             },
-            "time": "2026-04-11T10:33:05+00:00"
+            "time": "2026-05-20T13:07:01+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "amphp/amp",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-27T21:42:00+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/parser": "^1.1",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2.3"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.22.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "https://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T17:10:27+00:00"
+        },
+        {
+            "name": "amphp/cache",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/cache.git",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/cache/zipball/46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "reference": "46912e387e6aa94933b61ea1ead9cf7540b7797c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Cache\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A fiber-aware cache API based on Amp and Revolt.",
+            "homepage": "https://amphp.org/cache",
+            "support": {
+                "issues": "https://github.com/amphp/cache/issues",
+                "source": "https://github.com/amphp/cache/tree/v2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:38:06+00:00"
+        },
+        {
+            "name": "amphp/dns",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/dns.git",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/dns/zipball/78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "reference": "78eb3db5fc69bf2fc0cb503c4fcba667bc223c71",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/parser": "^1",
+                "amphp/process": "^2",
+                "daverandom/libdns": "^2.0.2",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.20"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Dns\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Wright",
+                    "email": "addr@daverandom.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Async DNS resolution for Amp.",
+            "homepage": "https://github.com/amphp/dns",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "dns",
+                "resolve"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/dns/issues",
+                "source": "https://github.com/amphp/dns/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-19T15:43:40+00:00"
+        },
+        {
+            "name": "amphp/hpack",
+            "version": "v3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/hpack.git",
+                "reference": "291da27078e7e149a9bad4d08ff05bf7d81c89f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/hpack/zipball/291da27078e7e149a9bad4d08ff05bf7d81c89f4",
+                "reference": "291da27078e7e149a9bad4d08ff05bf7d81c89f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "http2jp/hpack-test-case": "^1",
+                "nikic/php-fuzzer": "^0.0.11",
+                "phpunit/phpunit": "^7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Http\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "HTTP/2 HPack implementation.",
+            "homepage": "https://github.com/amphp/hpack",
+            "keywords": [
+                "headers",
+                "hpack",
+                "http-2"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/hpack/issues",
+                "source": "https://github.com/amphp/hpack/tree/v3.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-03T19:28:59+00:00"
+        },
+        {
+            "name": "amphp/http",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/http.git",
+                "reference": "3680d80bd38b5d6f3c2cef2214ca6dd6cef26588"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/http/zipball/3680d80bd38b5d6f3c2cef2214ca6dd6cef26588",
+                "reference": "3680d80bd38b5d6f3c2cef2214ca6dd6cef26588",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/hpack": "^3",
+                "amphp/parser": "^1.1",
+                "league/uri-components": "^2.4.2 | ^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "league/uri": "^6.8 | ^7.1",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.26.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/constants.php"
+                ],
+                "psr-4": {
+                    "Amp\\Http\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "Basic HTTP primitives which can be shared by servers and clients.",
+            "support": {
+                "issues": "https://github.com/amphp/http/issues",
+                "source": "https://github.com/amphp/http/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-23T14:57:26+00:00"
+        },
+        {
+            "name": "amphp/http-client",
+            "version": "v5.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/http-client.git",
+                "reference": "ca155026acafa74a612d776a97202d53077fee86"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/http-client/zipball/ca155026acafa74a612d776a97202d53077fee86",
+                "reference": "ca155026acafa74a612d776a97202d53077fee86",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/hpack": "^3",
+                "amphp/http": "^2",
+                "amphp/pipeline": "^1",
+                "amphp/socket": "^2",
+                "amphp/sync": "^2",
+                "league/uri": "^7",
+                "league/uri-components": "^7",
+                "league/uri-interfaces": "^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2",
+                "revolt/event-loop": "^1"
+            },
+            "conflict": {
+                "amphp/file": "<3 | >=5"
+            },
+            "require-dev": {
+                "amphp/file": "^3 | ^4",
+                "amphp/http-server": "^3",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "ext-json": "*",
+                "kelunik/link-header-rfc5988": "^1",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "suggest": {
+                "amphp/file": "Required for file request bodies and HTTP archive logging",
+                "ext-json": "Required for logging HTTP archives",
+                "ext-zlib": "Allows using compression for response bodies."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Http\\Client\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "An advanced async HTTP client library for PHP, enabling efficient, non-blocking, and concurrent requests and responses.",
+            "homepage": "https://amphp.org/http-client",
+            "keywords": [
+                "async",
+                "client",
+                "concurrent",
+                "http",
+                "non-blocking",
+                "rest"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/http-client/issues",
+                "source": "https://github.com/amphp/http-client/tree/v5.3.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-15T23:29:38+00:00"
+        },
+        {
+            "name": "amphp/http-server",
+            "version": "v3.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/http-server.git",
+                "reference": "ae0fd01e16aba336247852df0c3f8c649a31896d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/http-server/zipball/ae0fd01e16aba336247852df0c3f8c649a31896d",
+                "reference": "ae0fd01e16aba336247852df0c3f8c649a31896d",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/cache": "^2",
+                "amphp/hpack": "^3",
+                "amphp/http": "^2",
+                "amphp/pipeline": "^1",
+                "amphp/socket": "^2.1",
+                "amphp/sync": "^2.2",
+                "league/uri": "^7.1",
+                "league/uri-interfaces": "^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1 | ^2",
+                "psr/log": "^1 | ^2 | ^3",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/http-client": "^5",
+                "amphp/log": "^2",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "league/uri-components": "^7.1",
+                "monolog/monolog": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "suggest": {
+                "ext-zlib": "Allows GZip compression of response bodies"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Driver/functions.php",
+                    "src/Middleware/functions.php",
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Http\\Server\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Bob Weinand"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                }
+            ],
+            "description": "A non-blocking HTTP application server for PHP based on Amp.",
+            "homepage": "https://github.com/amphp/http-server",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "http",
+                "non-blocking",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/http-server/issues",
+                "source": "https://github.com/amphp/http-server/tree/v3.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-01T03:55:07+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/v1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:16:53+00:00"
+        },
+        {
+            "name": "amphp/pipeline",
+            "version": "v1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "a044733e080940d1483f56caff0c412ad6982776"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/a044733e080940d1483f56caff0c412ad6982776",
+                "reference": "a044733e080940d1483f56caff0c412ad6982776",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-06T05:37:57+00:00"
+        },
+        {
+            "name": "amphp/process",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/process.git",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/process/zipball/52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "reference": "52e08c09dec7511d5fbc1fb00d3e4e79fc77d58d",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Process\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A fiber-aware process manager based on Amp and Revolt.",
+            "homepage": "https://amphp.org/process",
+            "support": {
+                "issues": "https://github.com/amphp/process/issues",
+                "source": "https://github.com/amphp/process/tree/v2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-19T03:13:44+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
+        },
+        {
+            "name": "amphp/socket",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/socket.git",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/dadb63c5d3179fd83803e29dfeac27350e619314",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/dns": "^2",
+                "ext-openssl": "*",
+                "kelunik/certificate": "^1.1",
+                "league/uri": "^7",
+                "league/uri-interfaces": "^7",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/process": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php",
+                    "src/SocketAddress/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Socket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@gmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Non-blocking socket connection / server implementations based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/socket",
+            "keywords": [
+                "amp",
+                "async",
+                "encryption",
+                "non-blocking",
+                "sockets",
+                "tcp",
+                "tls"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/socket/issues",
+                "source": "https://github.com/amphp/socket/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-19T15:09:56+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-03T19:31:26+00:00"
+        },
+        {
+            "name": "amphp/websocket",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/websocket.git",
+                "reference": "963904b6a883c4b62d9222d1d9749814fac96a3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/websocket/zipball/963904b6a883c4b62d9222d1d9749814fac96a3b",
+                "reference": "963904b6a883c4b62d9222d1d9749814fac96a3b",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
+                "amphp/parser": "^1",
+                "amphp/pipeline": "^1",
+                "amphp/socket": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "suggest": {
+                "ext-zlib": "Required for compression"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Websocket\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                }
+            ],
+            "description": "Shared code for websocket servers and clients.",
+            "homepage": "https://github.com/amphp/websocket",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "http",
+                "non-blocking",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/websocket/issues",
+                "source": "https://github.com/amphp/websocket/tree/v2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-28T21:28:45+00:00"
+        },
+        {
+            "name": "amphp/websocket-client",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/websocket-client.git",
+                "reference": "dc033fdce0af56295a23f63ac4f579b34d470d6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/websocket-client/zipball/dc033fdce0af56295a23f63ac4f579b34d470d6c",
+                "reference": "dc033fdce0af56295a23f63ac4f579b34d470d6c",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2.1",
+                "amphp/http": "^2.1",
+                "amphp/http-client": "^5",
+                "amphp/socket": "^2.2",
+                "amphp/websocket": "^2",
+                "league/uri": "^7.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1|^2",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/http-server": "^3",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "amphp/websocket-server": "^3|^4",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "~5.26.1",
+                "psr/log": "^1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Websocket\\Client\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Async WebSocket client for PHP based on Amp.",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "client",
+                "http",
+                "non-blocking",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/websocket-client/issues",
+                "source": "https://github.com/amphp/websocket-client/tree/v2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-24T17:25:34+00:00"
+        },
+        {
+            "name": "brianium/paratest",
+            "version": "v7.22.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paratestphp/paratest.git",
+                "reference": "6f0a85f9982f0a1ad4a3746a943baa83d544b8ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/6f0a85f9982f0a1ad4a3746a943baa83d544b8ec",
+                "reference": "6f0a85f9982f0a1ad4a3746a943baa83d544b8ec",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-simplexml": "*",
+                "fidry/cpu-core-counter": "^1.3.0",
+                "jean85/pretty-package-versions": "^2.1.1",
+                "php": "~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^14.1.8",
+                "phpunit/php-file-iterator": "^7",
+                "phpunit/php-timer": "^9",
+                "phpunit/phpunit": "^13.1.8",
+                "sebastian/environment": "^9.3.0",
+                "symfony/console": "^7.4.8 || ^8.0.8",
+                "symfony/process": "^7.4.8 || ^8.0.8"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14.0.0",
+                "ext-pcntl": "*",
+                "ext-pcov": "*",
+                "ext-posix": "*",
+                "phpstan/phpstan": "^2.1.54",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.11",
+                "symfony/filesystem": "^7.4.8 || ^8.0.8"
+            },
+            "bin": [
+                "bin/paratest",
+                "bin/paratest_for_phpstorm"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParaTest\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Scaturro",
+                    "email": "scaturrob@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Filippo Tessarotto",
+                    "email": "zoeslam@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parallel testing for PHP",
+            "homepage": "https://github.com/paratestphp/paratest",
+            "keywords": [
+                "concurrent",
+                "parallel",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/paratestphp/paratest/issues",
+                "source": "https://github.com/paratestphp/paratest/tree/v7.22.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/Slamdunk",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2026-05-12T12:07:42+00:00"
+        },
+        {
+            "name": "daverandom/libdns",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DaveRandom/LibDNS.git",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "Required for IDN support"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "LibDNS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "DNS protocol implementation written in pure PHP",
+            "keywords": [
+                "dns"
+            ],
+            "support": {
+                "issues": "https://github.com/DaveRandom/LibDNS/issues",
+                "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+            },
+            "time": "2024-04-12T12:12:48+00:00"
+        },
         {
             "name": "doctrine/dbal",
             "version": "4.4.3",
@@ -9521,6 +10894,67 @@
             "time": "2024-11-21T13:46:39+00:00"
         },
         {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
             "name": "filp/whoops",
             "version": "2.18.4",
             "source": {
@@ -9641,6 +11075,124 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
             "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "kelunik/certificate",
+            "version": "v1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kelunik/certificate.git",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kelunik\\Certificate\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Access certificate details and transform between different formats.",
+            "keywords": [
+                "DER",
+                "certificate",
+                "certificates",
+                "openssl",
+                "pem",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/kelunik/certificate/issues",
+                "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+            },
+            "time": "2023-02-03T21:26:53+00:00"
         },
         {
             "name": "laravel/pail",
@@ -9852,6 +11404,90 @@
                 "source": "https://github.com/laravel/sail"
             },
             "time": "2026-05-13T14:02:20+00:00"
+        },
+        {
+            "name": "league/uri-components",
+            "version": "7.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri-components.git",
+                "reference": "848ff9db2f0be06229d6034b7c2e33d41b4fd675"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri-components/zipball/848ff9db2f0be06229d6034b7c2e33d41b4fd675",
+                "reference": "848ff9db2f0be06229d6034b7c2e33d41b4fd675",
+                "shasum": ""
+            },
+            "require": {
+                "league/uri": "^7.8.1",
+                "php": "^8.1"
+            },
+            "suggest": {
+                "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-fileinfo": "to create Data URI from file contennts",
+                "ext-gmp": "to improve IPV4 host parsing",
+                "ext-intl": "to handle IDN host with the best performance",
+                "ext-mbstring": "to use the sorting algorithm of URLSearchParams",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
+                "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
+                "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Uri\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://nyamsprod.com"
+                }
+            ],
+            "description": "URI components manipulation library",
+            "homepage": "http://uri.thephpleague.com",
+            "keywords": [
+                "authority",
+                "components",
+                "fragment",
+                "host",
+                "middleware",
+                "modifier",
+                "path",
+                "port",
+                "query",
+                "rfc3986",
+                "scheme",
+                "uri",
+                "url",
+                "userinfo"
+            ],
+            "support": {
+                "docs": "https://uri.thephpleague.com",
+                "forum": "https://thephpleague.slack.com",
+                "issues": "https://github.com/thephpleague/uri-src/issues",
+                "source": "https://github.com/thephpleague/uri-components/tree/7.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -10091,6 +11727,554 @@
                 }
             ],
             "time": "2026-04-21T14:04:20+00:00"
+        },
+        {
+            "name": "pestphp/pest",
+            "version": "5.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest.git",
+                "reference": "4d550cecfd17b85a2eac939cea0e338b38c3b2da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/4d550cecfd17b85a2eac939cea0e338b38c3b2da",
+                "reference": "4d550cecfd17b85a2eac939cea0e338b38c3b2da",
+                "shasum": ""
+            },
+            "require": {
+                "brianium/paratest": "^7.22.3",
+                "nunomaduro/collision": "^8.9.4",
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest-plugin": "^5.0.0",
+                "pestphp/pest-plugin-arch": "^5.0.0",
+                "pestphp/pest-plugin-mutate": "^5.0.0",
+                "pestphp/pest-plugin-profanity": "^5.0.0",
+                "php": "^8.4",
+                "phpunit/phpunit": "^13.1.8",
+                "symfony/process": "^8.1.0"
+            },
+            "conflict": {
+                "filp/whoops": "<2.18.3",
+                "phpunit/phpunit": ">13.1.8",
+                "sebastian/exporter": "<7.0.0",
+                "webmozart/assert": "<1.11.0"
+            },
+            "require-dev": {
+                "laravel/pao": "^1.0.6",
+                "mrpunyapal/peststan": "^0.2.10",
+                "pestphp/pest-dev-tools": "^5.0.0",
+                "pestphp/pest-plugin-browser": "^5.0.0",
+                "pestphp/pest-plugin-type-coverage": "^5.0.0",
+                "psy/psysh": "^0.12.22"
+            },
+            "bin": [
+                "bin/pest"
+            ],
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Mutate\\Plugins\\Mutate",
+                        "Pest\\Plugins\\Configuration",
+                        "Pest\\Plugins\\Bail",
+                        "Pest\\Plugins\\Cache",
+                        "Pest\\Plugins\\Coverage",
+                        "Pest\\Plugins\\Init",
+                        "Pest\\Plugins\\Environment",
+                        "Pest\\Plugins\\Help",
+                        "Pest\\Plugins\\Memory",
+                        "Pest\\Plugins\\Only",
+                        "Pest\\Plugins\\Printer",
+                        "Pest\\Plugins\\ProcessIsolation",
+                        "Pest\\Plugins\\Profile",
+                        "Pest\\Plugins\\Retry",
+                        "Pest\\Plugins\\Snapshot",
+                        "Pest\\Plugins\\Verbose",
+                        "Pest\\Plugins\\Version",
+                        "Pest\\Plugins\\Shard",
+                        "Pest\\Plugins\\Tia",
+                        "Pest\\Plugins\\Parallel"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php",
+                    "src/Pest.php"
+                ],
+                "psr-4": {
+                    "Pest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "The elegant PHP Testing Framework.",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/pestphp/pest/issues",
+                "source": "https://github.com/pestphp/pest/tree/5.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-13T11:20:46+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin",
+            "version": "5.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin.git",
+                "reference": "7f837d8162e854d1cdae388371f3a8875ae1615b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/7f837d8162e854d1cdae388371f3a8875ae1615b",
+                "reference": "7f837d8162e854d1cdae388371f3a8875ae1615b",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0.0",
+                "composer-runtime-api": "^2.2.2",
+                "php": "^8.4"
+            },
+            "conflict": {
+                "pestphp/pest": "<5.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.9.5",
+                "pestphp/pest": "^5.0.0",
+                "pestphp/pest-dev-tools": "^5.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Pest\\Plugin\\Manager"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest plugin manager",
+            "keywords": [
+                "framework",
+                "manager",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin/tree/5.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-13T01:30:29+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-arch",
+            "version": "5.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-arch.git",
+                "reference": "e152889f90b9bc6e8b9545ec5329682e0fa0d842"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/e152889f90b9bc6e8b9545ec5329682e0fa0d842",
+                "reference": "e152889f90b9bc6e8b9545ec5329682e0fa0d842",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^5.0.0",
+                "php": "^8.4",
+                "ta-tikoma/phpunit-architecture-test": "^0.8.7"
+            },
+            "require-dev": {
+                "pestphp/pest": "^5.0.0",
+                "pestphp/pest-dev-tools": "^5.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Arch\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Arch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Arch plugin for Pest PHP.",
+            "keywords": [
+                "arch",
+                "architecture",
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-arch/tree/5.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-13T01:32:11+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-browser",
+            "version": "5.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-browser.git",
+                "reference": "25271f0cfd2359b52a6b2accc17a31ea13d5da24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-browser/zipball/25271f0cfd2359b52a6b2accc17a31ea13d5da24",
+                "reference": "25271f0cfd2359b52a6b2accc17a31ea13d5da24",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3.1.1",
+                "amphp/http-server": "^3.4.4",
+                "amphp/websocket-client": "^2.0.2",
+                "ext-sockets": "*",
+                "pestphp/pest": "^5.0.0",
+                "pestphp/pest-plugin": "^5.0.0",
+                "php": "^8.4",
+                "symfony/process": "^8.0.5"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "ext-posix": "*",
+                "livewire/livewire": "^3.7.15",
+                "nunomaduro/collision": "^8.9.3",
+                "orchestra/testbench": "^10.11.0",
+                "pestphp/pest-dev-tools": "^5.0.0",
+                "pestphp/pest-plugin-laravel": "^5.0.0",
+                "pestphp/pest-plugin-type-coverage": "^5.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Browser\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Browser\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Pest plugin to test browser interactions",
+            "keywords": [
+                "browser",
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-browser/tree/5.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-05-13T01:33:08+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-laravel",
+            "version": "5.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-laravel.git",
+                "reference": "3dd5713e5f90cd6648e5a0621207459639dd6a62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-laravel/zipball/3dd5713e5f90cd6648e5a0621207459639dd6a62",
+                "reference": "3dd5713e5f90cd6648e5a0621207459639dd6a62",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^11.45.2|^12.25.0|^13.1.1",
+                "pestphp/pest": "^5.0.0",
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "laravel/dusk": "^8.4.1",
+                "orchestra/testbench": "^9.13.0|^10.5.0|^11.0",
+                "pestphp/pest-dev-tools": "^5.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Laravel\\Plugin"
+                    ]
+                },
+                "laravel": {
+                    "providers": [
+                        "Pest\\Laravel\\PestServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Laravel Plugin",
+            "keywords": [
+                "framework",
+                "laravel",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-laravel/tree/5.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-13T01:44:39+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-mutate",
+            "version": "5.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-mutate.git",
+                "reference": "c61cb58ddfb552918a90f6e117800c389b580bbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/c61cb58ddfb552918a90f6e117800c389b580bbc",
+                "reference": "c61cb58ddfb552918a90f6e117800c389b580bbc",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.7.0",
+                "pestphp/pest-plugin": "^5.0.0",
+                "php": "^8.4",
+                "psr/simple-cache": "^3.0.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^5.0.0",
+                "pestphp/pest-dev-tools": "^5.0.0",
+                "pestphp/pest-plugin-type-coverage": "^5.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Mutate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                },
+                {
+                    "name": "Sandro Gehri",
+                    "email": "sandrogehri@gmail.com"
+                }
+            ],
+            "description": "Mutates your code to find untested cases",
+            "keywords": [
+                "framework",
+                "mutate",
+                "mutation",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/5.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-13T01:44:27+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-profanity",
+            "version": "5.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-profanity.git",
+                "reference": "73aa4c14735b8f0682e06205b35b8481dd8628a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-profanity/zipball/73aa4c14735b8f0682e06205b35b8481dd8628a9",
+                "reference": "73aa4c14735b8f0682e06205b35b8481dd8628a9",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^5.0.0",
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "faissaloux/pest-plugin-inside": "^1.9",
+                "pestphp/pest": "^5.0.0",
+                "pestphp/pest-dev-tools": "^5.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Profanity\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Profanity\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Profanity Plugin",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "profanity",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-profanity/tree/5.x"
+            },
+            "time": "2026-05-21T01:01:12+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -10595,16 +12779,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.1.10",
+            "version": "13.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "38959098d3c10660a189afaa35a94290c1de67bb"
+                "reference": "f49a2b5e51ffb33421745368cc099cf66830d71b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38959098d3c10660a189afaa35a94290c1de67bb",
-                "reference": "38959098d3c10660a189afaa35a94290c1de67bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f49a2b5e51ffb33421745368cc099cf66830d71b",
+                "reference": "f49a2b5e51ffb33421745368cc099cf66830d71b",
                 "shasum": ""
             },
             "require": {
@@ -10618,14 +12802,14 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.4.1",
-                "phpunit/php-code-coverage": "^14.1.8",
+                "phpunit/php-code-coverage": "^14.1.6",
                 "phpunit/php-file-iterator": "^7.0.0",
                 "phpunit/php-invoker": "^7.0.0",
                 "phpunit/php-text-template": "^6.0.0",
                 "phpunit/php-timer": "^9.0.0",
                 "sebastian/cli-parser": "^5.0.0",
-                "sebastian/comparator": "^8.1.3",
-                "sebastian/diff": "^8.3.0",
+                "sebastian/comparator": "^8.1.2",
+                "sebastian/diff": "^8.1.0",
                 "sebastian/environment": "^9.3.0",
                 "sebastian/exporter": "^8.0.2",
                 "sebastian/git-state": "^1.0",
@@ -10674,7 +12858,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.10"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.8"
             },
             "funding": [
                 {
@@ -10682,7 +12866,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-15T08:03:56+00:00"
+            "time": "2026-05-01T04:22:45+00:00"
         },
         {
             "name": "psr/cache",
@@ -10732,6 +12916,78 @@
                 "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
             "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
+            },
+            "time": "2026-05-16T17:55:38+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -10804,16 +13060,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "8.1.4",
+            "version": "8.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1edd557042bf4ff9978ec125d8131b147d5c8224"
+                "reference": "ce999bf08b2c387a5423fe56961c32eed3f88089"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1edd557042bf4ff9978ec125d8131b147d5c8224",
-                "reference": "1edd557042bf4ff9978ec125d8131b147d5c8224",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ce999bf08b2c387a5423fe56961c32eed3f88089",
+                "reference": "ce999bf08b2c387a5423fe56961c32eed3f88089",
                 "shasum": ""
             },
             "require": {
@@ -10821,10 +13077,10 @@
                 "ext-mbstring": "*",
                 "php": ">=8.4",
                 "sebastian/diff": "^8.3",
-                "sebastian/exporter": "^8.0"
+                "sebastian/exporter": "^8.0.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -10832,7 +13088,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.1-dev"
+                    "dev-main": "8.2-dev"
                 }
             },
             "autoload": {
@@ -10872,7 +13128,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/8.1.4"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.2.1"
             },
             "funding": [
                 {
@@ -10892,7 +13148,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-15T08:30:51+00:00"
+            "time": "2026-05-21T04:46:40+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -11045,23 +13301,23 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "9.3.0",
+            "version": "9.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6767059a30e4277ac95ee034809e793528464768"
+                "reference": "a15fa79a5f5cfd0e9f6817dbcdb0048e99efa146"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6767059a30e4277ac95ee034809e793528464768",
-                "reference": "6767059a30e4277ac95ee034809e793528464768",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a15fa79a5f5cfd0e9f6817dbcdb0048e99efa146",
+                "reference": "a15fa79a5f5cfd0e9f6817dbcdb0048e99efa146",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -11097,7 +13353,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/9.3.1"
             },
             "funding": [
                 {
@@ -11117,20 +13373,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T12:14:03+00:00"
+            "time": "2026-05-21T08:47:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "8.0.2",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb"
+                "reference": "c0d29a945f8cf82f300a05e69874508e307ca4c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
-                "reference": "9cee180ebe62259e3ed48df2212d1fc8cfd971bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c0d29a945f8cf82f300a05e69874508e307ca4c6",
+                "reference": "c0d29a945f8cf82f300a05e69874508e307ca4c6",
                 "shasum": ""
             },
             "require": {
@@ -11139,12 +13395,12 @@
                 "sebastian/recursion-context": "^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -11187,7 +13443,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/8.0.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.0"
             },
             "funding": [
                 {
@@ -11207,7 +13463,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-15T12:38:05+00:00"
+            "time": "2026-05-21T11:50:56+00:00"
         },
         {
             "name": "sebastian/git-state",
@@ -11354,24 +13610,24 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "4f21bb7768e1c997722ccc7efb1d6b5c11bfd471"
+                "reference": "d2cff273a90c79b0eb590baa682d4b5c318bdbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/4f21bb7768e1c997722ccc7efb1d6b5c11bfd471",
-                "reference": "4f21bb7768e1c997722ccc7efb1d6b5c11bfd471",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d2cff273a90c79b0eb590baa682d4b5c318bdbb7",
+                "reference": "d2cff273a90c79b0eb590baa682d4b5c318bdbb7",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.0",
+                "nikic/php-parser": "^5.7.0",
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "library",
             "extra": {
@@ -11400,7 +13656,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/5.0.1"
             },
             "funding": [
                 {
@@ -11420,7 +13676,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T04:45:54+00:00"
+            "time": "2026-05-19T16:23:37+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -11638,23 +13894,23 @@
         },
         {
             "name": "sebastian/type",
-            "version": "7.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "42412224607bd3931241bbd17f38e0f972f5a916"
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/42412224607bd3931241bbd17f38e0f972f5a916",
-                "reference": "42412224607bd3931241bbd17f38e0f972f5a916",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fee0309275847fefd7636167085e379c1dbf6990",
+                "reference": "fee0309275847fefd7636167085e379c1dbf6990",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.0"
+                "phpunit/phpunit": "^13.1.10"
             },
             "type": "library",
             "extra": {
@@ -11683,7 +13939,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/7.0.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/7.0.1"
             },
             "funding": [
                 {
@@ -11703,7 +13959,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T04:52:09+00:00"
+            "time": "2026-05-20T06:49:11+00:00"
         },
         {
             "name": "sebastian/version",
@@ -11899,6 +14155,65 @@
             "time": "2026-05-13T12:07:53+00:00"
         },
         {
+            "name": "ta-tikoma/phpunit-architecture-test",
+            "version": "0.8.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18.0 || ^5.0.0",
+                "php": "^8.1.0",
+                "phpdocumentor/reflection-docblock": "^5.3.0 || ^6.0.0",
+                "phpunit/phpunit": "^10.5.5 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+                "symfony/finder": "^6.4.0 || ^7.0.0 || ^8.0.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.13.7",
+                "phpstan/phpstan": "^1.10.52"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPUnit\\Architecture\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ni Shi",
+                    "email": "futik0ma011@gmail.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Methods for testing application architecture",
+            "keywords": [
+                "architecture",
+                "phpunit",
+                "stucture",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.7"
+            },
+            "time": "2026-02-17T17:25:14+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "2.0.1",
             "source": {
@@ -11951,7 +14266,16 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "pestphp/pest": 20,
+        "pestphp/pest-plugin": 20,
+        "pestphp/pest-plugin-arch": 20,
+        "pestphp/pest-plugin-browser": 20,
+        "pestphp/pest-plugin-laravel": 20,
+        "pestphp/pest-plugin-mutate": 20,
+        "pestphp/pest-plugin-profanity": 20,
+        "symfony/process": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b15113e5cbe87b6558830f4d70edd77b",
+    "content-hash": "ffb179852cb27c894594c1f17170e2a2",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/composer.lock
+++ b/composer.lock
@@ -1950,16 +1950,16 @@
         },
         {
             "name": "laravel/jetstream",
-            "version": "v5.5.2",
+            "version": "v5.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/jetstream.git",
-                "reference": "555fda2f7b84eb551b81172ba1ad7794974924cc"
+                "reference": "61cac5cde455311890f6981fb2da47acd298e4e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/jetstream/zipball/555fda2f7b84eb551b81172ba1ad7794974924cc",
-                "reference": "555fda2f7b84eb551b81172ba1ad7794974924cc",
+                "url": "https://api.github.com/repos/laravel/jetstream/zipball/61cac5cde455311890f6981fb2da47acd298e4e2",
+                "reference": "61cac5cde455311890f6981fb2da47acd298e4e2",
                 "shasum": ""
             },
             "require": {
@@ -2012,20 +2012,20 @@
                 "issues": "https://github.com/laravel/jetstream/issues",
                 "source": "https://github.com/laravel/jetstream"
             },
-            "time": "2026-03-20T15:08:31+00:00"
+            "time": "2026-05-19T01:30:03+00:00"
         },
         {
             "name": "laravel/passkeys",
-            "version": "v0.2.0",
+            "version": "v0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/passkeys-server.git",
-                "reference": "d4f5518e8e86ee3f6e0bbc284513f604f5ce1aef"
+                "reference": "a76656ada41b2b4a591f075eddae5ddc67e8ab9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/passkeys-server/zipball/d4f5518e8e86ee3f6e0bbc284513f604f5ce1aef",
-                "reference": "d4f5518e8e86ee3f6e0bbc284513f604f5ce1aef",
+                "url": "https://api.github.com/repos/laravel/passkeys-server/zipball/a76656ada41b2b4a591f075eddae5ddc67e8ab9c",
+                "reference": "a76656ada41b2b4a591f075eddae5ddc67e8ab9c",
                 "shasum": ""
             },
             "require": {
@@ -2080,7 +2080,7 @@
                 "issues": "https://github.com/laravel/passkeys-server/issues",
                 "source": "https://github.com/laravel/passkeys-server"
             },
-            "time": "2026-05-14T18:49:04+00:00"
+            "time": "2026-05-18T16:26:00+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -5290,16 +5290,16 @@
         },
         {
             "name": "spatie/crawler",
-            "version": "9.3.0",
+            "version": "9.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/crawler.git",
-                "reference": "1b9ce60037a7fd97eb5489521d99383bd2abad9f"
+                "reference": "0c0b6e4928040d90c1d0508fd6e5655e8a51067c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/crawler/zipball/1b9ce60037a7fd97eb5489521d99383bd2abad9f",
-                "reference": "1b9ce60037a7fd97eb5489521d99383bd2abad9f",
+                "url": "https://api.github.com/repos/spatie/crawler/zipball/0c0b6e4928040d90c1d0508fd6e5655e8a51067c",
+                "reference": "0c0b6e4928040d90c1d0508fd6e5655e8a51067c",
                 "shasum": ""
             },
             "require": {
@@ -5353,7 +5353,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/crawler/issues",
-                "source": "https://github.com/spatie/crawler/tree/9.3.0"
+                "source": "https://github.com/spatie/crawler/tree/9.3.1"
             },
             "funding": [
                 {
@@ -5365,20 +5365,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-15T11:16:19+00:00"
+            "time": "2026-05-18T13:26:09+00:00"
         },
         {
             "name": "spatie/laravel-package-tools",
-            "version": "1.93.0",
+            "version": "1.93.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-package-tools.git",
-                "reference": "0d097bce95b2bf6802fb1d83e1e753b0f5a948e7"
+                "reference": "d5552849801f2642aea710557463234b59ef65eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/0d097bce95b2bf6802fb1d83e1e753b0f5a948e7",
-                "reference": "0d097bce95b2bf6802fb1d83e1e753b0f5a948e7",
+                "url": "https://api.github.com/repos/spatie/laravel-package-tools/zipball/d5552849801f2642aea710557463234b59ef65eb",
+                "reference": "d5552849801f2642aea710557463234b59ef65eb",
                 "shasum": ""
             },
             "require": {
@@ -5418,7 +5418,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-package-tools/issues",
-                "source": "https://github.com/spatie/laravel-package-tools/tree/1.93.0"
+                "source": "https://github.com/spatie/laravel-package-tools/tree/1.93.1"
             },
             "funding": [
                 {
@@ -5426,20 +5426,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-21T12:49:54+00:00"
+            "time": "2026-05-19T14:06:37+00:00"
         },
         {
             "name": "spatie/laravel-pdf",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-pdf.git",
-                "reference": "2ba286a03ee5e22463fb0a6e706b157a21d5f60a"
+                "reference": "cc6fbcbd7db6ad97e7a0961e06a2f82d2aca8af2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-pdf/zipball/2ba286a03ee5e22463fb0a6e706b157a21d5f60a",
-                "reference": "2ba286a03ee5e22463fb0a6e706b157a21d5f60a",
+                "url": "https://api.github.com/repos/spatie/laravel-pdf/zipball/cc6fbcbd7db6ad97e7a0961e06a2f82d2aca8af2",
+                "reference": "cc6fbcbd7db6ad97e7a0961e06a2f82d2aca8af2",
                 "shasum": ""
             },
             "require": {
@@ -5517,9 +5517,9 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-pdf/issues",
-                "source": "https://github.com/spatie/laravel-pdf/tree/2.8.0"
+                "source": "https://github.com/spatie/laravel-pdf/tree/2.9.0"
             },
-            "time": "2026-04-27T08:15:52+00:00"
+            "time": "2026-05-22T12:31:26+00:00"
         },
         {
             "name": "spatie/laravel-sitemap",
@@ -6206,16 +6206,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v8.0.8",
+            "version": "v8.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "284ace90732b445b027728b5e0eec6418a17a364"
+                "reference": "011b0ce60417f6d40052434d8ae6295b876ecbdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/284ace90732b445b027728b5e0eec6418a17a364",
-                "reference": "284ace90732b445b027728b5e0eec6418a17a364",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/011b0ce60417f6d40052434d8ae6295b876ecbdd",
+                "reference": "011b0ce60417f6d40052434d8ae6295b876ecbdd",
                 "shasum": ""
             },
             "require": {
@@ -6252,7 +6252,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v8.0.8"
+                "source": "https://github.com/symfony/dom-crawler/tree/v8.0.12"
             },
             "funding": [
                 {
@@ -6272,7 +6272,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-20T07:22:03+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -9205,16 +9205,16 @@
         },
         {
             "name": "web-auth/webauthn-lib",
-            "version": "5.3.2",
+            "version": "5.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-auth/webauthn-lib.git",
-                "reference": "a272f254c056fb3d6c80a4801d3c7c5fedc6a08d"
+                "reference": "e6f656d6c6b29fa305382fe6a0a3be8177d177df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-auth/webauthn-lib/zipball/a272f254c056fb3d6c80a4801d3c7c5fedc6a08d",
-                "reference": "a272f254c056fb3d6c80a4801d3c7c5fedc6a08d",
+                "url": "https://api.github.com/repos/web-auth/webauthn-lib/zipball/e6f656d6c6b29fa305382fe6a0a3be8177d177df",
+                "reference": "e6f656d6c6b29fa305382fe6a0a3be8177d177df",
                 "shasum": ""
             },
             "require": {
@@ -9275,7 +9275,7 @@
                 "webauthn"
             ],
             "support": {
-                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.2"
+                "source": "https://github.com/web-auth/webauthn-lib/tree/5.3.3"
             },
             "funding": [
                 {
@@ -9287,7 +9287,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-05-01T12:14:37+00:00"
+            "time": "2026-05-17T19:04:30+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -11344,16 +11344,16 @@
         },
         {
             "name": "laravel/sail",
-            "version": "v1.59.0",
+            "version": "v1.60.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "a41abad557e487eaefde6c9873085ed086fdf47a"
+                "reference": "2a1538ed22eed4210ac1e17904235032571bd89c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/a41abad557e487eaefde6c9873085ed086fdf47a",
-                "reference": "a41abad557e487eaefde6c9873085ed086fdf47a",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/2a1538ed22eed4210ac1e17904235032571bd89c",
+                "reference": "2a1538ed22eed4210ac1e17904235032571bd89c",
                 "shasum": ""
             },
             "require": {
@@ -11403,7 +11403,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-05-13T14:02:20+00:00"
+            "time": "2026-05-14T17:29:51+00:00"
         },
         {
             "name": "league/uri-components",
@@ -14081,16 +14081,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v8.0.11",
+            "version": "v8.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "48046fbd5567bd1717f278eaa2cfc3131f489984"
+                "reference": "2a36f4b8405d41fa31799b06874dbd45c1b16c30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/48046fbd5567bd1717f278eaa2cfc3131f489984",
-                "reference": "48046fbd5567bd1717f278eaa2cfc3131f489984",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/2a36f4b8405d41fa31799b06874dbd45c1b16c30",
+                "reference": "2a36f4b8405d41fa31799b06874dbd45c1b16c30",
                 "shasum": ""
             },
             "require": {
@@ -14132,7 +14132,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v8.0.11"
+                "source": "https://github.com/symfony/yaml/tree/v8.0.12"
             },
             "funding": [
                 {
@@ -14152,7 +14152,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-13T12:07:53+00:00"
+            "time": "2026-05-20T07:22:03+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "axios": "^1.13.2",
                 "chart.js": "^4.5.1",
                 "concurrently": "^9.2.1",
-                "daisyui": "^5.5.17",
+                "daisyui": "^5.5.20",
                 "laravel-vite-plugin": "^3.0.1",
                 "postcss": "^8.5.6",
                 "puppeteer": "^25.0.2",
@@ -3331,9 +3331,9 @@
             }
         },
         "node_modules/daisyui": {
-            "version": "5.5.19",
-            "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
-            "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
+            "version": "5.5.20",
+            "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.20.tgz",
+            "integrity": "sha512-HemJcjl0Gk9rQ8BcgofN6p+EURrqftQG9wK1Hkxs98i49xe68+QxpNvry+PyxwkIUgrbMpNmZ5ZWjmtffAjfhQ==",
             "dev": true,
             "license": "MIT",
             "funding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1173,21 +1173,27 @@
             "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.4.3",
-                "@emnapi/runtime": "^1.4.3",
-                "@tybys/wasm-util": "^0.10.0"
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.130.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-            "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+            "version": "0.132.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+            "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1233,9 +1239,9 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.2.tgz",
-            "integrity": "sha512-JnOSHrAdCQOj27P5QnTrd6bkYd9cXXeFMJS5UJF3UmQbpZQAMMO7AaL0NyrT7i2l/43bwjaHguU+LOpBRyx66w==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.3.tgz",
+            "integrity": "sha512-v3YaiGpzUTgOZkHBFR0iZg58Vto25SqBQxfLUXDiofJccwVl6Mlr7BdLCS1NZgxikdeIHf936cxYWL9IZp3tow==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1261,9 +1267,9 @@
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -1274,9 +1280,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-            "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+            "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1291,9 +1297,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-            "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+            "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
             "cpu": [
                 "arm64"
             ],
@@ -1308,9 +1314,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-            "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+            "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
             "cpu": [
                 "x64"
             ],
@@ -1325,9 +1331,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-            "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+            "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
             "cpu": [
                 "x64"
             ],
@@ -1342,9 +1348,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-            "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+            "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
             "cpu": [
                 "arm"
             ],
@@ -1359,9 +1365,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-            "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+            "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
             "cpu": [
                 "arm64"
             ],
@@ -1379,9 +1385,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-            "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+            "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
             "cpu": [
                 "arm64"
             ],
@@ -1399,9 +1405,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-            "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+            "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
             "cpu": [
                 "ppc64"
             ],
@@ -1419,9 +1425,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-            "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+            "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1439,9 +1445,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-            "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+            "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
             "cpu": [
                 "x64"
             ],
@@ -1459,9 +1465,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-            "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+            "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
             "cpu": [
                 "x64"
             ],
@@ -1479,9 +1485,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-            "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+            "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
             "cpu": [
                 "arm64"
             ],
@@ -1496,9 +1502,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-            "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+            "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
             "cpu": [
                 "wasm32"
             ],
@@ -1514,29 +1520,10 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-            "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+            "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
             "cpu": [
                 "arm64"
             ],
@@ -1551,9 +1538,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-            "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+            "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
             "cpu": [
                 "x64"
             ],
@@ -2028,9 +2015,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "25.8.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
-            "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
+            "version": "25.9.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+            "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": ">=7.24.0 <7.24.7"
@@ -2070,9 +2057,9 @@
             "license": "ISC"
         },
         "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-            "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+            "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
             "cpu": [
                 "arm"
             ],
@@ -2083,9 +2070,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-android-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-            "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+            "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2096,9 +2083,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-            "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+            "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
             "cpu": [
                 "arm64"
             ],
@@ -2109,9 +2096,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-            "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+            "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
             "cpu": [
                 "x64"
             ],
@@ -2122,9 +2109,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-freebsd-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-            "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+            "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
             "cpu": [
                 "x64"
             ],
@@ -2135,9 +2122,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-            "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+            "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
             "cpu": [
                 "arm"
             ],
@@ -2148,9 +2135,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-            "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+            "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
             "cpu": [
                 "arm"
             ],
@@ -2161,9 +2148,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-            "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+            "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
             "cpu": [
                 "arm64"
             ],
@@ -2177,9 +2164,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-            "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+            "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
             "cpu": [
                 "arm64"
             ],
@@ -2192,10 +2179,42 @@
                 "linux"
             ]
         },
+        "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+            "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+            "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+            "cpu": [
+                "loong64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
         "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-            "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+            "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
             "cpu": [
                 "ppc64"
             ],
@@ -2209,9 +2228,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-            "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+            "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
             "cpu": [
                 "riscv64"
             ],
@@ -2225,9 +2244,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-            "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+            "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
             "cpu": [
                 "riscv64"
             ],
@@ -2241,9 +2260,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-            "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+            "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
             "cpu": [
                 "s390x"
             ],
@@ -2257,9 +2276,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-            "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+            "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
             "cpu": [
                 "x64"
             ],
@@ -2273,9 +2292,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-            "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+            "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
             "cpu": [
                 "x64"
             ],
@@ -2288,26 +2307,41 @@
                 "linux"
             ]
         },
+        "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+            "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
         "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-            "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+            "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
             "cpu": [
                 "wasm32"
             ],
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^0.2.11"
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-            "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+            "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
             "cpu": [
                 "arm64"
             ],
@@ -2318,9 +2352,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-            "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+            "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
             "cpu": [
                 "ia32"
             ],
@@ -2331,9 +2365,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-            "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+            "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
             "cpu": [
                 "x64"
             ],
@@ -2344,16 +2378,16 @@
             ]
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-            "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+            "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.6",
-                "@vitest/utils": "4.1.6",
+                "@vitest/spy": "4.1.7",
+                "@vitest/utils": "4.1.7",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -2362,13 +2396,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-            "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+            "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.6",
+                "@vitest/spy": "4.1.7",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -2389,9 +2423,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-            "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+            "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2402,13 +2436,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-            "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+            "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.6",
+                "@vitest/utils": "4.1.7",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -2416,14 +2450,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-            "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+            "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.6",
-                "@vitest/utils": "4.1.6",
+                "@vitest/pretty-format": "4.1.7",
+                "@vitest/utils": "4.1.7",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -2432,9 +2466,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-            "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+            "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -2442,13 +2476,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-            "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+            "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.6",
+                "@vitest/pretty-format": "4.1.7",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -2859,9 +2893,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.30",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
-            "integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
+            "version": "2.10.32",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+            "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -3457,9 +3491,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.357",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
-            "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
+            "version": "1.5.361",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+            "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
             "license": "ISC"
         },
         "node_modules/emittery": {
@@ -3491,9 +3525,9 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.21.3",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
-            "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+            "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3563,9 +3597,9 @@
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4257,9 +4291,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -4816,9 +4850,9 @@
             }
         },
         "node_modules/jest-snapshot/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -5405,9 +5439,9 @@
             }
         },
         "node_modules/make-dir/node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -5557,10 +5591,13 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.44",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
-            "license": "MIT"
+            "version": "2.0.46",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+            "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -5867,9 +5904,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "dev": true,
             "funding": [
                 {
@@ -5887,7 +5924,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.11",
+                "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -5984,18 +6021,18 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "25.0.2",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.0.2.tgz",
-            "integrity": "sha512-cXj/5RlDCzSC7k1YdBIm6prb8lK8lEdmScVbcalX1rBn4fqNN1UNuEz/HZZYiDLsK8dOGvyLpGjh6CgxCyqKtg==",
+            "version": "25.0.4",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.0.4.tgz",
+            "integrity": "sha512-QFdBAuNOqL0I+AdARTlRR1KcgPk0fo0dU127e1ZQFVxb9QPcpBDIiQp/dMgdbyLXHpF2GRjC/OezDmjKcLCKYw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "3.0.2",
+                "@puppeteer/browsers": "3.0.3",
                 "chromium-bidi": "16.0.1",
                 "cosmiconfig": "^9.0.0",
                 "devtools-protocol": "0.0.1608973",
-                "puppeteer-core": "25.0.2",
+                "puppeteer-core": "25.0.4",
                 "typed-query-selector": "^2.12.2"
             },
             "bin": {
@@ -6006,13 +6043,13 @@
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "25.0.2",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.0.2.tgz",
-            "integrity": "sha512-Q0IUIHER1S9PiNIfdNFc+pVOj79Tp4b9v0Fv4enigwsLy0Hbgq45KFgqzmN31DeCXh+Uvxnt9r7fMERhAMjs8Q==",
+            "version": "25.0.4",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.0.4.tgz",
+            "integrity": "sha512-K1LQKDP6w1rIr1jUyN9obH16TO/DCy86k3q+FBd2prGY+TStxhFySxmaZZuRF+0D3BJXjwCYFke7tMHCH4olTA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@puppeteer/browsers": "3.0.2",
+                "@puppeteer/browsers": "3.0.3",
                 "chromium-bidi": "16.0.1",
                 "debug": "^4.4.3",
                 "devtools-protocol": "0.0.1608973",
@@ -6085,13 +6122,13 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-            "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+            "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.130.0",
+                "@oxc-project/types": "=0.132.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -6101,21 +6138,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.1",
-                "@rolldown/binding-darwin-arm64": "1.0.1",
-                "@rolldown/binding-darwin-x64": "1.0.1",
-                "@rolldown/binding-freebsd-x64": "1.0.1",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.1",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.1",
-                "@rolldown/binding-linux-arm64-musl": "1.0.1",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.1",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.1",
-                "@rolldown/binding-linux-x64-gnu": "1.0.1",
-                "@rolldown/binding-linux-x64-musl": "1.0.1",
-                "@rolldown/binding-openharmony-arm64": "1.0.1",
-                "@rolldown/binding-wasm32-wasi": "1.0.1",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.1",
-                "@rolldown/binding-win32-x64-msvc": "1.0.1"
+                "@rolldown/binding-android-arm64": "1.0.2",
+                "@rolldown/binding-darwin-arm64": "1.0.2",
+                "@rolldown/binding-darwin-x64": "1.0.2",
+                "@rolldown/binding-freebsd-x64": "1.0.2",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+                "@rolldown/binding-linux-arm64-musl": "1.0.2",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-gnu": "1.0.2",
+                "@rolldown/binding-linux-x64-musl": "1.0.2",
+                "@rolldown/binding-openharmony-arm64": "1.0.2",
+                "@rolldown/binding-wasm32-wasi": "1.0.2",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+                "@rolldown/binding-win32-x64-msvc": "1.0.2"
             }
         },
         "node_modules/rrweb-cssom": {
@@ -6774,37 +6811,40 @@
             "license": "MIT"
         },
         "node_modules/unrs-resolver": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-            "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+            "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "napi-postinstall": "^0.3.0"
+                "napi-postinstall": "^0.3.4"
             },
             "funding": {
                 "url": "https://opencollective.com/unrs-resolver"
             },
             "optionalDependencies": {
-                "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-                "@unrs/resolver-binding-android-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-x64": "1.11.1",
-                "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-                "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-                "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+                "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+                "@unrs/resolver-binding-android-arm64": "1.12.2",
+                "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+                "@unrs/resolver-binding-darwin-x64": "1.12.2",
+                "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+                "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+                "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+                "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+                "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+                "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+                "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+                "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -6859,16 +6899,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.13",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-            "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+            "version": "8.0.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+            "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.14",
-                "rolldown": "1.0.1",
+                "postcss": "^8.5.15",
+                "rolldown": "1.0.2",
                 "tinyglobby": "^0.2.16"
             },
             "bin": {
@@ -6961,19 +7001,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-            "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+            "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.6",
-                "@vitest/mocker": "4.1.6",
-                "@vitest/pretty-format": "4.1.6",
-                "@vitest/runner": "4.1.6",
-                "@vitest/snapshot": "4.1.6",
-                "@vitest/spy": "4.1.6",
-                "@vitest/utils": "4.1.6",
+                "@vitest/expect": "4.1.7",
+                "@vitest/mocker": "4.1.7",
+                "@vitest/pretty-format": "4.1.7",
+                "@vitest/runner": "4.1.7",
+                "@vitest/snapshot": "4.1.7",
+                "@vitest/spy": "4.1.7",
+                "@vitest/utils": "4.1.7",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -7001,12 +7041,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.6",
-                "@vitest/browser-preview": "4.1.6",
-                "@vitest/browser-webdriverio": "4.1.6",
-                "@vitest/coverage-istanbul": "4.1.6",
-                "@vitest/coverage-v8": "4.1.6",
-                "@vitest/ui": "4.1.6",
+                "@vitest/browser-playwright": "4.1.7",
+                "@vitest/browser-preview": "4.1.7",
+                "@vitest/browser-webdriverio": "4.1.7",
+                "@vitest/coverage-istanbul": "4.1.7",
+                "@vitest/coverage-v8": "4.1.7",
+                "@vitest/ui": "4.1.7",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -7262,9 +7302,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.20.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
         "test:e2e": "playwright test",
         "test:e2e:docker": "node tests/e2e/run-playwright-docker.mjs",
-        "test:e2e:modal-screenshots:docker": "node tests/e2e/run-playwright-docker.mjs tests/e2e/modal-preview.spec.js --project=chromium",
+        "test:e2e:modal-screenshots:docker": "node tests/e2e/run-playwright-docker.mjs --capture-modal-screenshots tests/e2e/modal-preview.spec.js --project=chromium",
         "test:vitest": "vitest run --config vitest.config.js --maxWorkers=1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
         "test:e2e": "playwright test",
         "test:e2e:docker": "node tests/e2e/run-playwright-docker.mjs",
+        "test:e2e:modal-screenshots:docker": "node tests/e2e/run-playwright-docker.mjs tests/e2e/modal-preview.spec.js --project=chromium",
         "test:vitest": "vitest run --config vitest.config.js --maxWorkers=1"
     },
     "devDependencies": {
@@ -22,7 +23,7 @@
         "axios": "^1.13.2",
         "chart.js": "^4.5.1",
         "concurrently": "^9.2.1",
-        "daisyui": "^5.5.17",
+        "daisyui": "^5.5.20",
         "laravel-vite-plugin": "^3.0.1",
         "postcss": "^8.5.6",
         "puppeteer": "^25.0.2",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Browser">
+            <directory>tests/Browser</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,9 +7,6 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
-        <testsuite name="Browser">
-            <directory>tests/Browser</directory>
-        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -153,11 +153,11 @@ details.dropdown:has(> summary.btn-sm) > ul.menu {
     font-weight: 600;
 }
 
-/* DaisyUI-Modal-Hintergrund: Die produktive Modal-Kette laeuft ueber
-   `dialog.modal`, den nativen `::backdrop` und bei Mary zusaetzlich ueber ein
-   internes `.modal-backdrop`-Element. DaisyUI liefert diese Regeln in einem
-   Layer aus; hier bewusst un-layered haerten, damit der halbtransparente
-   Overlay in allen Oeffnungspfaden sichtbar bleibt. */
+/* DaisyUI-Modal-Hintergrund: Die produktive Modal-Kette läuft über
+    `dialog.modal`, den nativen `::backdrop` und bei Mary zusätzlich über ein
+    internes `.modal-backdrop`-Element. DaisyUI liefert diese Regeln in einem
+    Layer aus; hier bewusst ohne Layer härten, damit der halbtransparente
+    Overlay in allen Öffnungspfaden sichtbar bleibt. */
 dialog.modal:is(.modal-open, [open], :target),
 dialog.modal:is(.modal-open, [open], :target)::backdrop,
 dialog.modal:is(.modal-open, [open], :target) > .modal-backdrop {

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -153,11 +153,14 @@ details.dropdown:has(> summary.btn-sm) > ul.menu {
     font-weight: 600;
 }
 
-/* DaisyUI-Modal-Hintergrund: Die Backdrop-Regel (.modal.modal-open) liegt in
-   @layer daisyui.l1.l2 – layered Styles haben niedrigere Priorität als
-   un-layered Styles. Hier un-layered setzen, damit der halbtransparente
-   Overlay zuverlässig angezeigt wird. */
-dialog.modal:is(.modal-open, [open], :target) {
+/* DaisyUI-Modal-Hintergrund: Die produktive Modal-Kette laeuft ueber
+   `dialog.modal`, den nativen `::backdrop` und bei Mary zusaetzlich ueber ein
+   internes `.modal-backdrop`-Element. DaisyUI liefert diese Regeln in einem
+   Layer aus; hier bewusst un-layered haerten, damit der halbtransparente
+   Overlay in allen Oeffnungspfaden sichtbar bleibt. */
+dialog.modal:is(.modal-open, [open], :target),
+dialog.modal:is(.modal-open, [open], :target)::backdrop,
+dialog.modal:is(.modal-open, [open], :target) > .modal-backdrop {
     background-color: oklch(0% 0 0 / 40%);
 }
 

--- a/resources/views/testing/modal-preview.blade.php
+++ b/resources/views/testing/modal-preview.blade.php
@@ -51,8 +51,8 @@
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 <body class="min-h-screen bg-base-200 text-base-content antialiased">
-    <main data-preview-page class="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-8 px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
-        <header class="rounded-4xl border border-base-300 bg-base-100 px-6 py-8 shadow-sm sm:px-8">
+    <main data-preview-page data-expected-modal-count="{{ count($allModals) }}" class="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-8 px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
+        <header class="rounded-3xl border border-base-300 bg-base-100 px-6 py-8 shadow-sm sm:px-8">
             <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
                 <div class="max-w-3xl space-y-3">
                     <span class="badge badge-outline badge-lg">Nur lokal und im Test</span>
@@ -129,7 +129,7 @@
                 </section>
             </div>
 
-            <aside class="rounded-4xl border border-base-300 bg-base-100 p-6 shadow-sm lg:p-7">
+            <aside class="rounded-3xl border border-base-300 bg-base-100 p-6 shadow-sm lg:p-7">
                 <h2 class="text-xl font-semibold">Prüfziel</h2>
                 <div class="mt-4 space-y-4 text-sm leading-7 text-base-content/70">
                     <p>Alle Vorschauen verwenden dieselbe Backdrop-Prüfung wie die Browser-Tests. Sobald ein Modal geöffnet wird, darf der Hintergrund nicht transparent bleiben.</p>
@@ -155,7 +155,7 @@
         <dialog id="{{ $modal['id'] }}" class="modal" data-preview-modal data-modal-family="{{ $modal['family'] }}">
             <div class="modal-box">
                 <form method="dialog" tabindex="-1">
-                    <button type="submit" class="btn btn-circle btn-ghost btn-sm absolute inset-e-2 top-2 z-999" tabindex="-1">✕</button>
+                    <button type="submit" class="btn btn-circle btn-ghost btn-sm absolute inset-e-2 top-2 z-10" aria-label="Schließen" tabindex="-1">✕</button>
                 </form>
 
                 <div class="mb-5 space-y-3">
@@ -190,9 +190,9 @@
             data-preview-overlay
             data-modal-family="{{ $modal['family'] }}"
             data-open="false"
-            class="{{ $modal['backdropClass'] }} fixed inset-0 z-50 hidden items-center justify-center px-4 py-8"
+            class="{{ $modal['backdropClass'] }} fixed inset-0 z-50 hidden flex items-center justify-center px-4 py-8"
         >
-            <div class="relative w-full max-w-2xl rounded-4xl border border-white/15 bg-base-100 p-6 shadow-2xl sm:p-8">
+            <div class="relative w-full max-w-2xl rounded-3xl border border-white/15 bg-base-100 p-6 shadow-2xl sm:p-8">
                 <button type="button" class="btn btn-circle btn-ghost absolute right-4 top-4" aria-label="Schließen" onclick="window.__omxfcClosePreviewModals()">✕</button>
                 <div class="space-y-4">
                     <span class="badge badge-outline">{{ $modal['family'] }}</span>
@@ -212,34 +212,81 @@
 
     <script>
         (() => {
-            const colorParser = document.createElement('canvas').getContext('2d');
+            function clampAlpha(value) {
+                return Math.min(Math.max(value, 0), 1);
+            }
 
-            function normalizeColor(color) {
-                if (!colorParser || !color) {
-                    return 'transparent';
+            function normalizeAlphaValue(value) {
+                const normalized = value.trim();
+
+                if (!normalized) {
+                    return 0;
                 }
 
-                colorParser.fillStyle = '#000';
-                colorParser.fillStyle = color;
+                const parsed = Number.parseFloat(normalized);
 
-                return colorParser.fillStyle;
+                if (Number.isNaN(parsed)) {
+                    return 0;
+                }
+
+                return clampAlpha(normalized.endsWith('%') ? parsed / 100 : parsed);
+            }
+
+            function alphaFromHex(color) {
+                const value = color.slice(1);
+
+                if (value.length === 4) {
+                    return clampAlpha(Number.parseInt(value.slice(3, 4).repeat(2), 16) / 255);
+                }
+
+                if (value.length === 8) {
+                    return clampAlpha(Number.parseInt(value.slice(6, 8), 16) / 255);
+                }
+
+                return 1;
             }
 
             function alphaFromColor(color) {
-                const normalized = normalizeColor(color);
+                if (typeof color !== 'string') {
+                    return 0;
+                }
+
+                const normalized = color.trim().toLowerCase();
 
                 if (!normalized || normalized === 'transparent') {
                     return 0;
                 }
 
-                const rgbaMatch = normalized.match(/^rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*([0-9.]+)\s*\)$/i);
+                if (normalized.startsWith('#')) {
+                    return alphaFromHex(normalized);
+                }
 
-                if (rgbaMatch) {
-                    return Number(rgbaMatch[1]);
+                const functionalColorMatch = normalized.match(/^([a-z-]+)\((.*)\)$/i);
+
+                if (!functionalColorMatch) {
+                    return 0;
+                }
+
+                const [, functionName, rawArguments] = functionalColorMatch;
+                const alphaSeparatorIndex = rawArguments.lastIndexOf('/');
+
+                if (alphaSeparatorIndex !== -1) {
+                    return normalizeAlphaValue(rawArguments.slice(alphaSeparatorIndex + 1));
+                }
+
+                const commaSeparatedArguments = rawArguments
+                    .split(',')
+                    .map((part) => part.trim())
+                    .filter(Boolean);
+
+                if ((functionName.endsWith('a') || commaSeparatedArguments.length === 4) && commaSeparatedArguments.length > 0) {
+                    return normalizeAlphaValue(commaSeparatedArguments.at(-1));
                 }
 
                 return 1;
             }
+
+            window.__omxfcPreviewExpectedModalCount = () => Number(document.querySelector('[data-preview-page]')?.dataset.expectedModalCount ?? 0);
 
             window.__omxfcClosePreviewModals = () => {
                 document.querySelectorAll('dialog[data-preview-modal][open]').forEach((dialog) => {

--- a/resources/views/testing/modal-preview.blade.php
+++ b/resources/views/testing/modal-preview.blade.php
@@ -1,0 +1,298 @@
+@php
+    $maryModals = [
+        ['id' => 'preview-todo-delete', 'alias' => 'modal', 'label' => 'Challenge löschen', 'source' => 'resources/views/livewire/todo-show.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-three-d-model-delete', 'alias' => 'modal', 'label' => '3D-Modell löschen', 'source' => 'resources/views/livewire/three-d-model-show.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-hoerbuch-delete', 'alias' => 'modal', 'label' => 'Hörbuchfolge löschen', 'source' => 'resources/views/livewire/hoerbuch-show.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-api-token-display', 'alias' => 'modal', 'label' => 'API Token anzeigen', 'source' => 'resources/views/api/api-token-manager.blade.php', 'family' => 'Jetstream x-modal'],
+        ['id' => 'preview-api-token-permissions', 'alias' => 'modal', 'label' => 'API Token Rechte', 'source' => 'resources/views/api/api-token-manager.blade.php', 'family' => 'Jetstream x-modal'],
+        ['id' => 'preview-api-token-delete', 'alias' => 'modal', 'label' => 'API Token löschen', 'source' => 'resources/views/api/api-token-manager.blade.php', 'family' => 'Jetstream x-modal'],
+        ['id' => 'preview-review-delete', 'alias' => 'modal', 'label' => 'Rezension löschen', 'source' => 'resources/views/livewire/rezension-show.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-confirm-password', 'alias' => 'modal', 'label' => 'Passwort bestätigen', 'source' => 'resources/views/components/confirms-password.blade.php', 'family' => 'Jetstream x-modal'],
+        ['id' => 'preview-reward-modal', 'alias' => 'modal', 'label' => 'Belohnung bearbeiten', 'source' => 'resources/views/livewire/belohnungen-admin.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-rule-modal', 'alias' => 'modal', 'label' => 'Vergaberegel bearbeiten', 'source' => 'resources/views/livewire/belohnungen-admin.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-review-special-offer', 'alias' => 'modal', 'label' => 'Review-Sonderaktion bearbeiten', 'source' => 'resources/views/livewire/belohnungen-admin.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-maddraxiversum-special-offer', 'alias' => 'modal', 'label' => 'Maddraxiversum-Sonderaktion bearbeiten', 'source' => 'resources/views/livewire/belohnungen-admin.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-romantausch-special-offer', 'alias' => 'modal', 'label' => 'Romantausch-Sonderaktion bearbeiten', 'source' => 'resources/views/livewire/belohnungen-admin.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-download-modal', 'alias' => 'modal', 'label' => 'Download bearbeiten', 'source' => 'resources/views/livewire/belohnungen-admin.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-kompendium-edit', 'alias' => 'modal', 'label' => 'Roman bearbeiten', 'source' => 'resources/views/livewire/kompendium-admin-dashboard.blade.php', 'family' => 'Livewire x-modal'],
+        ['id' => 'preview-mission-modal', 'alias' => 'modal', 'label' => 'Mission-Info', 'source' => 'resources/views/maddraxiversum/index.blade.php', 'family' => 'Seitenweites x-modal'],
+        ['id' => 'preview-logout-sessions', 'alias' => 'mary-modal', 'label' => 'Alle anderen Browser-Sitzungen beenden', 'source' => 'resources/views/profile/logout-other-browser-sessions-form.blade.php', 'family' => 'Jetstream x-mary-modal'],
+        ['id' => 'preview-delete-user', 'alias' => 'mary-modal', 'label' => 'Mitgliedschaft kündigen', 'source' => 'resources/views/profile/delete-user-form.blade.php', 'family' => 'Jetstream x-mary-modal'],
+        ['id' => 'preview-delete-team', 'alias' => 'mary-modal', 'label' => 'Arbeitsgruppe löschen', 'source' => 'resources/views/teams/delete-team-form.blade.php', 'family' => 'Jetstream x-mary-modal'],
+        ['id' => 'preview-team-role', 'alias' => 'mary-modal', 'label' => 'Rolle verwalten', 'source' => 'resources/views/teams/team-member-manager.blade.php', 'family' => 'Jetstream x-mary-modal'],
+        ['id' => 'preview-leave-team', 'alias' => 'mary-modal', 'label' => 'Arbeitsgruppe verlassen', 'source' => 'resources/views/teams/team-member-manager.blade.php', 'family' => 'Jetstream x-mary-modal'],
+        ['id' => 'preview-remove-member', 'alias' => 'mary-modal', 'label' => 'Mitglied entfernen', 'source' => 'resources/views/teams/team-member-manager.blade.php', 'family' => 'Jetstream x-mary-modal'],
+        ['id' => 'preview-profile-photo', 'alias' => 'mary-modal', 'label' => 'Profilfoto', 'source' => 'resources/views/profile/view.blade.php', 'family' => 'showModal x-mary-modal'],
+        ['id' => 'preview-badge-modal', 'alias' => 'mary-modal', 'label' => 'Badge-Ansicht', 'source' => 'resources/views/profile/view.blade.php', 'family' => 'showModal x-mary-modal'],
+        ['id' => 'preview-reject-applicant', 'alias' => 'mary-modal', 'label' => 'Antrag ablehnen', 'source' => 'resources/views/dashboard/partials/applicants-panel.blade.php', 'family' => 'showModal x-mary-modal'],
+        ['id' => 'preview-fanfiction-delete', 'alias' => 'mary-modal', 'label' => 'Fanfiction löschen', 'source' => 'resources/views/admin/fanfiction/index.blade.php', 'family' => 'showModal x-mary-modal'],
+    ];
+
+    $customOverlays = [
+        ['id' => 'preview-confirm-delete', 'label' => 'Bestätigung aus confirm-delete', 'source' => 'resources/views/components/confirm-delete.blade.php', 'family' => 'Alpine Overlay', 'backdropClass' => 'bg-black/50'],
+        ['id' => 'preview-kassenbuch-payment', 'label' => 'Kassenbuch Zahlungsdaten', 'source' => 'resources/views/livewire/kassenbuch-index.blade.php', 'family' => 'Livewire Overlay', 'backdropClass' => 'bg-black/50'],
+        ['id' => 'preview-kassenbuch-create', 'label' => 'Kassenbucheintrag hinzufügen', 'source' => 'resources/views/livewire/kassenbuch-index.blade.php', 'family' => 'Livewire Overlay', 'backdropClass' => 'bg-black/50'],
+        ['id' => 'preview-kassenbuch-request-edit', 'label' => 'Bearbeitung anfragen', 'source' => 'resources/views/livewire/kassenbuch-index.blade.php', 'family' => 'Livewire Overlay', 'backdropClass' => 'bg-black/50'],
+        ['id' => 'preview-kassenbuch-edit', 'label' => 'Kassenbucheintrag bearbeiten', 'source' => 'resources/views/livewire/kassenbuch-index.blade.php', 'family' => 'Livewire Overlay', 'backdropClass' => 'bg-black/50'],
+        ['id' => 'preview-kassenbuch-reject-request', 'label' => 'Bearbeitungsanfrage ablehnen', 'source' => 'resources/views/livewire/kassenbuch-index.blade.php', 'family' => 'Livewire Overlay', 'backdropClass' => 'bg-black/50'],
+        ['id' => 'preview-romantausch-photo', 'label' => 'Romantausch Fotoansicht', 'source' => 'resources/views/livewire/romantausch-index.blade.php', 'family' => 'Galerie Overlay', 'backdropClass' => 'bg-black/70 backdrop-blur-sm'],
+        ['id' => 'preview-newsletter-confirm', 'label' => 'Newsletter Sende-Bestätigung', 'source' => 'resources/views/newsletter/versenden.blade.php', 'family' => 'Alpine Overlay', 'backdropClass' => 'bg-base-300/75'],
+        ['id' => 'preview-chronik-lightbox', 'label' => 'Chronik Lightbox', 'source' => 'resources/views/pages/chronik.blade.php', 'family' => 'Lightbox Overlay', 'backdropClass' => 'bg-black/80 backdrop-blur-sm'],
+    ];
+
+    $allModals = array_merge($maryModals, $customOverlays);
+@endphp
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="caramellatte">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Modal-Vorschau</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="min-h-screen bg-base-200 text-base-content antialiased">
+    <main data-preview-page class="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-8 px-4 py-6 sm:px-6 lg:px-8 lg:py-10">
+        <header class="rounded-4xl border border-base-300 bg-base-100 px-6 py-8 shadow-sm sm:px-8">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                <div class="max-w-3xl space-y-3">
+                    <span class="badge badge-outline badge-lg">Nur lokal und im Test</span>
+                    <h1 class="font-display text-4xl font-semibold tracking-tight">Modal-Vorschau</h1>
+                    <p class="max-w-2xl text-base leading-7 text-base-content/70">
+                        Diese Seite bündelt alle Modal-Familien, die aktuell im Projekt verwendet werden. Sie dient als visuelle Regression für die globale Backdrop-Korrektur und als Screenshot-Ziel für den Docker-Lauf.
+                    </p>
+                </div>
+                <div class="rounded-3xl border border-base-300 bg-base-200 px-5 py-4 text-sm text-base-content/70">
+                    <p class="font-semibold text-base-content">Abgedeckte Vorschauen</p>
+                    <p>{{ count($maryModals) }} MaryUI/daisyUI-Dialoge und {{ count($customOverlays) }} eigene Overlays</p>
+                </div>
+            </div>
+        </header>
+
+        <section class="grid gap-8 xl:grid-cols-[minmax(0,1.2fr)_minmax(22rem,0.8fr)]">
+            <div class="space-y-8">
+                <section class="space-y-4">
+                    <div class="flex items-center justify-between gap-4">
+                        <div>
+                            <h2 class="text-2xl font-semibold">MaryUI und daisyUI</h2>
+                            <p class="text-sm text-base-content/65">x-modal und x-mary-modal, jeweils an den realen Einsatzstellen gespiegelt.</p>
+                        </div>
+                        <span class="badge badge-neutral badge-outline">{{ count($maryModals) }} Stück</span>
+                    </div>
+                    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        @foreach ($maryModals as $modal)
+                            <button
+                                id="open-{{ $modal['id'] }}"
+                                type="button"
+                                data-modal-trigger
+                                data-modal-target="{{ $modal['id'] }}"
+                                onclick="window.__omxfcOpenPreviewModal('{{ $modal['id'] }}')"
+                                class="group rounded-[1.75rem] border border-base-300 bg-base-100 p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+                            >
+                                <div class="flex items-center justify-between gap-3 text-xs uppercase tracking-[0.18em] text-base-content/45">
+                                    <span>{{ $modal['family'] }}</span>
+                                    <span>{{ $modal['alias'] }}</span>
+                                </div>
+                                <p class="mt-4 text-lg font-semibold text-base-content">{{ $modal['label'] }}</p>
+                                <p class="mt-2 text-sm leading-6 text-base-content/65">{{ $modal['source'] }}</p>
+                            </button>
+                        @endforeach
+                    </div>
+                </section>
+
+                <section class="space-y-4">
+                    <div class="flex items-center justify-between gap-4">
+                        <div>
+                            <h2 class="text-2xl font-semibold">Eigene Overlays</h2>
+                            <p class="text-sm text-base-content/65">Kassenbuch, Chronik, Romantausch und weitere projektinterne Dialoge ohne Mary-Komponente.</p>
+                        </div>
+                        <span class="badge badge-neutral badge-outline">{{ count($customOverlays) }} Stück</span>
+                    </div>
+                    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                        @foreach ($customOverlays as $modal)
+                            <button
+                                id="open-{{ $modal['id'] }}"
+                                type="button"
+                                data-modal-trigger
+                                data-modal-target="{{ $modal['id'] }}"
+                                onclick="window.__omxfcOpenPreviewModal('{{ $modal['id'] }}')"
+                                class="group rounded-[1.75rem] border border-base-300 bg-base-100 p-5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+                            >
+                                <div class="flex items-center justify-between gap-3 text-xs uppercase tracking-[0.18em] text-base-content/45">
+                                    <span>{{ $modal['family'] }}</span>
+                                    <span>overlay</span>
+                                </div>
+                                <p class="mt-4 text-lg font-semibold text-base-content">{{ $modal['label'] }}</p>
+                                <p class="mt-2 text-sm leading-6 text-base-content/65">{{ $modal['source'] }}</p>
+                            </button>
+                        @endforeach
+                    </div>
+                </section>
+            </div>
+
+            <aside class="rounded-4xl border border-base-300 bg-base-100 p-6 shadow-sm lg:p-7">
+                <h2 class="text-xl font-semibold">Prüfziel</h2>
+                <div class="mt-4 space-y-4 text-sm leading-7 text-base-content/70">
+                    <p>Alle Vorschauen verwenden dieselbe Backdrop-Prüfung wie die Browser-Tests. Sobald ein Modal geöffnet wird, darf der Hintergrund nicht transparent bleiben.</p>
+                    <p>Die Screenshots aus dem Docker-Lauf werden aus genau dieser Seite erzeugt. Neue Modals sollten deshalb hier ergänzt werden, damit der visuelle Regressionstest vollständig bleibt.</p>
+                </div>
+
+                <div class="mt-6 rounded-3xl border border-dashed border-base-300 bg-base-200 p-5 text-sm text-base-content/70">
+                    <p class="font-semibold text-base-content">Aktuelle Abdeckung</p>
+                    <ul class="mt-3 space-y-2">
+                        @foreach ($allModals as $modal)
+                            <li class="flex items-start justify-between gap-4 border-b border-base-300/60 pb-2 last:border-b-0 last:pb-0">
+                                <span class="font-medium text-base-content">{{ $modal['label'] }}</span>
+                                <span class="text-right text-xs uppercase tracking-[0.18em] text-base-content/45">{{ $modal['family'] }}</span>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            </aside>
+        </section>
+    </main>
+
+    @foreach ($maryModals as $modal)
+        <dialog id="{{ $modal['id'] }}" class="modal" data-preview-modal data-modal-family="{{ $modal['family'] }}">
+            <div class="modal-box">
+                <form method="dialog" tabindex="-1">
+                    <button type="submit" class="btn btn-circle btn-ghost btn-sm absolute inset-e-2 top-2 z-999" tabindex="-1">✕</button>
+                </form>
+
+                <div class="mb-5 space-y-3">
+                    <span class="badge badge-outline">{{ $modal['alias'] }}</span>
+                    <h2 class="text-xl font-semibold">{{ $modal['label'] }}</h2>
+                    <p class="text-sm leading-6 text-base-content/75">Diese Vorschau spiegelt den Dialog aus {{ $modal['source'] }}. Entscheidend ist der abgedunkelte Hintergrund hinter dem Dialog.</p>
+                </div>
+
+                <div class="space-y-4">
+                    <div class="rounded-3xl bg-base-200 p-4 text-sm text-base-content/70">
+                        <p class="font-semibold text-base-content">Warum diese Variante wichtig ist</p>
+                        <p>Die globale Korrektur muss Livewire-gesteuerte und direkt per ID geöffnete Mary-DOM-Strukturen gleichermaßen decken.</p>
+                    </div>
+                </div>
+
+                <div class="modal-action">
+                    <form method="dialog">
+                        <button type="submit" class="btn btn-primary">Schließen</button>
+                    </form>
+                </div>
+            </div>
+
+            <form class="modal-backdrop" method="dialog">
+                <button type="submit">close</button>
+            </form>
+        </dialog>
+    @endforeach
+
+    @foreach ($customOverlays as $modal)
+        <div
+            id="{{ $modal['id'] }}"
+            data-preview-overlay
+            data-modal-family="{{ $modal['family'] }}"
+            data-open="false"
+            class="{{ $modal['backdropClass'] }} fixed inset-0 z-50 hidden items-center justify-center px-4 py-8"
+        >
+            <div class="relative w-full max-w-2xl rounded-4xl border border-white/15 bg-base-100 p-6 shadow-2xl sm:p-8">
+                <button type="button" class="btn btn-circle btn-ghost absolute right-4 top-4" aria-label="Schließen" onclick="window.__omxfcClosePreviewModals()">✕</button>
+                <div class="space-y-4">
+                    <span class="badge badge-outline">{{ $modal['family'] }}</span>
+                    <h2 class="text-2xl font-semibold">{{ $modal['label'] }}</h2>
+                    <p class="text-sm leading-6 text-base-content/75">Diese Vorschau deckt die Overlay-Struktur aus {{ $modal['source'] }} ab. Für die Regression zählt hier vor allem, dass der Overlay-Hintergrund sichtbar abdunkelt.</p>
+                    <div class="rounded-3xl bg-base-200 p-4 text-sm text-base-content/70">
+                        <p class="font-semibold text-base-content">Sichtprüfung</p>
+                        <p>Beim Öffnen muss die Seite unter dem Overlay deutlich abgedunkelt bleiben. Genau diese Zustände werden in Chromium als Screenshot abgelegt.</p>
+                    </div>
+                </div>
+                <div class="mt-6 flex justify-end">
+                    <button type="button" class="btn btn-primary" onclick="window.__omxfcClosePreviewModals()">Schließen</button>
+                </div>
+            </div>
+        </div>
+    @endforeach
+
+    <script>
+        (() => {
+            const colorParser = document.createElement('canvas').getContext('2d');
+
+            function normalizeColor(color) {
+                if (!colorParser || !color) {
+                    return 'transparent';
+                }
+
+                colorParser.fillStyle = '#000';
+                colorParser.fillStyle = color;
+
+                return colorParser.fillStyle;
+            }
+
+            function alphaFromColor(color) {
+                const normalized = normalizeColor(color);
+
+                if (!normalized || normalized === 'transparent') {
+                    return 0;
+                }
+
+                const rgbaMatch = normalized.match(/^rgba\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*([0-9.]+)\s*\)$/i);
+
+                if (rgbaMatch) {
+                    return Number(rgbaMatch[1]);
+                }
+
+                return 1;
+            }
+
+            window.__omxfcClosePreviewModals = () => {
+                document.querySelectorAll('dialog[data-preview-modal][open]').forEach((dialog) => {
+                    dialog.close();
+                });
+
+                document.querySelectorAll('[data-preview-overlay]').forEach((overlay) => {
+                    overlay.classList.add('hidden');
+                    overlay.dataset.open = 'false';
+                });
+            };
+
+            window.__omxfcOpenPreviewModal = (id) => {
+                window.__omxfcClosePreviewModals();
+
+                const target = document.getElementById(id);
+
+                if (!target) {
+                    return;
+                }
+
+                if (target instanceof HTMLDialogElement) {
+                    target.showModal();
+
+                    return;
+                }
+
+                target.classList.remove('hidden');
+                target.dataset.open = 'true';
+            };
+
+            window.__omxfcPreviewBackdropAlpha = (id) => {
+                const target = document.getElementById(id);
+
+                if (!target) {
+                    return 0;
+                }
+
+                const alphas = [alphaFromColor(window.getComputedStyle(target).backgroundColor)];
+
+                if (target instanceof HTMLDialogElement) {
+                    alphas.push(alphaFromColor(window.getComputedStyle(target, '::backdrop').backgroundColor));
+
+                    const maryBackdrop = target.querySelector('.modal-backdrop');
+
+                    if (maryBackdrop) {
+                        alphas.push(alphaFromColor(window.getComputedStyle(maryBackdrop).backgroundColor));
+                    }
+                }
+
+                return Math.max(...alphas);
+            };
+        })();
+    </script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -101,6 +101,10 @@ Route::prefix('hoerbuecher')->name('hoerbuecher.')->group(function () {
     Route::livewire('{episode}', \App\Livewire\HoerbuchShow::class)->name('show')->whereNumber('episode');
 });
 
+if (app()->environment(['local', 'testing'])) {
+    Route::view('/_testing/modal-vorschau', 'testing.modal-preview')->name('testing.modal-preview');
+}
+
 // POST Route für Mitgliedschaftsantrag
 Route::post('/mitglied-werden', [MitgliedschaftController::class, 'store'])->name('mitglied.store');
 

--- a/tests/Browser/ModalBackdropPreviewTest.php
+++ b/tests/Browser/ModalBackdropPreviewTest.php
@@ -1,0 +1,25 @@
+<?php
+
+it('zeigt fuer Vorschau-Modals deckende Backdrops', function () {
+    $page = visit('/_testing/modal-vorschau');
+
+    $page->assertSee('Modal-Vorschau')
+        ->assertCount('[data-modal-trigger]', 35)
+        ->assertNoJavaScriptErrors();
+
+    $page->click('#open-preview-todo-delete')
+        ->assertVisible('#preview-todo-delete')
+        ->assertScript('window.__omxfcPreviewBackdropAlpha("preview-todo-delete") > 0.2', true);
+
+    $page->script('window.__omxfcClosePreviewModals()');
+
+    $page->click('#open-preview-profile-photo')
+        ->assertVisible('#preview-profile-photo')
+        ->assertScript('window.__omxfcPreviewBackdropAlpha("preview-profile-photo") > 0.2', true);
+
+    $page->script('window.__omxfcClosePreviewModals()');
+
+    $page->click('#open-preview-chronik-lightbox')
+        ->assertVisible('#preview-chronik-lightbox')
+        ->assertScript('window.__omxfcPreviewBackdropAlpha("preview-chronik-lightbox") > 0.2', true);
+});

--- a/tests/Browser/ModalBackdropPreviewTest.php
+++ b/tests/Browser/ModalBackdropPreviewTest.php
@@ -1,6 +1,6 @@
 <?php
 
-it('zeigt fuer Vorschau-Modals deckende Backdrops', function () {
+it('zeigt für Vorschau-Modals deckende Backdrops', function () {
     $page = visit('/_testing/modal-vorschau');
 
     $page->assertSee('Modal-Vorschau')

--- a/tests/Browser/ModalBackdropPreviewTest.php
+++ b/tests/Browser/ModalBackdropPreviewTest.php
@@ -4,7 +4,8 @@ it('zeigt fuer Vorschau-Modals deckende Backdrops', function () {
     $page = visit('/_testing/modal-vorschau');
 
     $page->assertSee('Modal-Vorschau')
-        ->assertCount('[data-modal-trigger]', 35)
+        ->assertScript('window.__omxfcPreviewExpectedModalCount() > 0', true)
+        ->assertScript('window.__omxfcPreviewExpectedModalCount() === document.querySelectorAll("[data-modal-trigger]").length', true)
         ->assertNoJavaScriptErrors();
 
     $page->click('#open-preview-todo-delete')

--- a/tests/Browser/ModalBackdropPreviewTest.php
+++ b/tests/Browser/ModalBackdropPreviewTest.php
@@ -8,19 +8,16 @@ it('zeigt fuer Vorschau-Modals deckende Backdrops', function () {
         ->assertScript('window.__omxfcPreviewExpectedModalCount() === document.querySelectorAll("[data-modal-trigger]").length', true)
         ->assertNoJavaScriptErrors();
 
-    $page->click('#open-preview-todo-delete')
-        ->assertVisible('#preview-todo-delete')
-        ->assertScript('window.__omxfcPreviewBackdropAlpha("preview-todo-delete") > 0.2', true);
+    $modalIds = $page->script("() => Array.from(document.querySelectorAll('[data-modal-trigger]')).map((trigger) => trigger.dataset.modalTarget)");
+    $expectedModalCount = $page->script('() => window.__omxfcPreviewExpectedModalCount()');
 
-    $page->script('window.__omxfcClosePreviewModals()');
+    expect($modalIds)->toHaveCount($expectedModalCount);
 
-    $page->click('#open-preview-profile-photo')
-        ->assertVisible('#preview-profile-photo')
-        ->assertScript('window.__omxfcPreviewBackdropAlpha("preview-profile-photo") > 0.2', true);
+    foreach ($modalIds as $modalId) {
+        $page->click("#open-{$modalId}")
+            ->assertVisible("#{$modalId}")
+            ->assertScript("window.__omxfcPreviewBackdropAlpha('{$modalId}') > 0.2", true);
 
-    $page->script('window.__omxfcClosePreviewModals()');
-
-    $page->click('#open-preview-chronik-lightbox')
-        ->assertVisible('#preview-chronik-lightbox')
-        ->assertScript('window.__omxfcPreviewBackdropAlpha("preview-chronik-lightbox") > 0.2', true);
+        $page->script('window.__omxfcClosePreviewModals()');
+    }
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,10 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+pest()->extend(TestCase::class)->in('Feature');
+
+pest()->extend(TestCase::class)->use(RefreshDatabase::class)->in('Browser');
+
+pest()->browser()->timeout(15000);

--- a/tests/e2e/modal-preview.spec.js
+++ b/tests/e2e/modal-preview.spec.js
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+
+const expectedModalCount = 35;
+
+async function backdropAlpha(page, modalId) {
+    return page.evaluate((id) => window.__omxfcPreviewBackdropAlpha(id), modalId);
+}
+
+async function closePreviewModals(page) {
+    await page.evaluate(() => {
+        window.__omxfcClosePreviewModals();
+    });
+}
+
+test.describe('Modal-Vorschau', () => {
+    test('alle Vorschau-Modals nutzen einen deckenden Hintergrund', async ({ page }) => {
+        test.slow();
+
+        await page.goto('/_testing/modal-vorschau');
+        await expect(page.getByRole('heading', { level: 1, name: 'Modal-Vorschau' })).toBeVisible();
+
+        const triggers = page.locator('[data-modal-trigger]');
+        await expect(triggers).toHaveCount(expectedModalCount);
+
+        for (let index = 0; index < expectedModalCount; index += 1) {
+            const trigger = triggers.nth(index);
+            const modalId = await trigger.getAttribute('data-modal-target');
+
+            expect(modalId).toBeTruthy();
+
+            await trigger.scrollIntoViewIfNeeded();
+            await trigger.click();
+
+            const modal = page.locator(`#${modalId}`);
+            await expect(modal).toBeVisible();
+            await expect
+                .poll(() => backdropAlpha(page, modalId), {
+                    message: `Backdrop von ${modalId} bleibt transparent.`,
+                })
+                .toBeGreaterThan(0.2);
+
+            await closePreviewModals(page);
+        }
+    });
+
+    test('schreibt in Chromium Screenshots fuer alle Vorschau-Modals', async ({ page, browserName }, testInfo) => {
+        test.skip(browserName !== 'chromium', 'Screenshots werden nur einmal benötigt.');
+        test.slow();
+
+        await page.goto('/_testing/modal-vorschau');
+
+        const triggers = page.locator('[data-modal-trigger]');
+        await expect(triggers).toHaveCount(expectedModalCount);
+
+        for (let index = 0; index < expectedModalCount; index += 1) {
+            const trigger = triggers.nth(index);
+            const modalId = await trigger.getAttribute('data-modal-target');
+
+            expect(modalId).toBeTruthy();
+
+            await trigger.scrollIntoViewIfNeeded();
+            await trigger.click();
+
+            const modal = page.locator(`#${modalId}`);
+            await expect(modal).toBeVisible();
+            await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }));
+            await page.screenshot({
+                path: testInfo.outputPath(`modal-preview/${String(index + 1).padStart(2, '0')}-${modalId}.png`),
+            });
+
+            await closePreviewModals(page);
+        }
+    });
+});

--- a/tests/e2e/modal-preview.spec.js
+++ b/tests/e2e/modal-preview.spec.js
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test';
 
+const shouldCaptureModalScreenshots = process.env.PLAYWRIGHT_CAPTURE_MODAL_SCREENSHOTS === '1';
+
 async function expectedModalCount(page) {
     return page.evaluate(() => window.__omxfcPreviewExpectedModalCount());
 }
@@ -50,6 +52,7 @@ test.describe('Modal-Vorschau', () => {
 
     test('schreibt in Chromium Screenshots fuer alle Vorschau-Modals', async ({ page, browserName }, testInfo) => {
         test.skip(browserName !== 'chromium', 'Screenshots werden nur einmal benötigt.');
+        test.skip(!shouldCaptureModalScreenshots, 'Screenshots werden nur bei explizitem Export geschrieben.');
         test.slow();
 
         await page.goto('/_testing/modal-vorschau');

--- a/tests/e2e/modal-preview.spec.js
+++ b/tests/e2e/modal-preview.spec.js
@@ -50,7 +50,7 @@ test.describe('Modal-Vorschau', () => {
         }
     });
 
-    test('schreibt in Chromium Screenshots fuer alle Vorschau-Modals', async ({ page, browserName }, testInfo) => {
+    test('schreibt in Chromium Screenshots für alle Vorschau-Modals', async ({ page, browserName }, testInfo) => {
         test.skip(browserName !== 'chromium', 'Screenshots werden nur einmal benötigt.');
         test.skip(!shouldCaptureModalScreenshots, 'Screenshots werden nur bei explizitem Export geschrieben.');
         test.slow();

--- a/tests/e2e/modal-preview.spec.js
+++ b/tests/e2e/modal-preview.spec.js
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test';
 
-const expectedModalCount = 35;
+async function expectedModalCount(page) {
+    return page.evaluate(() => window.__omxfcPreviewExpectedModalCount());
+}
 
 async function backdropAlpha(page, modalId) {
     return page.evaluate((id) => window.__omxfcPreviewBackdropAlpha(id), modalId);
@@ -19,10 +21,13 @@ test.describe('Modal-Vorschau', () => {
         await page.goto('/_testing/modal-vorschau');
         await expect(page.getByRole('heading', { level: 1, name: 'Modal-Vorschau' })).toBeVisible();
 
-        const triggers = page.locator('[data-modal-trigger]');
-        await expect(triggers).toHaveCount(expectedModalCount);
+        const modalCount = await expectedModalCount(page);
+        expect(modalCount).toBeGreaterThan(0);
 
-        for (let index = 0; index < expectedModalCount; index += 1) {
+        const triggers = page.locator('[data-modal-trigger]');
+        await expect(triggers).toHaveCount(modalCount);
+
+        for (let index = 0; index < modalCount; index += 1) {
             const trigger = triggers.nth(index);
             const modalId = await trigger.getAttribute('data-modal-target');
 
@@ -49,10 +54,13 @@ test.describe('Modal-Vorschau', () => {
 
         await page.goto('/_testing/modal-vorschau');
 
-        const triggers = page.locator('[data-modal-trigger]');
-        await expect(triggers).toHaveCount(expectedModalCount);
+        const modalCount = await expectedModalCount(page);
+        expect(modalCount).toBeGreaterThan(0);
 
-        for (let index = 0; index < expectedModalCount; index += 1) {
+        const triggers = page.locator('[data-modal-trigger]');
+        await expect(triggers).toHaveCount(modalCount);
+
+        for (let index = 0; index < modalCount; index += 1) {
             const trigger = triggers.nth(index);
             const modalId = await trigger.getAttribute('data-modal-target');
 
@@ -63,7 +71,7 @@ test.describe('Modal-Vorschau', () => {
 
             const modal = page.locator(`#${modalId}`);
             await expect(modal).toBeVisible();
-            await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' }));
+            await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'auto' }));
             await page.screenshot({
                 path: testInfo.outputPath(`modal-preview/${String(index + 1).padStart(2, '0')}-${modalId}.png`),
             });

--- a/tests/e2e/run-playwright-docker.mjs
+++ b/tests/e2e/run-playwright-docker.mjs
@@ -2,11 +2,18 @@ import { spawn } from 'child_process';
 import path from 'path';
 
 const playwrightCli = path.resolve('node_modules/playwright/cli.js');
-const child = spawn(process.execPath, [playwrightCli, 'test', ...process.argv.slice(2)], {
+const extraArgs = process.argv.slice(2);
+const captureModalScreenshots = extraArgs.includes('--capture-modal-screenshots');
+const playwrightArgs = captureModalScreenshots
+    ? extraArgs.filter((arg) => arg !== '--capture-modal-screenshots')
+    : extraArgs;
+
+const child = spawn(process.execPath, [playwrightCli, 'test', ...playwrightArgs], {
     stdio: 'inherit',
     env: {
         ...process.env,
         PLAYWRIGHT_USE_DOCKER: '1',
+        PLAYWRIGHT_CAPTURE_MODAL_SCREENSHOTS: captureModalScreenshots ? '1' : process.env.PLAYWRIGHT_CAPTURE_MODAL_SCREENSHOTS,
     },
 });
 

--- a/tests/e2e/run-playwright-docker.mjs
+++ b/tests/e2e/run-playwright-docker.mjs
@@ -7,14 +7,20 @@ const captureModalScreenshots = extraArgs.includes('--capture-modal-screenshots'
 const playwrightArgs = captureModalScreenshots
     ? extraArgs.filter((arg) => arg !== '--capture-modal-screenshots')
     : extraArgs;
+const forwardedScreenshotFlag = captureModalScreenshots
+    ? '1'
+    : process.env.PLAYWRIGHT_CAPTURE_MODAL_SCREENSHOTS ?? null;
+const childEnv = {
+    ...process.env,
+    PLAYWRIGHT_USE_DOCKER: '1',
+    ...(forwardedScreenshotFlag === null
+        ? {}
+        : { PLAYWRIGHT_CAPTURE_MODAL_SCREENSHOTS: forwardedScreenshotFlag }),
+};
 
 const child = spawn(process.execPath, [playwrightCli, 'test', ...playwrightArgs], {
     stdio: 'inherit',
-    env: {
-        ...process.env,
-        PLAYWRIGHT_USE_DOCKER: '1',
-        PLAYWRIGHT_CAPTURE_MODAL_SCREENSHOTS: captureModalScreenshots ? '1' : process.env.PLAYWRIGHT_CAPTURE_MODAL_SCREENSHOTS,
-    },
+    env: childEnv,
 });
 
 child.on('exit', (code) => {


### PR DESCRIPTION
This pull request introduces a browser-based regression test for modal backdrops using Pest and Playwright, updates dependencies to support the latest Pest 5.x stack, and improves documentation and CSS robustness for modal overlays. The changes ensure compatibility with Laravel 13 and enhance CI workflows for browser testing.

**Browser regression testing and workflow enhancements:**

* Adds a new `browser_preview` job to `.github/workflows/phpunit.yml` to run a Playwright-based browser regression test using Pest 5.x on PHP 8.5, including all necessary setup steps for dependencies and database.
* Introduces a new npm script `test:e2e:modal-screenshots:docker` in `package.json` for running modal screenshot exports in a Dockerized environment, and documents its use in the `README.md`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159-R171)

**Dependency and compatibility updates:**

* Updates `composer.json` to require unreleased Pest 5.x packages and a dev version of `symfony/process` for compatibility with Laravel 13, as well as updating `phpunit/phpunit` to 13.1.8.
* Upgrades `daisyui` dependency in `package.json` from 5.5.17 to 5.5.20.

**Modal overlay CSS improvements:**

* Strengthens modal backdrop styling in `app.css` by explicitly targeting native and custom modal overlays to ensure consistent semi-transparent backgrounds across all modal opening methods.

**Documentation updates:**

* Expands the `README.md` with instructions for running browser regression tests and explains the current dependency situation for Pest 5.x and its Laravel plugin, including the rationale for using unreleased branches.