### PR TITLE
Fix: Speaker name not readable on EARDRAX Dashboard

### DIFF
--- a/resources/views/livewire/hoerbuch-show.blade.php
+++ b/resources/views/livewire/hoerbuch-show.blade.php
@@ -55,7 +55,7 @@
                         <tbody>
                             @foreach($this->episode->roles as $role)
                             @php
-                                $rowClasses = $role->uploaded ? 'bg-success/10 text-success-content' : '';
+                                $rowClasses = $role->uploaded ? 'bg-success/10' : '';
                             @endphp
                             <tr class="{{ $rowClasses }}">
                                 <td class="align-top">
@@ -70,7 +70,7 @@
                                 <td>{{ $role->description }}</td>
                                 <td>{{ $role->takes }}</td>
                                 <td>
-                                    {{ $role->user?->name ?? $role->speaker_name ?? '-' }}
+                                    <span class="text-base-content">{{ $role->user?->name ?? $role->speaker_name ?? '-' }}</span>
                                     @if(auth()->user()?->hasVorstandRole() || auth()->user()?->isMemberOfTeam('AG Fanhörbücher'))
                                         @php($prev = $this->previousSpeakers[$role->name] ?? null)
                                         @if($prev)

--- a/tests/Feature/HoerbuchLivewireTest.php
+++ b/tests/Feature/HoerbuchLivewireTest.php
@@ -414,17 +414,23 @@ class HoerbuchLivewireTest extends TestCase
     public function test_detail_view_hides_upload_column_and_controls(): void
     {
         $user = $this->actingMember('Admin');
+        $assignedSpeaker = User::factory()->create(['name' => 'Mitgliedsstimme']);
 
         $episode = AudiobookEpisode::create([
             'episode_number' => 'F42', 'title' => 'Keine Upload Checkbox', 'author' => 'Autor',
             'planned_release_date' => '12.2025', 'status' => 'Skripterstellung',
             'responsible_user_id' => null, 'progress' => 10,
-            'roles_total' => 1, 'roles_filled' => 1, 'notes' => null,
+            'roles_total' => 2, 'roles_filled' => 2, 'notes' => null,
         ]);
 
         $episode->roles()->create([
             'name' => 'Erzähler', 'description' => 'Erzählt die Geschichte',
-            'takes' => 4, 'uploaded' => true,
+            'takes' => 4, 'speaker_name' => 'Lesestimme', 'uploaded' => true,
+        ]);
+
+        $episode->roles()->create([
+            'name' => 'Captain', 'description' => 'Fuehrt durch die Szene',
+            'takes' => 2, 'user_id' => $assignedSpeaker->id, 'uploaded' => true,
         ]);
 
         $response = $this->actingAs($user)->get(route('hoerbuecher.show', $episode));
@@ -436,6 +442,9 @@ class HoerbuchLivewireTest extends TestCase
         $response->assertDontSee('data-auto-submit');
         $response->assertSee('Upload vorhanden');
         $response->assertSee('bg-success/10', false);
+        $response->assertDontSee('text-success-content', false);
+        $response->assertSee('<span class="text-base-content">Lesestimme</span>', false);
+        $response->assertSee('<span class="text-base-content">Mitgliedsstimme</span>', false);
     }
 
     public function test_admin_can_delete_episode(): void


### PR DESCRIPTION
This pull request makes minor improvements to the audiobook episode detail view and its related test. The main focus is on adjusting the display of speaker names and row styling for uploaded roles, as well as updating the corresponding feature test to reflect these changes.

Display and styling updates in audiobook episode detail view:

* Removed the `text-success-content` class from rows for uploaded roles, so only the background color indicates upload status (`bg-success/10`).
* Wrapped the speaker name in a `<span class="text-base-content">` to ensure consistent text color, regardless of upload status.

Feature test adjustments:

* Updated the test data to include two roles: one with a `speaker_name` and one assigned to a user, both marked as uploaded.
* Added assertions to ensure the `text-success-content` class is not present, and that speaker names are rendered within a `<span class="text-base-content">`.