### PR TITLE
Feature: RPG Character Editor access and navigation

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -55,5 +55,10 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('access-dashboard', function ($user) {
             return $user->hasTeamPermission($user->currentTeam, 'read');
         });
+
+        Gate::define('access-rpg-char-editor', function (User $user) {
+            return $user->hasAnyMitgliederTeamRole(\App\Enums\Role::Admin)
+                || $user->isMemberOfTeam('AG Rollenspiel');
+        });
     }
 }

--- a/app/Support/Navigation/NavigationBuilder.php
+++ b/app/Support/Navigation/NavigationBuilder.php
@@ -157,6 +157,18 @@ class NavigationBuilder
             }
         }
 
+        if (isset($predicate['mitglieder_roles_any'])) {
+            $roles = array_values(array_filter(
+                $predicate['mitglieder_roles_any'],
+                fn (mixed $role): bool => $role instanceof Role,
+            ));
+            $mitgliederRole = $visibilityState['mitglieder_team_role'] ?? null;
+
+            if ($roles === [] || ! $mitgliederRole instanceof Role || ! in_array($mitgliederRole, $roles, true)) {
+                return false;
+            }
+        }
+
         if (isset($predicate['team_any'])) {
             $teamNames = array_filter($predicate['team_any'], 'is_string');
             $memberTeamNames = $visibilityState['team_names'] ?? [];
@@ -213,6 +225,7 @@ class NavigationBuilder
 
         return [
             'current_role' => $currentRole,
+            'mitglieder_team_role' => $mitgliederTeamRole,
             'has_vorstand_role' => $currentRole instanceof Role
                 && in_array($currentRole, [Role::Admin, Role::Vorstand, Role::Kassenwart], true),
             'can_manage_veranstaltungen' => $mitgliederTeamRole instanceof Role

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,11 +1,13 @@
 <?php
 
 use App\Providers\AppServiceProvider;
+use App\Providers\AuthServiceProvider;
 use App\Providers\FortifyServiceProvider;
 use App\Providers\JetstreamServiceProvider;
 
 return [
     AppServiceProvider::class,
+    AuthServiceProvider::class,
     FortifyServiceProvider::class,
     JetstreamServiceProvider::class,
 ];

--- a/config/navigation.php
+++ b/config/navigation.php
@@ -123,6 +123,15 @@ return [
                     'tour_key' => 'teams-manage',
                     'has_non_personal_owned_team' => true,
                 ],
+                [
+                    'title' => 'Charakter-Editor',
+                    'route' => 'rpg.char-editor',
+                    'tour_key' => 'teams-char-editor',
+                    'visible_any' => [
+                        ['team_any' => ['AG Rollenspiel']],
+                        ['mitglieder_roles_any' => [Role::Admin]],
+                    ],
+                ],
             ],
         ],
         [
@@ -153,7 +162,6 @@ return [
             'roles_any' => [Role::Admin],
             'items' => [
                 ['title' => 'Kurznachrichten', 'route' => 'admin.messages.index', 'tour_key' => 'admin-messages'],
-                ['title' => 'Charakter-Editor', 'route' => 'rpg.char-editor', 'tour_key' => 'admin-char-editor'],
                 ['title' => 'Arbeitsgruppen', 'route' => 'arbeitsgruppen.index', 'tour_key' => 'admin-working-groups'],
                 ['title' => 'Belohnungen', 'route' => 'rewards.admin', 'tour_key' => 'admin-rewards'],
             ],

--- a/config/tours.php
+++ b/config/tours.php
@@ -2,7 +2,7 @@
 
 return [
     'hauptmenue' => [
-        'version' => 2,
+        'version' => 3,
         'title' => 'Hauptmenü entdecken',
         'description' => 'Fuehrt neue Mitglieder durch Schnellzugriff, Bereiche und Profil-Einstieg des Hauptmenues.',
         'self_service_enabled' => true,
@@ -418,6 +418,19 @@ return [
                 'selectors' => [
                     'desktop' => '[data-tour-device="desktop"][data-tour-key="teams-manage"]',
                     'mobile' => '[data-tour-device="mobile"][data-tour-key="teams-manage"]',
+                ],
+                'reveal' => [
+                    'desktop' => ['[data-tour-device="desktop"][data-tour-key="section-teams"]'],
+                    'mobile' => ['[data-tour-device="mobile"][data-tour-key="mobile-menu-toggle"]', '[data-tour-device="mobile"][data-tour-key="section-teams"]'],
+                ],
+            ],
+            [
+                'key' => 'teams-char-editor',
+                'title' => 'Charakter-Editor',
+                'description' => 'Wenn du in der AG Rollenspiel aktiv bist oder den globalen Adminzugriff hast, erreichst du hier den Charakter-Editor.',
+                'selectors' => [
+                    'desktop' => '[data-tour-device="desktop"][data-tour-key="teams-char-editor"]',
+                    'mobile' => '[data-tour-device="mobile"][data-tour-key="teams-char-editor"]',
                 ],
                 'reveal' => [
                     'desktop' => ['[data-tour-device="desktop"][data-tour-key="section-teams"]'],

--- a/public/changelog.json
+++ b/public/changelog.json
@@ -12,6 +12,7 @@
       "[New] Neue Baxx-Belohnungen und Spezialangebote ergänzt, darunter die Freischaltung der Mitgliederkarte und neue Maddraxiversum-Inhalte",
       "[New] Kassenbuch unterstützt jetzt Löschanfragen mit Freigabe- und Benachrichtigungsprozess",
       "[New] Rollenspiel-Regelwerke im Download-Bereich verfügbar",
+      "[New] Charakter-Editor für die AG Rollenspiel als Alpha-Version hinzugefügt",
       "[Improved] Kompendium-Suche reagiert schneller und liefert präzisere Ergebnisse",
       "[Improved] Fotogalerie zeigt aktuelle 2026-Fotos und lädt externe Nextcloud-Alben zuverlässiger",
       "[Improved] Oberfläche, Navigation und Dialoge wurden an vielen Stellen modernisiert und klarer strukturiert",

--- a/routes/web.php
+++ b/routes/web.php
@@ -325,11 +325,11 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
 
     Route::get('/rpg/char-editor', [RpgCharEditorController::class, 'index'])
         ->name('rpg.char-editor')
-        ->middleware('admin');
+        ->middleware('can:access-rpg-char-editor');
 
     Route::post('/rpg/char-editor/pdf', [RpgCharEditorController::class, 'pdf'])
         ->name('rpg.char-editor.pdf')
-        ->middleware('admin');
+        ->middleware('can:access-rpg-char-editor');
 
     Route::prefix('romantauschboerse')->name('romantausch.')->group(function () {
         Route::livewire('/', RomantauschIndex::class)->name('index');

--- a/tests/Feature/NavigationMenuTest.php
+++ b/tests/Feature/NavigationMenuTest.php
@@ -20,6 +20,20 @@ class NavigationMenuTest extends TestCase
     use CreatesUserWithRole;
     use RefreshDatabase;
 
+    private function addAgRollenspielMembership(User $user): User
+    {
+        $owner = User::factory()->create();
+
+        $team = Team::factory()->create([
+            'user_id' => $owner->id,
+            'name' => 'AG Rollenspiel',
+            'personal_team' => false,
+        ]);
+        $team->users()->attach($user, ['role' => Role::Mitglied->value]);
+
+        return $user->refresh();
+    }
+
     private function createManagementUserWithDifferentCurrentTeam(Role $role): User
     {
         $managementTeam = Team::membersTeam() ?? Team::factory()->create([
@@ -191,6 +205,30 @@ class NavigationMenuTest extends TestCase
         $this->assertNotNull($teamsSection);
         $this->assertSame(['EARDRAX Dashboard', 'Kompendium', 'AG verwalten'], array_column($teamsSection['items'], 'title'));
         $this->assertLessThanOrEqual(2, count($queries));
+    }
+
+    public function test_ag_rollenspiel_member_sees_character_editor_in_teams_section(): void
+    {
+        $user = $this->addAgRollenspielMembership($this->createUserWithRole(Role::Mitglied));
+
+        $navigation = app(NavigationBuilder::class)->build($user);
+        $teamsSection = collect($navigation['sections'])->firstWhere('title', 'Teams & AG');
+
+        $this->assertNotNull($teamsSection);
+        $this->assertContains('Charakter-Editor', array_column($teamsSection['items'], 'title'));
+    }
+
+    public function test_global_admin_with_different_current_team_sees_character_editor_in_teams_section_only(): void
+    {
+        $user = $this->createManagementUserWithDifferentCurrentTeam(Role::Admin);
+
+        $navigation = app(NavigationBuilder::class)->build($user);
+        $teamsSection = collect($navigation['sections'])->firstWhere('title', 'Teams & AG');
+        $adminSection = collect($navigation['sections'])->firstWhere('title', 'Admin');
+
+        $this->assertNotNull($teamsSection);
+        $this->assertContains('Charakter-Editor', array_column($teamsSection['items'], 'title'));
+        $this->assertNull($adminSection);
     }
 
     public function test_authenticated_users_see_termine_link_in_veranstaltungen_menu(): void

--- a/tests/Feature/RpgCharEditorAccessTest.php
+++ b/tests/Feature/RpgCharEditorAccessTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\Role;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -11,18 +12,69 @@ class RpgCharEditorAccessTest extends TestCase
 {
     use RefreshDatabase;
 
-    private function createMember(string $role = 'Mitglied'): User
+    private function createMember(Role|string $role = Role::Mitglied): User
     {
         $team = Team::membersTeam();
-        $user = User::factory()->create(['current_team_id' => $team->id]);
-        $team->users()->attach($user, ['role' => $role]);
 
-        return $user;
+        if (! $team) {
+            $team = Team::factory()->create(['name' => 'Mitglieder', 'personal_team' => false]);
+        }
+
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => $role instanceof Role ? $role->value : $role]);
+
+        return $user->refresh();
     }
 
-    public function test_admin_can_access_editor(): void
+    private function addAgRollenspielMembership(User $user): User
     {
-        $admin = $this->createMember('Admin');
+        $owner = User::factory()->create();
+
+        $team = Team::factory()->create([
+            'user_id' => $owner->id,
+            'name' => 'AG Rollenspiel',
+            'personal_team' => false,
+        ]);
+        $team->users()->attach($user, ['role' => Role::Mitglied->value]);
+
+        return $user->refresh();
+    }
+
+    private function createManagementUserWithDifferentCurrentTeam(Role $role): User
+    {
+        $managementTeam = Team::membersTeam() ?? Team::factory()->create([
+            'name' => 'Mitglieder',
+            'personal_team' => false,
+        ]);
+
+        $user = User::factory()->create(['current_team_id' => $managementTeam->id]);
+        $managementTeam->users()->attach($user, ['role' => $role->value]);
+
+        $otherTeam = Team::factory()->create([
+            'user_id' => $user->id,
+            'name' => 'Nebenverein',
+            'personal_team' => false,
+        ]);
+        $otherTeam->users()->attach($user, ['role' => Role::Mitglied->value]);
+
+        $user->forceFill(['current_team_id' => $otherTeam->id])->save();
+
+        return $user->refresh();
+    }
+
+    public function test_ag_rollenspiel_member_can_access_editor(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        $this->actingAs($member)
+            ->get('/rpg/char-editor')
+            ->assertOk()
+            ->assertSee('Charakter-Editor');
+    }
+
+    public function test_global_admin_can_access_editor_with_different_current_team(): void
+    {
+        $admin = $this->createManagementUserWithDifferentCurrentTeam(Role::Admin);
 
         $this->actingAs($admin)
             ->get('/rpg/char-editor')
@@ -30,7 +82,7 @@ class RpgCharEditorAccessTest extends TestCase
             ->assertSee('Charakter-Editor');
     }
 
-    public function test_non_admin_is_forbidden_from_editor(): void
+    public function test_member_without_ag_rollenspiel_is_forbidden_from_editor(): void
     {
         $user = $this->createMember();
 

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -16,18 +16,60 @@ class RpgCharEditorPdfTest extends TestCase
 {
     use RefreshDatabase;
 
-    private function adminUser(): User
+    private function createMember(Role|string $role = Role::Mitglied): User
     {
         $team = Team::membersTeam();
-        $user = User::factory()->create(['current_team_id' => $team->id]);
-        $team->users()->attach($user, ['role' => Role::Admin->value]);
 
-        return $user;
+        if (! $team) {
+            $team = Team::factory()->create(['name' => 'Mitglieder', 'personal_team' => false]);
+        }
+
+        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $team->users()->attach($user, ['role' => $role instanceof Role ? $role->value : $role]);
+
+        return $user->refresh();
     }
 
-    public function test_pdf_downloads_with_sanitized_filename(): void
+    private function addAgRollenspielMembership(User $user): User
     {
-        $admin = $this->adminUser();
+        $owner = User::factory()->create();
+
+        $team = Team::factory()->create([
+            'user_id' => $owner->id,
+            'name' => 'AG Rollenspiel',
+            'personal_team' => false,
+        ]);
+        $team->users()->attach($user, ['role' => Role::Mitglied->value]);
+
+        return $user->refresh();
+    }
+
+    private function createManagementUserWithDifferentCurrentTeam(Role $role): User
+    {
+        $managementTeam = Team::membersTeam() ?? Team::factory()->create([
+            'name' => 'Mitglieder',
+            'personal_team' => false,
+        ]);
+
+        $user = User::factory()->create(['current_team_id' => $managementTeam->id]);
+        $managementTeam->users()->attach($user, ['role' => $role->value]);
+
+        $otherTeam = Team::factory()->create([
+            'user_id' => $user->id,
+            'name' => 'Nebenverein',
+            'personal_team' => false,
+        ]);
+        $otherTeam->users()->attach($user, ['role' => Role::Mitglied->value]);
+
+        $user->forceFill(['current_team_id' => $otherTeam->id])->save();
+
+        return $user->refresh();
+    }
+
+    public function test_pdf_downloads_with_sanitized_filename_for_ag_rollenspiel_member(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
         Pdf::shouldReceive('view')->once()->with('rpg.char-sheet', \Mockery::type('array'))
             ->andReturn(new class extends PdfBuilder
             {
@@ -37,7 +79,7 @@ class RpgCharEditorPdfTest extends TestCase
                 }
             });
 
-        $response = $this->actingAs($admin)->post('/rpg/char-editor/pdf', [
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Foo/Bar',
             'portrait' => UploadedFile::fake()->image('avatar.jpg'),
         ]);
@@ -45,20 +87,20 @@ class RpgCharEditorPdfTest extends TestCase
         $this->assertStringContainsString('foobar.pdf', $response->headers->get('content-disposition'));
     }
 
-    public function test_rejects_non_image_portrait(): void
+    public function test_rejects_non_image_portrait_for_ag_rollenspiel_member(): void
     {
-        $admin = $this->adminUser();
+        $member = $this->addAgRollenspielMembership($this->createMember());
 
-        $response = $this->actingAs($admin)->post('/rpg/char-editor/pdf', [
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
             'portrait' => UploadedFile::fake()->create('bad.exe', 10, 'application/octet-stream'),
         ]);
 
         $response->assertSessionHasErrors('portrait');
     }
 
-    public function test_pdf_generates_without_portrait(): void
+    public function test_pdf_generates_without_portrait_for_global_admin_with_different_current_team(): void
     {
-        $admin = $this->adminUser();
+        $admin = $this->createManagementUserWithDifferentCurrentTeam(Role::Admin);
 
         Pdf::shouldReceive('view')
             ->once()
@@ -78,9 +120,9 @@ class RpgCharEditorPdfTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_pdf_includes_base64_portrait_when_uploaded(): void
+    public function test_pdf_includes_base64_portrait_when_uploaded_for_ag_rollenspiel_member(): void
     {
-        $admin = $this->adminUser();
+        $member = $this->addAgRollenspielMembership($this->createMember());
 
         Pdf::shouldReceive('view')
             ->once()
@@ -93,12 +135,21 @@ class RpgCharEditorPdfTest extends TestCase
                 }
             });
 
-        $response = $this->actingAs($admin)->post('/rpg/char-editor/pdf', [
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Foo',
             'portrait' => UploadedFile::fake()->image('avatar.png'),
         ]);
 
         $response->assertOk();
+    }
+
+    public function test_member_without_ag_rollenspiel_is_forbidden_from_pdf_endpoint(): void
+    {
+        $member = $this->createMember();
+
+        $this->actingAs($member)
+            ->post('/rpg/char-editor/pdf', ['character_name' => 'Foo'])
+            ->assertForbidden();
     }
 
     public function test_laravel_pdf_is_configured(): void

--- a/tests/Feature/TourControllerTest.php
+++ b/tests/Feature/TourControllerTest.php
@@ -51,7 +51,7 @@ class TourControllerTest extends TestCase
             ->assertJsonPath('tour.assignment_id', $assignment->id)
             ->assertJsonPath('tour.key', 'hauptmenue')
             ->assertJsonPath('tour.status', TourAssignmentStatus::Pending->value)
-            ->assertJsonCount(34, 'tour.steps');
+            ->assertJsonCount(35, 'tour.steps');
     }
 
     public function test_current_upgrades_outdated_assignment_before_returning_payload(): void
@@ -92,7 +92,7 @@ class TourControllerTest extends TestCase
             ->assertOk()
             ->assertJsonPath('tour.current_step_key', 'profile-settings')
             ->assertJsonPath('tour.status', TourAssignmentStatus::InProgress->value)
-            ->assertJsonPath('tour.current_step_index', 33);
+            ->assertJsonPath('tour.current_step_index', 34);
 
         $this->assertDatabaseHas('tour_assignments', [
             'id' => $assignment->id,


### PR DESCRIPTION
This pull request introduces a new "Charakter-Editor" (Character Editor) feature for the AG Rollenspiel group, including navigation integration, access control, and comprehensive test coverage. The changes ensure that only global admins or members of the "AG Rollenspiel" team can access this editor, and they update navigation, permissions, and onboarding tours accordingly.

**Access Control and Permissions:**
- Added a new `access-rpg-char-editor` gate in `AuthServiceProvider` to allow access for global admins and members of the "AG Rollenspiel" team. Route middleware updated to use this gate for both GET and POST endpoints of the character editor. [[1]](diffhunk://#diff-9d0a077acda375ef8f06f27e2f823037207bcbaa21c2c87cf4c113a13a3eb0c4R58-R62) [[2]](diffhunk://#diff-193e04aa1705f6f3e484d7efca8f45fe4d19d0ece3b6e6880d3ea070938a1fadL328-R332) [[3]](diffhunk://#diff-139a53739f995e3b2b9b570638ed4c7208c345e76961805f15f7cdca600668cdR4-R10)
- Enhanced the navigation builder to support visibility predicates based on team roles, enabling menu items to be shown only to users with specific roles or memberships. [[1]](diffhunk://#diff-9c4e3f09b59637a74cfb0a4fc3ac651ac997c6b349ec495f79d1419e84cbd0fcR160-R171) [[2]](diffhunk://#diff-9c4e3f09b59637a74cfb0a4fc3ac651ac997c6b349ec495f79d1419e84cbd0fcR228)

**Navigation and UI Updates:**
- Added the "Charakter-Editor" item to the "Teams & AG" section in the navigation, visible to "AG Rollenspiel" members and global admins. Removed it from the admin section to avoid duplication. [[1]](diffhunk://#diff-1304c3abede63b710d81928b83667409af73b592c9df40cc05b5aa1145ecfcceR126-R134) [[2]](diffhunk://#diff-1304c3abede63b710d81928b83667409af73b592c9df40cc05b5aa1145ecfcceL156)
- Updated the onboarding tour configuration to include a step for the new character editor, incrementing the tour version and providing selectors and descriptions for both desktop and mobile. [[1]](diffhunk://#diff-40b410809aaa0b155fabf67a2457cd37f53ee5eea9da1d2bf1a154997a062b76L5-R5) [[2]](diffhunk://#diff-40b410809aaa0b155fabf67a2457cd37f53ee5eea9da1d2bf1a154997a062b76R427-R439)

**Testing and Quality Assurance:**
- Extended feature tests to cover all relevant access scenarios for the character editor, including membership checks, admin role checks, and forbidden access for unauthorized users. Tests also verify navigation visibility and PDF generation endpoints. [[1]](diffhunk://#diff-a5990b460dbb214ee73b4bc0cac09cd61f4368dcd0b6b56657bbb123dfa6a7f5R5) [[2]](diffhunk://#diff-a5990b460dbb214ee73b4bc0cac09cd61f4368dcd0b6b56657bbb123dfa6a7f5L14-R85) [[3]](diffhunk://#diff-f07fc19527b4a5bab3d806bcfae04538554be984c2baf74012660dc78ac8672aR23-R36) [[4]](diffhunk://#diff-f07fc19527b4a5bab3d806bcfae04538554be984c2baf74012660dc78ac8672aR210-R233) [[5]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L19-R72) [[6]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L40-R103) [[7]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L81-R125) [[8]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L96-R154)

**Documentation and Changelog:**
- Updated the public changelog to announce the addition of the character editor as an alpha feature for AG Rollenspiel.

**Tour and Onboarding:**
- Increased the main menu tour step count and ensured the new character editor step is included in tour progress and assignment logic. [[1]](diffhunk://#diff-9ee7fa1c9c2966b55cd57f658fb782fd712af910b73d0046db919c961bf6fb89L54-R54) [[2]](diffhunk://#diff-9ee7fa1c9c2966b55cd57f658fb782fd712af910b73d0046db919c961bf6fb89L95-R95)