### PR TITLE
Fix: AG Logos are shown cutted

### DIFF
--- a/app/Support/BuiltInServerStaticPathResolver.php
+++ b/app/Support/BuiltInServerStaticPathResolver.php
@@ -8,13 +8,13 @@ final class BuiltInServerStaticPathResolver
     {
         $normalizedRequestPath = self::normalizeRequestPath($requestPath);
 
-        if ($normalizedRequestPath === null || $normalizedRequestPath === '/') {
+        if ($normalizedRequestPath === null || $normalizedRequestPath === '/' || self::isDisallowedStaticRequestPath($normalizedRequestPath)) {
             return null;
         }
 
-        $publicPath = self::buildProjectPath($projectRoot, 'public', $normalizedRequestPath);
+        $publicPath = self::resolvePublicPath($projectRoot, $normalizedRequestPath);
 
-        if ($publicPath !== null && is_file($publicPath)) {
+        if ($publicPath !== null) {
             return $publicPath;
         }
 
@@ -74,6 +74,29 @@ final class BuiltInServerStaticPathResolver
         return self::pathIsWithinBase($resolvedPath, $storageRoot) ? $resolvedPath : null;
     }
 
+    private static function resolvePublicPath(string $projectRoot, string $requestPath): ?string
+    {
+        $publicRoot = realpath(self::buildProjectPath($projectRoot, 'public', '/'));
+
+        if ($publicRoot === false) {
+            return null;
+        }
+
+        $candidatePath = self::buildProjectPath($projectRoot, 'public', $requestPath);
+
+        if ($candidatePath === null) {
+            return null;
+        }
+
+        $resolvedPath = realpath($candidatePath);
+
+        if ($resolvedPath === false || ! is_file($resolvedPath)) {
+            return null;
+        }
+
+        return self::pathIsWithinBase($resolvedPath, $publicRoot) ? $resolvedPath : null;
+    }
+
     private static function buildProjectPath(string $projectRoot, string $baseDirectory, string $requestPath): ?string
     {
         $relativePath = ltrim($requestPath, '/');
@@ -93,5 +116,18 @@ final class BuiltInServerStaticPathResolver
 
         return $normalizedResolvedPath === $normalizedBasePath
             || str_starts_with($normalizedResolvedPath, $normalizedBasePath.'/');
+    }
+
+    private static function isDisallowedStaticRequestPath(string $requestPath): bool
+    {
+        $basename = basename($requestPath);
+
+        if ($basename === '' || str_starts_with($basename, '.')) {
+            return true;
+        }
+
+        $extension = strtolower(pathinfo($basename, PATHINFO_EXTENSION));
+
+        return in_array($extension, ['php', 'phtml', 'phar'], true);
     }
 }

--- a/app/Support/BuiltInServerStaticPathResolver.php
+++ b/app/Support/BuiltInServerStaticPathResolver.php
@@ -84,10 +84,6 @@ final class BuiltInServerStaticPathResolver
 
         $candidatePath = self::buildProjectPath($projectRoot, 'public', $requestPath);
 
-        if ($candidatePath === null) {
-            return null;
-        }
-
         $resolvedPath = realpath($candidatePath);
 
         if ($resolvedPath === false || ! is_file($resolvedPath)) {
@@ -97,7 +93,7 @@ final class BuiltInServerStaticPathResolver
         return self::pathIsWithinBase($resolvedPath, $publicRoot) ? $resolvedPath : null;
     }
 
-    private static function buildProjectPath(string $projectRoot, string $baseDirectory, string $requestPath): ?string
+    private static function buildProjectPath(string $projectRoot, string $baseDirectory, string $requestPath): string
     {
         $relativePath = ltrim($requestPath, '/');
         $basePath = rtrim($projectRoot, '/\\').DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $baseDirectory);

--- a/app/Support/BuiltInServerStaticPathResolver.php
+++ b/app/Support/BuiltInServerStaticPathResolver.php
@@ -116,7 +116,15 @@ final class BuiltInServerStaticPathResolver
 
     private static function isDisallowedStaticRequestPath(string $requestPath): bool
     {
-        $basename = basename($requestPath);
+        $segments = array_values(array_filter(explode('/', trim($requestPath, '/')), static fn (string $segment) => $segment !== ''));
+
+        foreach ($segments as $segment) {
+            if (str_starts_with($segment, '.')) {
+                return true;
+            }
+        }
+
+        $basename = $segments === [] ? '' : end($segments);
 
         if ($basename === '' || str_starts_with($basename, '.')) {
             return true;

--- a/app/Support/BuiltInServerStaticPathResolver.php
+++ b/app/Support/BuiltInServerStaticPathResolver.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Support;
+
+final class BuiltInServerStaticPathResolver
+{
+    public static function resolve(string $projectRoot, string $requestPath): ?string
+    {
+        $normalizedRequestPath = self::normalizeRequestPath($requestPath);
+
+        if ($normalizedRequestPath === null || $normalizedRequestPath === '/') {
+            return null;
+        }
+
+        $publicPath = self::buildProjectPath($projectRoot, 'public', $normalizedRequestPath);
+
+        if ($publicPath !== null && is_file($publicPath)) {
+            return $publicPath;
+        }
+
+        if (! str_starts_with($normalizedRequestPath, '/storage/')) {
+            return null;
+        }
+
+        return self::resolveStoragePath($projectRoot, substr($normalizedRequestPath, strlen('/storage/')));
+    }
+
+    public static function normalizeRequestPath(string $requestPath): ?string
+    {
+        if ($requestPath === '' || ! str_starts_with($requestPath, '/')) {
+            return null;
+        }
+
+        if (str_contains($requestPath, '\\')) {
+            return null;
+        }
+
+        $normalizedSegments = [];
+
+        foreach (explode('/', $requestPath) as $index => $segment) {
+            if ($index === 0 || $segment === '' || $segment === '.') {
+                continue;
+            }
+
+            if ($segment === '..') {
+                return null;
+            }
+
+            $normalizedSegments[] = $segment;
+        }
+
+        return '/'.implode('/', $normalizedSegments);
+    }
+
+    private static function resolveStoragePath(string $projectRoot, string $relativePath): ?string
+    {
+        if ($relativePath === '' || str_contains($relativePath, '\\')) {
+            return null;
+        }
+
+        $storageRoot = realpath(self::buildProjectPath($projectRoot, 'storage/app/public', '/'));
+
+        if ($storageRoot === false) {
+            return null;
+        }
+
+        $candidatePath = $storageRoot.DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, trim($relativePath, '/'));
+        $resolvedPath = realpath($candidatePath);
+
+        if ($resolvedPath === false || ! is_file($resolvedPath)) {
+            return null;
+        }
+
+        return self::pathIsWithinBase($resolvedPath, $storageRoot) ? $resolvedPath : null;
+    }
+
+    private static function buildProjectPath(string $projectRoot, string $baseDirectory, string $requestPath): ?string
+    {
+        $relativePath = ltrim($requestPath, '/');
+        $basePath = rtrim($projectRoot, '/\\').DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $baseDirectory);
+
+        if ($relativePath === '') {
+            return $basePath;
+        }
+
+        return $basePath.DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $relativePath);
+    }
+
+    private static function pathIsWithinBase(string $resolvedPath, string $basePath): bool
+    {
+        $normalizedBasePath = rtrim(str_replace('\\', '/', $basePath), '/');
+        $normalizedResolvedPath = str_replace('\\', '/', $resolvedPath);
+
+        return $normalizedResolvedPath === $normalizedBasePath
+            || str_starts_with($normalizedResolvedPath, $normalizedBasePath.'/');
+    }
+}

--- a/database/seeders/ArbeitsgruppenPlaywrightSeeder.php
+++ b/database/seeders/ArbeitsgruppenPlaywrightSeeder.php
@@ -6,9 +6,25 @@ use App\Enums\Role;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Storage;
 
 class ArbeitsgruppenPlaywrightSeeder extends Seeder
 {
+        private const PLAYWRIGHT_LOGO_PATH = 'ag-logos/arbeitsgruppen-playwright-logo.svg';
+
+        private const PLAYWRIGHT_LOGO_SVG = <<<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 160" role="img" aria-labelledby="title desc">
+    <title id="title">AG Fanhoerbuecher Logo</title>
+    <desc id="desc">Testlogo fuer Playwright-Pruefungen der Arbeitsgruppen-Seite.</desc>
+    <rect width="320" height="160" rx="28" fill="#7c1128"/>
+    <rect x="12" y="12" width="296" height="136" rx="22" fill="#f7efe5" opacity="0.96"/>
+    <path d="M74 44c-7.732 0-14 6.268-14 14v44c0 7.732 6.268 14 14 14h21.5c24.024 0 43.5-19.476 43.5-43.5S119.524 29 95.5 29H74Zm16 18h6.5c14.083 0 25.5 11.417 25.5 25.5S110.583 113 96.5 113H90V62Z" fill="#7c1128"/>
+    <path d="M163 47h18v28h29V47h18v69h-18V91h-29v25h-18V47Z" fill="#0f172a"/>
+    <path d="M248 47h18l26 69h-18.7l-4.6-13h-28.1l-4.6 13H217L248 47Zm15.2 42-8.5-24.1L246.1 89h17.1Z" fill="#c24d2c"/>
+    <circle cx="269" cy="58" r="6" fill="#7c1128"/>
+</svg>
+SVG;
+
     public function run(): void
     {
         $membersTeam = Team::membersTeam();
@@ -18,6 +34,8 @@ class ArbeitsgruppenPlaywrightSeeder extends Seeder
 
             return;
         }
+
+        Storage::disk('public')->put(self::PLAYWRIGHT_LOGO_PATH, self::PLAYWRIGHT_LOGO_SVG);
 
         $leader = User::factory()->create([
             'name' => 'Martin Gobrecht',
@@ -38,7 +56,7 @@ class ArbeitsgruppenPlaywrightSeeder extends Seeder
             'description' => 'EARDRAX: Die AG macht inszenierte Lesungen fuer YouTube zuganglich und sucht weitere Mitwirkende.',
             'meeting_schedule' => 'Nach Bedarf und Projektphase',
             'email' => 'ag-hoerbuecher@maddrax-fanclub.de',
-            'logo_path' => 'ag-logos/arbeitsgruppen-playwright-logo.svg',
+            'logo_path' => self::PLAYWRIGHT_LOGO_PATH,
         ]);
 
         $team->users()->syncWithoutDetaching([

--- a/database/seeders/ArbeitsgruppenPlaywrightSeeder.php
+++ b/database/seeders/ArbeitsgruppenPlaywrightSeeder.php
@@ -10,9 +10,9 @@ use Illuminate\Support\Facades\Storage;
 
 class ArbeitsgruppenPlaywrightSeeder extends Seeder
 {
-        private const PLAYWRIGHT_LOGO_PATH = 'ag-logos/arbeitsgruppen-playwright-logo.svg';
+    private const PLAYWRIGHT_LOGO_PATH = 'ag-logos/arbeitsgruppen-playwright-logo.svg';
 
-        private const PLAYWRIGHT_LOGO_SVG = <<<'SVG'
+    private const PLAYWRIGHT_LOGO_SVG = <<<'SVG'
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 160" role="img" aria-labelledby="title desc">
     <title id="title">AG Fanhoerbuecher Logo</title>
     <desc id="desc">Testlogo fuer Playwright-Pruefungen der Arbeitsgruppen-Seite.</desc>

--- a/database/seeders/ArbeitsgruppenPlaywrightSeeder.php
+++ b/database/seeders/ArbeitsgruppenPlaywrightSeeder.php
@@ -38,6 +38,7 @@ class ArbeitsgruppenPlaywrightSeeder extends Seeder
             'description' => 'EARDRAX: Die AG macht inszenierte Lesungen fuer YouTube zuganglich und sucht weitere Mitwirkende.',
             'meeting_schedule' => 'Nach Bedarf und Projektphase',
             'email' => 'ag-hoerbuecher@maddrax-fanclub.de',
+            'logo_path' => 'ag-logos/arbeitsgruppen-playwright-logo.svg',
         ]);
 
         $team->users()->syncWithoutDetaching([

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -81,12 +81,6 @@
     background-image: url('../images/omxfc-logo.png');
 }
 
-.ag-logo {
-    width: 25%;
-    margin-left: auto;
-    margin-right: auto;
-}
-
 .ag-beispielgrafiken {
     width: 50%;
     margin-left: auto;

--- a/resources/views/pages/arbeitsgruppen.blade.php
+++ b/resources/views/pages/arbeitsgruppen.blade.php
@@ -26,20 +26,28 @@
                     <article class="relative overflow-hidden rounded-[2rem] border border-base-content/10 bg-base-100/88 shadow-xl shadow-base-content/5 backdrop-blur">
                         <div class="absolute inset-x-0 top-0 h-px bg-linear-to-r from-primary/35 via-accent/25 to-transparent"></div>
 
-                        <div class="grid gap-0 lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)]">
+                        <div
+                            @class([
+                                'grid gap-0 lg:grid-cols-[minmax(16rem,0.78fr)_minmax(0,1fr)] lg:items-stretch' => $ag->logo_path,
+                            ])
+                        >
                             @if($ag->logo_path)
                                 <div class="border-b border-base-content/10 bg-base-200/55 lg:border-b-0 lg:border-r">
-                                    <img
-                                        loading="lazy"
-                                        src="{{ asset('storage/' . $ag->logo_path) }}"
-                                        alt="Logo der {{ $ag->name }}"
-                                        class="ag-logo h-full max-h-72 w-full object-cover"
-                                    >
+                                    <div class="flex h-full min-h-52 items-center justify-center bg-base-200/70 p-6 sm:min-h-60 sm:p-8" data-testid="ag-logo-stage">
+                                        <img
+                                            loading="lazy"
+                                            decoding="async"
+                                            src="{{ asset('storage/' . $ag->logo_path) }}"
+                                            alt="Logo der {{ $ag->name }}"
+                                            class="max-h-36 max-w-full object-contain sm:max-h-44 lg:max-h-52"
+                                            data-testid="ag-logo-image"
+                                        >
+                                    </div>
                                 </div>
                             @endif
 
-                            <div class="space-y-5 p-6 sm:p-7">
-                                <div class="space-y-3">
+                            <div class="space-y-6 p-6 sm:p-7 lg:p-8">
+                                <div class="space-y-4">
                                     <div class="flex flex-wrap items-center gap-2">
                                         <span class="badge badge-outline rounded-full px-3 py-3">Arbeitsgruppe</span>
                                         @if($ag->meeting_schedule)
@@ -49,27 +57,27 @@
 
                                     <h2 class="font-display text-2xl font-semibold tracking-tight text-base-content sm:text-[2rem]">{{ $ag->name }}</h2>
 
-                                    <p class="max-w-3xl text-sm leading-relaxed text-base-content/76 sm:text-base">
+                                    <p class="max-w-[65ch] text-sm leading-7 text-base-content/76 sm:text-base">
                                         {{ $ag->description ?: 'Diese Arbeitsgruppe bringt Mitglieder mit einem gemeinsamen Schwerpunkt zusammen und organisiert Austausch, Aufgaben und konkrete Vereinsbeiträge.' }}
                                     </p>
                                 </div>
 
-                                <dl class="grid gap-3 sm:grid-cols-2" data-testid="ag-detail-grid">
-                                    <div class="rounded-[1.35rem] border border-base-content/10 bg-base-100/75 p-4" data-testid="ag-lead-card">
+                                <dl class="grid gap-4 sm:grid-cols-2" data-testid="ag-detail-grid">
+                                    <div class="rounded-[1.35rem] border border-base-content/10 bg-base-100/75 p-4 sm:p-5" data-testid="ag-lead-card">
                                         <dt class="text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-base-content/46">AG-Leitung</dt>
                                         <dd class="mt-2 text-sm font-medium text-base-content sm:text-base">
                                             {{ $ag->owner?->publicFirstName() ?: 'Wird im Team abgestimmt' }}
                                         </dd>
                                     </div>
 
-                                    <div class="rounded-[1.35rem] border border-base-content/10 bg-base-100/75 p-4" data-testid="ag-meeting-card">
+                                    <div class="rounded-[1.35rem] border border-base-content/10 bg-base-100/75 p-4 sm:p-5" data-testid="ag-meeting-card">
                                         <dt class="text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-base-content/46">Treffen</dt>
                                         <dd class="mt-2 text-sm font-medium text-base-content sm:text-base">
                                             {{ $ag->meeting_schedule ?: 'Nach Bedarf und Projektphase' }}
                                         </dd>
                                     </div>
 
-                                    <div class="rounded-[1.35rem] border border-base-content/10 bg-base-100/75 p-4 sm:col-span-2" data-testid="ag-contact-card">
+                                    <div class="rounded-[1.35rem] border border-base-content/10 bg-base-100/75 p-4 sm:col-span-2 sm:p-5" data-testid="ag-contact-card">
                                         <dt class="text-[0.72rem] font-semibold uppercase tracking-[0.2em] text-base-content/46">Kontakt</dt>
                                         <dd class="mt-2 text-sm font-medium text-base-content sm:text-base">
                                             @if($ag->email)

--- a/server.php
+++ b/server.php
@@ -14,7 +14,7 @@ use App\Support\BuiltInServerStaticPathResolver;
 // Change to the project root directory
 chdir(__DIR__);
 
-require_once __DIR__.'/vendor/autoload.php';
+require_once __DIR__.'/app/Support/BuiltInServerStaticPathResolver.php';
 
 $uri = urldecode(
     parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''

--- a/server.php
+++ b/server.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Support\BuiltInServerStaticPathResolver;
+
 /**
  * Laravel - A PHP Framework For Web Artisans
  *
@@ -12,6 +14,8 @@
 // Change to the project root directory
 chdir(__DIR__);
 
+require_once __DIR__.'/vendor/autoload.php';
+
 $uri = urldecode(
     parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? ''
 );
@@ -19,19 +23,7 @@ $uri = urldecode(
 // Remove query string for file existence check
 $cleanUri = strtok($uri, '?');
 
-$publicPath = __DIR__.'/public'.$cleanUri;
-$storagePath = str_starts_with($cleanUri, '/storage/')
-    ? __DIR__.'/storage/app/public/'.ltrim(substr($cleanUri, strlen('/storage/')), '/')
-    : null;
-$staticPath = null;
-
-// Serve public assets directly and fall back to the public storage disk when
-// the local public/storage link is unavailable.
-if ($cleanUri !== '/' && is_file($publicPath)) {
-    $staticPath = $publicPath;
-} elseif ($storagePath && is_file($storagePath)) {
-    $staticPath = $storagePath;
-}
+$staticPath = BuiltInServerStaticPathResolver::resolve(__DIR__, $cleanUri);
 
 if ($staticPath) {
     // Determine MIME type

--- a/server.php
+++ b/server.php
@@ -20,9 +20,20 @@ $uri = urldecode(
 $cleanUri = strtok($uri, '?');
 
 $publicPath = __DIR__.'/public'.$cleanUri;
+$storagePath = str_starts_with($cleanUri, '/storage/')
+    ? __DIR__.'/storage/app/public/'.ltrim(substr($cleanUri, strlen('/storage/')), '/')
+    : null;
+$staticPath = null;
 
-// Check if the file exists in public directory
+// Serve public assets directly and fall back to the public storage disk when
+// the local public/storage link is unavailable.
 if ($cleanUri !== '/' && is_file($publicPath)) {
+    $staticPath = $publicPath;
+} elseif ($storagePath && is_file($storagePath)) {
+    $staticPath = $storagePath;
+}
+
+if ($staticPath) {
     // Determine MIME type
     $mimeTypes = [
         'css' => 'text/css',
@@ -49,18 +60,18 @@ if ($cleanUri !== '/' && is_file($publicPath)) {
         'pdf' => 'application/pdf',
     ];
 
-    $ext = strtolower(pathinfo($publicPath, PATHINFO_EXTENSION));
-    $mime = $mimeTypes[$ext] ?? (function_exists('mime_content_type') ? mime_content_type($publicPath) : 'application/octet-stream');
+    $ext = strtolower(pathinfo($staticPath, PATHINFO_EXTENSION));
+    $mime = $mimeTypes[$ext] ?? (function_exists('mime_content_type') ? mime_content_type($staticPath) : 'application/octet-stream');
 
     header('Content-Type: '.$mime);
-    header('Content-Length: '.filesize($publicPath));
+    header('Content-Length: '.filesize($staticPath));
 
     // Cache static assets for 1 hour in testing
     if (in_array($ext, ['css', 'js', 'png', 'jpg', 'jpeg', 'gif', 'svg', 'ico', 'webp', 'avif', 'woff', 'woff2', 'ttf', 'eot'])) {
         header('Cache-Control: public, max-age=3600');
     }
 
-    readfile($publicPath);
+    readfile($staticPath);
 
     return;
 }

--- a/tests/Feature/ArbeitsgruppenPageTest.php
+++ b/tests/Feature/ArbeitsgruppenPageTest.php
@@ -45,8 +45,45 @@ class ArbeitsgruppenPageTest extends TestCase
         $response->assertSee('sm:grid-cols-2', false);
         $response->assertDontSee('xl:grid-cols-3', false);
         $response->assertSee('sm:col-span-2', false);
+        $response->assertDontSee('data-testid="ag-logo-stage"', false);
+        $response->assertDontSee('data-testid="ag-logo-image"', false);
+        $response->assertDontSee('lg:grid-cols-[minmax(16rem,0.78fr)_minmax(0,1fr)]', false);
 
         $crawler = new Crawler($response->getContent());
         $this->assertCount(1, $crawler->filter('h1'));
+    }
+
+    public function test_arbeitsgruppen_page_renders_logos_in_a_contain_stage_without_crop_contract(): void
+    {
+        $leader = User::factory()->create([
+            'name' => 'Logo Leitung',
+            'vorname' => 'Logo',
+        ]);
+
+        $ag = Team::factory()->create([
+            'name' => 'AG mit Logo',
+            'user_id' => $leader->id,
+            'personal_team' => false,
+            'description' => 'Beschreibung mit Logo',
+            'meeting_schedule' => 'alle zwei Wochen',
+            'email' => 'logo-ag@example.com',
+            'logo_path' => 'ag-logos/test-logo.png',
+        ]);
+
+        $response = $this->withoutVite()->get('/arbeitsgruppen');
+
+        $response->assertOk();
+        $response->assertSee('data-testid="ag-logo-stage"', false);
+        $response->assertSee('data-testid="ag-logo-image"', false);
+        $response->assertSee('src="'.asset('storage/'.$ag->logo_path).'"', false);
+        $response->assertSee('alt="Logo der AG mit Logo"', false);
+        $response->assertSee('object-contain', false);
+        $response->assertDontSee('object-cover', false);
+        $response->assertDontSee('class="ag-logo', false);
+        $response->assertSee('lg:grid-cols-[minmax(16rem,0.78fr)_minmax(0,1fr)]', false);
+
+        $crawler = new Crawler($response->getContent());
+        $this->assertCount(1, $crawler->filter('[data-testid="ag-logo-stage"]'));
+        $this->assertCount(1, $crawler->filter('[data-testid="ag-logo-image"]'));
     }
 }

--- a/tests/Feature/ArbeitsgruppenPlaywrightSeederTest.php
+++ b/tests/Feature/ArbeitsgruppenPlaywrightSeederTest.php
@@ -46,4 +46,16 @@ class ArbeitsgruppenPlaywrightSeederTest extends TestCase
             'name' => 'AG Fanhoerbuecher',
         ]);
     }
+
+    public function test_seeder_creates_public_ag_with_logo_contract_for_playwright(): void
+    {
+        $seeder = new ArbeitsgruppenPlaywrightSeeder();
+        $seeder->run();
+
+        $this->assertDatabaseHas('teams', [
+            'name' => 'AG Fanhoerbuecher',
+            'personal_team' => false,
+            'logo_path' => 'ag-logos/arbeitsgruppen-playwright-logo.svg',
+        ]);
+    }
 }

--- a/tests/Feature/ArbeitsgruppenPlaywrightSeederTest.php
+++ b/tests/Feature/ArbeitsgruppenPlaywrightSeederTest.php
@@ -7,6 +7,7 @@ use Database\Seeders\ArbeitsgruppenPlaywrightSeeder;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 use Mockery;
 use Tests\TestCase;
 
@@ -49,6 +50,8 @@ class ArbeitsgruppenPlaywrightSeederTest extends TestCase
 
     public function test_seeder_creates_public_ag_with_logo_contract_for_playwright(): void
     {
+        Storage::fake('public');
+
         $seeder = new ArbeitsgruppenPlaywrightSeeder();
         $seeder->run();
 
@@ -57,5 +60,11 @@ class ArbeitsgruppenPlaywrightSeederTest extends TestCase
             'personal_team' => false,
             'logo_path' => 'ag-logos/arbeitsgruppen-playwright-logo.svg',
         ]);
+
+        Storage::disk('public')->assertExists('ag-logos/arbeitsgruppen-playwright-logo.svg');
+        $this->assertStringContainsString(
+            '<svg',
+            Storage::disk('public')->get('ag-logos/arbeitsgruppen-playwright-logo.svg')
+        );
     }
 }

--- a/tests/Unit/BuiltInServerStaticPathResolverTest.php
+++ b/tests/Unit/BuiltInServerStaticPathResolverTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\BuiltInServerStaticPathResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BuiltInServerStaticPathResolver::class)]
+class BuiltInServerStaticPathResolverTest extends TestCase
+{
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->projectRoot = sys_get_temp_dir().DIRECTORY_SEPARATOR.'omxfc-server-path-'.bin2hex(random_bytes(8));
+
+        mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'public', 0777, true);
+        mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'ag-logos', 0777, true);
+
+        file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'app.css', 'body {}');
+        file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'ag-logos'.DIRECTORY_SEPARATOR.'logo.svg', '<svg></svg>');
+        file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'secret.txt', 'secret');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteDirectory($this->projectRoot);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function resolve_prefers_public_assets_for_normalized_paths(): void
+    {
+        $resolvedPath = BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/app.css');
+
+        $this->assertSame($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'app.css', $resolvedPath);
+    }
+
+    #[Test]
+    public function resolve_falls_back_to_storage_public_assets_when_public_storage_path_is_unavailable(): void
+    {
+        $resolvedPath = BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/storage/ag-logos/logo.svg');
+
+        $this->assertSame(
+            $this->projectRoot.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'ag-logos'.DIRECTORY_SEPARATOR.'logo.svg',
+            $resolvedPath
+        );
+    }
+
+    #[Test]
+    public function resolve_rejects_directory_traversal_segments_for_public_and_storage_paths(): void
+    {
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/../secret.txt'));
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/storage/../secret.txt'));
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/storage/../../secret.txt'));
+    }
+
+    #[Test]
+    public function resolve_rejects_backslash_based_traversal_attempts(): void
+    {
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/storage/..\\secret.txt'));
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/..\\secret.txt'));
+    }
+
+    private function deleteDirectory(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path);
+
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $itemPath = $path.DIRECTORY_SEPARATOR.$item;
+
+            if (is_dir($itemPath)) {
+                $this->deleteDirectory($itemPath);
+
+                continue;
+            }
+
+            unlink($itemPath);
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Unit/BuiltInServerStaticPathResolverTest.php
+++ b/tests/Unit/BuiltInServerStaticPathResolverTest.php
@@ -21,12 +21,16 @@ class BuiltInServerStaticPathResolverTest extends TestCase
         mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'public', 0777, true);
         mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'ag-logos', 0777, true);
         mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'nested', 0777, true);
+        mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'.git', 0777, true);
+        mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'.private', 0777, true);
 
         file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'app.css', 'body {}');
         file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'index.php', '<?php echo "index";');
         file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'.htaccess', 'deny from all');
+        file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'.git'.DIRECTORY_SEPARATOR.'config', '[core]');
         file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'nested'.DIRECTORY_SEPARATOR.'.secret', 'hidden');
         file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'ag-logos'.DIRECTORY_SEPARATOR.'logo.svg', '<svg></svg>');
+        file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'.private'.DIRECTORY_SEPARATOR.'logo.svg', '<svg></svg>');
         file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'secret.txt', 'secret');
     }
 
@@ -77,6 +81,8 @@ class BuiltInServerStaticPathResolverTest extends TestCase
         $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/index.php'));
         $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/.htaccess'));
         $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/nested/.secret'));
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/.git/config'));
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/storage/.private/logo.svg'));
     }
 
     #[Test]

--- a/tests/Unit/BuiltInServerStaticPathResolverTest.php
+++ b/tests/Unit/BuiltInServerStaticPathResolverTest.php
@@ -20,8 +20,12 @@ class BuiltInServerStaticPathResolverTest extends TestCase
 
         mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'public', 0777, true);
         mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'ag-logos', 0777, true);
+        mkdir($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'nested', 0777, true);
 
         file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'app.css', 'body {}');
+        file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'index.php', '<?php echo "index";');
+        file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'.htaccess', 'deny from all');
+        file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'nested'.DIRECTORY_SEPARATOR.'.secret', 'hidden');
         file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'app'.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'ag-logos'.DIRECTORY_SEPARATOR.'logo.svg', '<svg></svg>');
         file_put_contents($this->projectRoot.DIRECTORY_SEPARATOR.'secret.txt', 'secret');
     }
@@ -65,6 +69,35 @@ class BuiltInServerStaticPathResolverTest extends TestCase
     {
         $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/storage/..\\secret.txt'));
         $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/..\\secret.txt'));
+    }
+
+    #[Test]
+    public function resolve_rejects_php_and_dotfile_targets(): void
+    {
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/index.php'));
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/.htaccess'));
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/nested/.secret'));
+    }
+
+    #[Test]
+    public function resolve_rejects_public_symlink_targets_outside_public_root(): void
+    {
+        if (! function_exists('symlink')) {
+            $this->markTestSkipped('Symlink creation is not supported in this environment.');
+        }
+
+        $outsideTarget = $this->projectRoot.DIRECTORY_SEPARATOR.'secret.txt';
+        $linkPath = $this->projectRoot.DIRECTORY_SEPARATOR.'public'.DIRECTORY_SEPARATOR.'leak.txt';
+
+        set_error_handler(static fn () => true);
+        $symlinkCreated = symlink($outsideTarget, $linkPath);
+        restore_error_handler();
+
+        if (! $symlinkCreated) {
+            $this->markTestSkipped('Symlink creation is not permitted in this environment.');
+        }
+
+        $this->assertNull(BuiltInServerStaticPathResolver::resolve($this->projectRoot, '/leak.txt'));
     }
 
     private function deleteDirectory(string $path): void

--- a/tests/e2e/arbeitsgruppen.spec.js
+++ b/tests/e2e/arbeitsgruppen.spec.js
@@ -28,6 +28,12 @@ test('arbeitsgruppen page links to the protected contact flow and keeps the cont
   await expect(logoImage).toHaveClass(/object-contain/);
   await expect(logoImage).not.toHaveClass(/object-cover/);
 
+  const logoSource = await logoImage.getAttribute('src');
+  expect(logoSource).toBeTruthy();
+
+  const logoResponse = await page.request.get(logoSource);
+  expect(logoResponse.ok()).toBeTruthy();
+
   const contactLink = article.getByRole('link', { name: 'Kontakt zur Arbeitsgruppe AG Fanhoerbuecher aufnehmen' });
   await expect(contactLink).toBeVisible();
   await expect(contactLink).toHaveAttribute('href', /\/arbeitsgruppen\/\d+\/kontakt$/);

--- a/tests/e2e/arbeitsgruppen.spec.js
+++ b/tests/e2e/arbeitsgruppen.spec.js
@@ -19,6 +19,15 @@ test('arbeitsgruppen page links to the protected contact flow and keeps the cont
   await expect(article).not.toContainText('ag-hoerbuecher@maddrax-fanclub.de');
   await expect(article.getByText('Kontakt aufnehmen', { exact: true })).toBeVisible();
 
+  const logoStage = article.getByTestId('ag-logo-stage');
+  const logoImage = article.getByTestId('ag-logo-image');
+
+  await expect(logoStage).toBeVisible();
+  await expect(logoImage).toHaveAttribute('alt', 'Logo der AG Fanhoerbuecher');
+  await expect(logoImage).toHaveAttribute('src', /\/storage\/ag-logos\/arbeitsgruppen-playwright-logo\.svg$/);
+  await expect(logoImage).toHaveClass(/object-contain/);
+  await expect(logoImage).not.toHaveClass(/object-cover/);
+
   const contactLink = article.getByRole('link', { name: 'Kontakt zur Arbeitsgruppe AG Fanhoerbuecher aufnehmen' });
   await expect(contactLink).toBeVisible();
   await expect(contactLink).toHaveAttribute('href', /\/arbeitsgruppen\/\d+\/kontakt$/);
@@ -27,4 +36,17 @@ test('arbeitsgruppen page links to the protected contact flow and keeps the cont
   await expect(article.getByTestId('ag-detail-grid')).toHaveClass(/sm:grid-cols-2/);
   await expect(article.getByTestId('ag-contact-card')).toHaveClass(/sm:col-span-2/);
   await expect(article.getByTestId('ag-contact-card').getByText('Kontakt', { exact: true })).toBeVisible();
+});
+
+test('arbeitsgruppen page keeps the logo stage stable on narrow viewports', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/arbeitsgruppen');
+
+  const article = page.locator('article', {
+    has: page.getByRole('heading', { level: 2, name: 'AG Fanhoerbuecher' }),
+  });
+
+  await expect(article.getByTestId('ag-logo-stage')).toBeVisible();
+  await expect(article.getByTestId('ag-logo-image')).toHaveClass(/object-contain/);
+  await expect(article.getByRole('link', { name: 'Kontakt zur Arbeitsgruppe AG Fanhoerbuecher aufnehmen' })).toBeVisible();
 });


### PR DESCRIPTION
This pull request introduces several improvements to how Arbeitsgruppen (working groups) logos are handled, displayed, and tested, as well as a refactor of the built-in server's static file resolution for enhanced security and maintainability. The key changes include adding support for group logos in the database and UI, updating the seeder and tests for logo contracts, and implementing a robust static file resolver to prevent serving disallowed files.

**Arbeitsgruppen Logo Support and Display:**

* The `ArbeitsgruppenPlaywrightSeeder` now creates a test logo SVG file and assigns its path to the seeded team, ensuring a consistent logo contract for Playwright tests. [[1]](diffhunk://#diff-1fc8917855f5de78405f60573a5b21b4b6d9c72459ce028795be51cf23ca18b2R9-R27) [[2]](diffhunk://#diff-1fc8917855f5de78405f60573a5b21b4b6d9c72459ce028795be51cf23ca18b2R38-R39) [[3]](diffhunk://#diff-1fc8917855f5de78405f60573a5b21b4b6d9c72459ce028795be51cf23ca18b2R59)
* The Arbeitsgruppen page (`arbeitsgruppen.blade.php`) has been updated to display group logos in a visually consistent, uncropped "contain" stage, with improved responsive styles and test IDs for UI testing. [[1]](diffhunk://#diff-abbd27ea037503a88cfe3aeb532cfc36556444c61a30cbe54ba5e3adcb9bbf63L29-R50) [[2]](diffhunk://#diff-abbd27ea037503a88cfe3aeb532cfc36556444c61a30cbe54ba5e3adcb9bbf63L52-R80)
* The old `.ag-logo` CSS class was removed, and logo styling is now handled inline in the Blade template for better flexibility.

**Testing Enhancements:**

* Feature tests now verify that the Arbeitsgruppen page properly renders logos according to the new contract, including presence of test IDs, correct image attributes, and layout classes.
* Seeder tests confirm that the logo SVG is created and stored as expected, and that the database reflects the correct logo path. [[1]](diffhunk://#diff-e26a5bda772faae0675de77337f9089d04785b518946eaaab40cfe8e5765805bR10) [[2]](diffhunk://#diff-e26a5bda772faae0675de77337f9089d04785b518946eaaab40cfe8e5765805bR50-R69)

**Built-in Server Security and Refactor:**

* A new `BuiltInServerStaticPathResolver` class was introduced to securely resolve static file paths, preventing access to disallowed paths (e.g., dotfiles, PHP files, or paths with `..`).
* The `server.php` script now uses this resolver, improving security and maintainability of static asset serving in development and testing. [[1]](diffhunk://#diff-a35003f202d86e283e3a2378727b7094fff8c81c768368f5acc07258cd56c0e0R3-R4) [[2]](diffhunk://#diff-a35003f202d86e283e3a2378727b7094fff8c81c768368f5acc07258cd56c0e0R17-R28) [[3]](diffhunk://#diff-a35003f202d86e283e3a2378727b7094fff8c81c768368f5acc07258cd56c0e0L52-R66)