### PR TITLE
Fix: Character Editor Form not working

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1377,16 +1377,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.10.1",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361"
+                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/73ab136360b5dfd858006eae9795e8fe43c80361",
-                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
+                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
                 "shasum": ""
             },
             "require": {
@@ -1474,7 +1474,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.10.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.2"
             },
             "funding": [
                 {
@@ -1490,7 +1490,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T09:27:36+00:00"
+            "time": "2026-05-25T22:58:15+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -36,6 +36,7 @@ const phpEnvironment = {
   FANTREFFEN_MIN_FORM_TIME: '0',
   FANTREFFEN_DISABLE_RATE_LIMIT: 'true',
   PLAYWRIGHT_USE_DOCKER: process.env.PLAYWRIGHT_USE_DOCKER ?? '0',
+  PLAYWRIGHT_USE_VITE_HOT: process.env.PLAYWRIGHT_USE_VITE_HOT ?? '0',
   PLAYWRIGHT_PORT: String(playwrightPort),
   DOCKER_DEV_PLAYWRIGHT_PORT: String(playwrightPort),
   PLAYWRIGHT_RUN_TOKEN: playwrightRunToken,

--- a/resources/js/alpine-init.js
+++ b/resources/js/alpine-init.js
@@ -15,13 +15,10 @@
  */
 export function initAlpine(alpineModule, plugins = []) {
     if (window.Alpine) {
-        // Livewire hat Alpine bereits geladen — nur Plugins registrieren.
-        // WICHTIG: window.Alpine NICHT überschreiben, da es Livewire-Extensions enthält.
-        if (typeof window.Alpine.plugin === 'function') {
-            for (const plugin of plugins) {
-                window.Alpine.plugin(plugin);
-            }
-        }
+        // Livewire hat Alpine bereits geladen und bringt die benoetigten
+        // Alpine-Plugins selbst mit. App-Bundle-Plugins hier erneut auf
+        // derselben Instanz zu registrieren, kann fatal sein
+        // (z. B. $persist -> Cannot redefine property).
         return { mode: 'livewire', alpine: window.Alpine };
     }
 
@@ -55,8 +52,9 @@ export function scheduleInitAlpine(alpineModule, plugins = []) {
     const run = () => initAlpine(alpineModule, plugins);
 
     if (window.Alpine) {
-        // Livewires Alpine ist bereits verfügbar — Plugins sofort registrieren,
-        // damit sie wirksam sind bevor Livewire Alpine.start() bei DOMContentLoaded aufruft.
+        // Livewires Alpine ist bereits verfuegbar.
+        // Keine Plugins aus dem App-Bundle nachregistrieren; Livewire kuemmert
+        // sich selbst um seine Alpine-Plugins.
         run();
     } else if (document.readyState === 'loading') {
         // DOM wird noch geparst, kein Alpine vorhanden — warte auf DOMContentLoaded,

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -443,5 +443,5 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 if (window.Alpine && typeof window.Alpine.data === 'function') {
     registerCharEditor({ hydrateExisting: true });
 } else {
-    document.addEventListener('alpine:init', registerCharEditor);
+    document.addEventListener('alpine:init', () => registerCharEditor(), { once: true });
 }

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -37,7 +37,7 @@ function hydrateExistingCharEditors() {
     });
 }
 
-export function registerCharEditor({ hydrateExisting = false } = {}) {
+function registerCharEditor({ hydrateExisting = false } = {}) {
     if (!window.Alpine || typeof window.Alpine.data !== 'function') {
         return;
     }

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -11,20 +11,33 @@ const CULTURE_DESCRIPTIONS = {
 const ATTRIBUTE_IDS = ['st', 'ge', 'ro', 'wi', 'wa', 'in', 'au'];
 
 function hydrateExistingCharEditors() {
-    if (!window.Alpine || typeof window.Alpine.initTree !== 'function') {
+    if (!window.Alpine
+        || typeof window.Alpine.initTree !== 'function'
+        || typeof window.Alpine.destroyTree !== 'function'
+        || typeof window.Alpine.$data !== 'function') {
         return;
     }
 
     document.querySelectorAll('[x-data="charEditor"], [x-data^="charEditor("]').forEach((element) => {
-        if (element._x_dataStack) {
+        const scope = element._x_dataStack ? window.Alpine.$data(element) : null;
+        const hasRegisteredState = scope
+            && typeof scope.basicsFilled === 'function'
+            && typeof scope.formValid === 'function'
+            && Object.hasOwn(scope, 'advancedUnlocked');
+
+        if (hasRegisteredState) {
             return;
+        }
+
+        if (element._x_dataStack) {
+            window.Alpine.destroyTree(element);
         }
 
         window.Alpine.initTree(element);
     });
 }
 
-function registerCharEditor({ hydrateExisting = false } = {}) {
+export function registerCharEditor({ hydrateExisting = false } = {}) {
     if (!window.Alpine || typeof window.Alpine.data !== 'function') {
         return;
     }
@@ -61,23 +74,23 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     // UI state
     advancedUnlocked: false,
 
-    get basicsFilled() {
+    basicsFilled() {
         return this.playerName.trim() && this.characterName.trim() && this.race && this.culture;
     },
 
-    get attributeMax() {
+    attributeMax() {
         return this.race === 'Barbar' ? 2 : 1;
     },
 
-    get apUsed() {
+    apUsed() {
         return ATTRIBUTE_IDS.reduce((sum, id) => sum + Math.max(this.attributes[id], 0), 0);
     },
 
-    get apRemaining() {
-        return this.base.AP + this.raceAPBonus - this.apUsed;
+    apRemaining() {
+        return this.base.AP + this.raceAPBonus - this.apUsed();
     },
 
-    get fpUsed() {
+    fpUsed() {
         return this.skills.reduce((sum, skill) => {
             const grant = this.getGrant(skill.name);
             const start = grant ? grant.value : 0;
@@ -87,35 +100,35 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         }, 0);
     },
 
-    get fpRemaining() {
-        return this.base.FP - this.fpUsed;
+    fpRemaining() {
+        return this.base.FP - this.fpUsed();
     },
 
-    get chosenAdvantagesCount() {
+    chosenAdvantagesCount() {
         return this.selectedAdvantages.filter(a => a !== 'Zäh').length;
     },
 
-    get freeAdvantagePoints() {
-        return this.base.freeAdvantages - this.chosenAdvantagesCount;
+    freeAdvantagePoints() {
+        return this.base.freeAdvantages - this.chosenAdvantagesCount();
     },
 
-    get hasKindZweierWelten() {
+    hasKindZweierWelten() {
         return this.selectedAdvantages.includes('Kind zweier Welten');
     },
 
-    get formValid() {
-        return this.apRemaining === 0
-            && this.fpRemaining === 0
-            && this.selectedDisadvantages.length >= this.chosenAdvantagesCount;
+    formValid() {
+        return this.apRemaining() === 0
+            && this.fpRemaining() === 0
+            && this.selectedDisadvantages.length >= this.chosenAdvantagesCount();
     },
 
-    get allUsedSkillNames() {
+    allUsedSkillNames() {
         const used = new Set([
             ...Object.keys(this.raceGrants),
             ...Object.keys(this.cultureGrants),
             ...this.skills.map(s => s.name).filter(Boolean),
         ]);
-        if (!this.hasKindZweierWelten) {
+        if (!this.hasKindZweierWelten()) {
             if (this.raceGrants['Intuition']) used.add('Bildung');
             if (this.raceGrants['Bildung']) used.add('Intuition');
         }
@@ -132,14 +145,14 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     clampAttribute(id) {
         let val = this.attributes[id];
         if (typeof val !== 'number' || isNaN(val)) val = 0;
-        val = Math.max(-1, Math.min(val, this.attributeMax));
+        val = Math.max(-1, Math.min(val, this.attributeMax()));
 
         // Check AP budget
         const othersUsed = ATTRIBUTE_IDS.reduce((sum, otherId) => {
             if (otherId === id) return sum;
             return sum + Math.max(this.attributes[otherId], 0);
         }, 0);
-        const maxForThis = Math.max(-1, Math.min(this.base.AP + this.raceAPBonus - othersUsed, this.attributeMax));
+        const maxForThis = Math.max(-1, Math.min(this.base.AP + this.raceAPBonus - othersUsed, this.attributeMax()));
         val = Math.min(val, maxForThis);
 
         this.attributes[id] = val;
@@ -171,7 +184,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     // --- Skill management ---
     addSkill() {
-        if (this.fpRemaining <= 0) return;
+        if (this.fpRemaining() <= 0) return;
         this.skills.push({ name: '', value: 0, source: null, locked: false, nameDisabled: false, valueDisabled: false, badge: null });
     },
 
@@ -228,7 +241,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         const grant = this.getGrant(skill.name);
         if (grant && grant.type === 'exact') return true;
         // Education/Intuition exclusivity
-        if (!this.hasKindZweierWelten) {
+        if (!this.hasKindZweierWelten()) {
             const intuitionGrant = !!this.raceGrants['Intuition'];
             const bildungGrant = !!this.raceGrants['Bildung'];
             if (intuitionGrant && skill.name === 'Bildung') return true;
@@ -272,11 +285,11 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     isSkillNameUsed(name, currentIndex) {
         if (!name) return false;
-        return this.allUsedSkillNames.has(name) && !this.skills.some((s, i) => i === currentIndex && s.name === name);
+        return this.allUsedSkillNames().has(name) && !this.skills.some((s, i) => i === currentIndex && s.name === name);
     },
 
     isSkillOptionDisabled(optionValue) {
-        return this.allUsedSkillNames.has(optionValue);
+        return this.allUsedSkillNames().has(optionValue);
     },
 
     // --- Race handling ---
@@ -308,7 +321,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (!cache) return;
         ATTRIBUTE_IDS.forEach(id => {
             if (cache.attributes[id] !== undefined) {
-                this.attributes[id] = Math.max(-1, Math.min(cache.attributes[id], this.attributeMax));
+                this.attributes[id] = Math.max(-1, Math.min(cache.attributes[id], this.attributeMax()));
             }
         });
         cache.skills.forEach(cached => {
@@ -414,7 +427,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     isAdvantageDisabled(value) {
         if (value === 'Zäh') return true;
-        return !this.selectedAdvantages.includes(value) && this.chosenAdvantagesCount >= this.base.freeAdvantages;
+        return !this.selectedAdvantages.includes(value) && this.chosenAdvantagesCount() >= this.base.freeAdvantages;
     },
 
     isDisadvantageDisabled(value) {

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -10,7 +10,25 @@ const CULTURE_DESCRIPTIONS = {
 
 const ATTRIBUTE_IDS = ['st', 'ge', 'ro', 'wi', 'wa', 'in', 'au'];
 
-document.addEventListener('alpine:init', () => {
+function hydrateExistingCharEditors() {
+    if (!window.Alpine || typeof window.Alpine.initTree !== 'function') {
+        return;
+    }
+
+    document.querySelectorAll('[x-data="charEditor"], [x-data^="charEditor("]').forEach((element) => {
+        if (element._x_dataStack) {
+            return;
+        }
+
+        window.Alpine.initTree(element);
+    });
+}
+
+function registerCharEditor({ hydrateExisting = false } = {}) {
+    if (!window.Alpine || typeof window.Alpine.data !== 'function') {
+        return;
+    }
+
     window.Alpine.data('charEditor', () => ({
     // Basic info
     playerName: '',
@@ -403,4 +421,14 @@ document.addEventListener('alpine:init', () => {
         return this.raceLocked.disadvantages.includes(value);
     },
 }));
-});
+
+    if (hydrateExisting) {
+        hydrateExistingCharEditors();
+    }
+}
+
+if (window.Alpine && typeof window.Alpine.data === 'function') {
+    registerCharEditor({ hydrateExisting: true });
+} else {
+    document.addEventListener('alpine:init', registerCharEditor);
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -10,11 +10,10 @@ import anchor from '@alpinejs/anchor';
 import collapse from '@alpinejs/collapse';
 import focus from '@alpinejs/focus';
 import persist from '@alpinejs/persist';
-import { registerCharEditor } from './alpine/char-editor';
+import './alpine/char-editor';
 import { scheduleInitAlpine } from './alpine-init';
 
 scheduleInitAlpine(Alpine, [anchor, focus, persist, collapse]);
-registerCharEditor({ hydrateExisting: true });
 
 const DARK_THEME = 'coffee';
 const LIGHT_THEME = 'caramellatte';

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -10,9 +10,11 @@ import anchor from '@alpinejs/anchor';
 import collapse from '@alpinejs/collapse';
 import focus from '@alpinejs/focus';
 import persist from '@alpinejs/persist';
+import { registerCharEditor } from './alpine/char-editor';
 import { scheduleInitAlpine } from './alpine-init';
 
 scheduleInitAlpine(Alpine, [anchor, focus, persist, collapse]);
+registerCharEditor({ hydrateExisting: true });
 
 const DARK_THEME = 'coffee';
 const LIGHT_THEME = 'caramellatte';
@@ -89,7 +91,6 @@ import 'leaflet/dist/leaflet.css';
 // Leaflet global verfügbar machen
 window.L = L;
 
-import './alpine/char-editor';
 import './alpine/hoerbuch-role-repeater';
 import { registerMarkdownEditorLifecycle } from './reviews/markdown-editor';
 import './todos';

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -19,7 +19,7 @@
     <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
     <!-- Styles -->
     @php($isMinimalTestLayout = app()->runningUnitTests() && config('app.testing_minimal_layout', false))
-    @php($shouldSkipViteAssets = app()->runningUnitTests())
+    @php($shouldSkipViteAssets = $isMinimalTestLayout && config('app.testing_skip_vite_assets', true))
     @include('layouts.partials.theme-bootstrap')
     @unless ($shouldSkipViteAssets)
         @vite(['resources/css/app.css'])

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -32,7 +32,7 @@
     <link href="https://fonts.bunny.net/css?family=space-grotesk:500,600,700&display=swap" rel="stylesheet" />
     <!-- Styles -->
     @php($isMinimalTestLayout = app()->runningUnitTests() && config('app.testing_minimal_layout', false))
-    @php($shouldSkipViteAssets = app()->runningUnitTests() && config('app.testing_skip_vite_assets', true))
+    @php($shouldSkipViteAssets = $isMinimalTestLayout && config('app.testing_skip_vite_assets', true))
     @include('layouts.partials.theme-bootstrap')
     @unless ($shouldSkipViteAssets)
         @vite(['resources/css/app.css'])

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -8,10 +8,10 @@
         />
 
         <x-ui.panel title="Charakterdaten" description="Alle Pflichtfelder, Freischaltungen und Exportaktionen bleiben in einem einzigen Editorfluss gebündelt.">
-            <form action="#" method="POST" enctype="multipart/form-data" x-data="charEditor" data-testid="char-editor-form">
+            <form action="#" method="POST" enctype="multipart/form-data" x-data="charEditor()" data-testid="char-editor-form">
                 @csrf
 
-                <input type="hidden" name="available_advantage_points" :value="freeAdvantagePoints">
+                <input type="hidden" name="available_advantage_points" :value="freeAdvantagePoints()">
                 <input type="hidden" name="figurenstaerke" value="1">
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
@@ -53,18 +53,18 @@
                     </div>
                 </div>
 
-                <div class="flex justify-end mb-6" x-show="basicsFilled && !advancedUnlocked" x-cloak>
+                <div class="flex justify-end mb-6" x-show="basicsFilled() && !advancedUnlocked" x-cloak>
                     <x-button type="button" label="Weiter, bei Wudan" class="btn-primary" @click="unlockAdvanced()" data-testid="char-editor-continue-button" />
                 </div>
 
                 <fieldset :disabled="!advancedUnlocked" :class="{ 'opacity-50': !advancedUnlocked }">
                     <div class="mb-6">
                         <h2 class="text-xl font-semibold text-primary mb-2">Attribute</h2>
-                        <p class="text-sm text-base-content mb-2" x-text="'Verfügbare Attributspunkte: ' + apRemaining"></p>
+                        <p class="text-sm text-base-content mb-2" x-text="'Verfügbare Attributspunkte: ' + apRemaining()"></p>
                         <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
                             @foreach(['st' => 'Stärke (ST)', 'ge' => 'Geschicklichkeit (GE)', 'ro' => 'Robustheit (RO)', 'wi' => 'Willenskraft (WI)', 'wa' => 'Wahrnehmung (WA)', 'in' => 'Intelligenz (IN)', 'au' => 'Auftreten (AU)'] as $attrId => $label)
                             <div>
-                                <x-input type="number" label="{{ $label }}" name="attributes[{{ $attrId }}]" id="{{ $attrId }}" min="-1" x-bind:max="attributeMax" step="1" x-model.number="attributes.{{ $attrId }}" @change="clampAttribute('{{ $attrId }}')" />
+                                <x-input type="number" label="{{ $label }}" name="attributes[{{ $attrId }}]" id="{{ $attrId }}" min="-1" x-bind:max="attributeMax()" step="1" x-model.number="attributes.{{ $attrId }}" @change="clampAttribute('{{ $attrId }}')" />
                             </div>
                             @endforeach
                         </div>
@@ -72,7 +72,7 @@
 
                     <div class="mb-6">
                         <h2 class="text-xl font-semibold text-primary mb-2">Fertigkeiten</h2>
-                        <p class="text-sm text-base-content mb-2" x-text="'Verfügbare Fertigkeitspunkte: ' + fpRemaining"></p>
+                        <p class="text-sm text-base-content mb-2" x-text="'Verfügbare Fertigkeitspunkte: ' + fpRemaining()"></p>
                         <div x-show="race === 'Barbar'" class="mb-2">
                             <label for="barbar-combat-select" class="text-sm font-medium text-base-content mb-1">Barbar Kampfbonus</label>
                             <select id="barbar-combat-select" class="select select-bordered w-full sm:w-auto" x-model="barbarCombatSkill" @change="setBarbarCombatSkill(barbarCombatSkill)">
@@ -116,7 +116,7 @@
                                 </div>
                             </template>
                         </div>
-                        <x-button type="button" label="Fertigkeit hinzufügen" class="btn-primary btn-sm mt-2" @click="addSkill()" x-bind:disabled="fpRemaining <= 0" />
+                        <x-button type="button" label="Fertigkeit hinzufügen" class="btn-primary btn-sm mt-2" @click="addSkill()" x-bind:disabled="fpRemaining() <= 0" />
                         <datalist id="skills-list">
                             <option value="Athletik"></option>
                             <option value="Beruf"></option>
@@ -193,8 +193,8 @@
                     </div>
 
                     <div class="flex justify-end space-x-2">
-                        <x-button id="pdf-button" type="submit" formaction="{{ route('rpg.char-editor.pdf') }}" formtarget="_blank" x-bind:disabled="!formValid" label="PDF drucken" icon="o-document-text" class="btn-ghost" data-testid="pdf-button" />
-                        <x-button id="submit-button" type="submit" x-bind:disabled="!formValid" label="Speichern" icon="o-check" class="btn-primary" data-testid="submit-button" />
+                        <x-button id="pdf-button" type="submit" formaction="{{ route('rpg.char-editor.pdf') }}" formtarget="_blank" x-bind:disabled="!formValid()" label="PDF drucken" icon="o-document-text" class="btn-ghost" data-testid="pdf-button" />
+                        <x-button id="submit-button" type="submit" x-bind:disabled="!formValid()" label="Speichern" icon="o-check" class="btn-primary" data-testid="submit-button" />
                     </div>
                 </fieldset>
             </form>

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -44,7 +44,7 @@
                     <div class="md:col-span-2" :class="{ 'opacity-50': advancedUnlocked }">
                         <label for="portrait" class="block text-sm font-medium text-base-content mb-1">Porträt/Symbol</label>
                         <input type="file" name="portrait" id="portrait" accept="image/*" class="file-input file-input-bordered w-full" @change="handlePortraitUpload($event)" :disabled="advancedUnlocked">
-                        <img x-show="portraitPreview" :src="portraitPreview" class="mt-2 w-24 h-24 object-cover rounded border border-base-content/20" alt="Portrait Vorschau">
+                        <img x-show="portraitPreview" x-cloak :src="portraitPreview" class="mt-2 w-24 h-24 object-cover rounded border border-base-content/20" alt="Portrait Vorschau" data-testid="char-editor-portrait-preview">
                     </div>
 
                     <div class="md:col-span-2">
@@ -53,8 +53,8 @@
                     </div>
                 </div>
 
-                <div class="flex justify-end mb-6" x-show="basicsFilled && !advancedUnlocked">
-                    <x-button type="button" label="Weiter, bei Wudan" class="btn-primary" @click="unlockAdvanced()" />
+                <div class="flex justify-end mb-6" x-show="basicsFilled && !advancedUnlocked" x-cloak>
+                    <x-button type="button" label="Weiter, bei Wudan" class="btn-primary" @click="unlockAdvanced()" data-testid="char-editor-continue-button" />
                 </div>
 
                 <fieldset :disabled="!advancedUnlocked" :class="{ 'opacity-50': !advancedUnlocked }">

--- a/tests/Feature/AppServiceProviderTest.php
+++ b/tests/Feature/AppServiceProviderTest.php
@@ -68,8 +68,10 @@ class AppServiceProviderTest extends TestCase
         $this->assertSame($url, $view->getData()['socialImage']);
     }
 
-    public function test_app_layout_skips_vite_assets_during_unit_tests(): void
+    public function test_app_layout_skips_vite_assets_for_minimal_test_layout(): void
     {
+        Config::set('app.testing_minimal_layout', true);
+
         $this->assertTrue(config('app.testing_skip_vite_assets'));
 
         $html = view('layouts.app', ['slot' => 'Testinhalt'])->render();
@@ -81,8 +83,6 @@ class AppServiceProviderTest extends TestCase
 
     public function test_app_layout_keeps_vite_assets_without_minimal_test_layout(): void
     {
-        Config::set('app.testing_skip_vite_assets', false);
-
         $this->withTemporaryViteManifest(function (): void {
             $html = view('layouts.app', ['slot' => 'Testinhalt'])->render();
 

--- a/tests/Jest/app.test.js
+++ b/tests/Jest/app.test.js
@@ -14,7 +14,7 @@ afterEach(() => {
   window.Alpine = originalAlpine;
 });
 
-async function loadApp(matches) {
+async function loadApp(matches, { existingAlpine } = {}) {
   jest.resetModules();
   document.documentElement.className = '';
   document.documentElement.dataset.theme = '';
@@ -55,6 +55,10 @@ async function loadApp(matches) {
   await jest.unstable_mockModule('@alpinejs/focus', () => ({ default: focusPlugin }));
   await jest.unstable_mockModule('@alpinejs/persist', () => ({ default: persistPlugin }));
   await jest.unstable_mockModule('@alpinejs/collapse', () => ({ default: collapsePlugin }));
+
+  if (existingAlpine) {
+    window.Alpine = existingAlpine;
+  }
 
   await import('../../resources/js/app.js');
   return {
@@ -101,5 +105,21 @@ describe('app module', () => {
     expect(mockAlpine.plugin).toHaveBeenNthCalledWith(2, plugins.focusPlugin);
     expect(mockAlpine.plugin).toHaveBeenNthCalledWith(3, plugins.persistPlugin);
     expect(mockAlpine.plugin).toHaveBeenNthCalledWith(4, plugins.collapsePlugin);
+  });
+
+  test('does not re-register Alpine plugins when Livewire Alpine already exists', async () => {
+    const livewireAlpine = {
+      plugin: jest.fn(),
+      start: jest.fn(),
+      persist: jest.fn(),
+      version: '3.15.4-livewire',
+    };
+
+    const { mockAlpine } = await loadApp(true, { existingAlpine: livewireAlpine });
+
+    expect(mockAlpine.plugin).not.toHaveBeenCalled();
+    expect(mockAlpine.start).not.toHaveBeenCalled();
+    expect(livewireAlpine.plugin).not.toHaveBeenCalled();
+    expect(livewireAlpine.start).not.toHaveBeenCalled();
   });
 });

--- a/tests/Vitest/alpine-init.test.js
+++ b/tests/Vitest/alpine-init.test.js
@@ -107,30 +107,24 @@ describe('alpine-init', () => {
             expect(livewireAlpine.start).not.toHaveBeenCalled();
         });
 
-        it('registriert Plugins auf Livewires Alpine, nicht auf dem App-Modul', () => {
+        it('registriert im Livewire-Modus keine Plugins aus dem App-Bundle', () => {
             const focus = vi.fn();
 
             initAlpine(mockAlpineModule, [focus]);
 
-            // Plugin wird auf Livewires Alpine registriert
-            expect(livewireAlpine.plugin).toHaveBeenCalledWith(focus);
-            expect(livewireAlpine.plugin).toHaveBeenCalledTimes(1);
-
-            // NICHT auf dem App-Modul
+            expect(livewireAlpine.plugin).not.toHaveBeenCalled();
             expect(mockAlpineModule.plugin).not.toHaveBeenCalled();
         });
 
-        it('registriert mehrere Plugins auf Livewires Alpine', () => {
+        it('registriert auch bei mehreren Plugins nichts nach', () => {
             const focus = vi.fn();
             const persist = vi.fn();
             const collapse = vi.fn();
 
             initAlpine(mockAlpineModule, [focus, persist, collapse]);
 
-            expect(livewireAlpine.plugin).toHaveBeenCalledTimes(3);
-            expect(livewireAlpine.plugin).toHaveBeenCalledWith(focus);
-            expect(livewireAlpine.plugin).toHaveBeenCalledWith(persist);
-            expect(livewireAlpine.plugin).toHaveBeenCalledWith(collapse);
+            expect(livewireAlpine.plugin).not.toHaveBeenCalled();
+            expect(mockAlpineModule.plugin).not.toHaveBeenCalled();
         });
     });
 
@@ -200,16 +194,17 @@ describe('alpine-init', () => {
             expect(callOrder).toEqual(['A', 'B', 'C']);
         });
 
-        it('Plugins-Reihenfolge bleibt im Livewire-Modus erhalten', () => {
-            const callOrder = [];
-            const pluginA = () => callOrder.push('A');
-            const pluginB = () => callOrder.push('B');
+        it('führt Plugin-Funktionen im Livewire-Modus nicht aus', () => {
+            const pluginA = vi.fn();
+            const pluginB = vi.fn();
 
-            window.Alpine = { plugin: vi.fn((fn) => fn()) };
+            window.Alpine = { plugin: vi.fn() };
 
             initAlpine(mockAlpineModule, [pluginA, pluginB]);
 
-            expect(callOrder).toEqual(['A', 'B']);
+            expect(pluginA).not.toHaveBeenCalled();
+            expect(pluginB).not.toHaveBeenCalled();
+            expect(window.Alpine.plugin).not.toHaveBeenCalled();
         });
     });
 
@@ -244,6 +239,21 @@ describe('alpine-init', () => {
             // Weder Livewires Alpine noch das App-Modul dürfen start() aufrufen
             expect(window.Alpine.start).not.toHaveBeenCalled();
             expect(mockAlpineModule.start).not.toHaveBeenCalled();
+        });
+
+        it('verhindert doppelte Persist-Registrierung auf Livewire-Alpine', () => {
+            const persistPlugin = vi.fn();
+
+            window.Alpine = {
+                plugin: vi.fn(() => {
+                    throw new TypeError('Cannot redefine property: $persist');
+                }),
+                start: vi.fn(),
+                persist: vi.fn(),
+            };
+
+            expect(() => initAlpine(mockAlpineModule, [persistPlugin])).not.toThrow();
+            expect(window.Alpine.plugin).not.toHaveBeenCalled();
         });
 
         it('prüft nicht _x_dataStack als Guard (alter fehlerhafter Guard)', () => {
@@ -312,13 +322,14 @@ describe('alpine-init', () => {
             expect(window.Alpine).toBe(mockAlpineModule);
         });
 
-        it('registriert Plugins im Livewire-Modus nur wenn plugin eine Funktion ist', () => {
+        it('ignoriert Plugins im Livewire-Modus auch wenn plugin eine Funktion ist', () => {
             const pluginFn = vi.fn();
             window.Alpine = { plugin: vi.fn() };
 
             initAlpine(mockAlpineModule, [pluginFn]);
 
-            expect(window.Alpine.plugin).toHaveBeenCalledWith(pluginFn);
+            expect(window.Alpine.plugin).not.toHaveBeenCalled();
+            expect(pluginFn).not.toHaveBeenCalled();
         });
 
         it('überspringt Plugins im Livewire-Modus wenn plugin keine Funktion ist', () => {
@@ -395,11 +406,11 @@ describe('scheduleInitAlpine', () => {
             });
         });
 
-        it('registriert Plugins sofort wenn Livewire-Alpine bereits vorhanden (Short-Circuit)', () => {
+        it('registriert bei vorhandenem Livewire-Alpine keine App-Bundle-Plugins nach (Short-Circuit)', () => {
             // Szenario: Livewires reguläres Script wurde bereits synchron ausgeführt
             // und hat window.Alpine gesetzt, aber DOM ist noch am Laden.
-            // Plugins müssen sofort registriert werden, damit sie wirksam sind
-            // bevor Livewire Alpine.start() bei DOMContentLoaded aufruft.
+            // App-Bundle-Plugins dürfen auf Livewires Alpine NICHT erneut
+            // registriert werden.
             Object.defineProperty(document, 'readyState', {
                 value: 'loading',
                 writable: true,
@@ -417,8 +428,8 @@ describe('scheduleInitAlpine', () => {
             const focus = vi.fn();
             scheduleInitAlpine(mockAlpineModule, [focus]);
 
-            // Plugin wurde SOFORT auf Livewires Alpine registriert
-            expect(livewireAlpine.plugin).toHaveBeenCalledWith(focus);
+            expect(livewireAlpine.plugin).not.toHaveBeenCalled();
+            expect(focus).not.toHaveBeenCalled();
 
             // window.Alpine wurde NICHT überschrieben
             expect(window.Alpine).toBe(livewireAlpine);
@@ -495,7 +506,7 @@ describe('scheduleInitAlpine', () => {
             });
         });
 
-        it('erkennt Livewires Alpine wenn DOMContentLoaded feuert', () => {
+        it('erkennt Livewires Alpine wenn DOMContentLoaded feuert und registriert nichts nach', () => {
             Object.defineProperty(document, 'readyState', {
                 value: 'loading',
                 writable: true,
@@ -521,8 +532,8 @@ describe('scheduleInitAlpine', () => {
             expect(window.Alpine).toBe(livewireAlpine);
             expect(window.Alpine).not.toBe(mockAlpineModule);
 
-            // Plugin wurde auf Livewires Alpine registriert
-            expect(livewireAlpine.plugin).toHaveBeenCalledWith(focus);
+            expect(livewireAlpine.plugin).not.toHaveBeenCalled();
+            expect(focus).not.toHaveBeenCalled();
 
             // Kein start() auf dem App-Modul
             expect(mockAlpineModule.start).not.toHaveBeenCalled();
@@ -568,7 +579,7 @@ describe('scheduleInitAlpine', () => {
             expect(mockAlpineModule.start).toHaveBeenCalledTimes(1);
         });
 
-        it('erkennt vorhandenes Livewire-Alpine sofort', () => {
+        it('erkennt vorhandenes Livewire-Alpine sofort ohne Plugin-Nachregistrierung', () => {
             const livewireAlpine = { plugin: vi.fn(), __fromLivewire: true };
             window.Alpine = livewireAlpine;
 
@@ -582,7 +593,8 @@ describe('scheduleInitAlpine', () => {
             scheduleInitAlpine(mockAlpineModule, [focus]);
 
             expect(window.Alpine).toBe(livewireAlpine);
-            expect(livewireAlpine.plugin).toHaveBeenCalledWith(focus);
+            expect(livewireAlpine.plugin).not.toHaveBeenCalled();
+            expect(focus).not.toHaveBeenCalled();
             expect(mockAlpineModule.start).not.toHaveBeenCalled();
         });
     });

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -67,8 +67,10 @@ describe('charEditor – Registrierung', () => {
 
         window.Alpine = lateAlpine;
         document.dispatchEvent(new CustomEvent('alpine:init'));
+        document.dispatchEvent(new CustomEvent('alpine:init'));
 
         expect(lateAlpine.data).toHaveBeenCalledWith('charEditor', expect.any(Function));
+        expect(lateAlpine.data).toHaveBeenCalledTimes(1);
         expect(editorFactory).toBeTypeOf('function');
         expect(lateAlpine.initTree).not.toHaveBeenCalled();
     });

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -1,9 +1,8 @@
 /**
  * Tests für die Char-Editor Alpine-Komponente.
  *
- * char-editor.js registriert Alpine.data() im 'alpine:init'-Event.
- * Wir mocken window.Alpine.data() und dispatchen das Event nach dem Import,
- * um die Factory-Funktion abzufangen.
+ * char-editor.js registriert Alpine.data() sofort, wenn window.Alpine bereits
+ * verfügbar ist. Andernfalls wartet das Modul auf 'alpine:init'.
  */
 
 let editorFactory;
@@ -16,14 +15,14 @@ beforeEach(async () => {
                 editorFactory = factory;
             }
         }),
+        initTree: vi.fn(),
     };
+
+    document.body.innerHTML = '<form x-data="charEditor"></form>';
 
     // Modul-Cache leeren und neu importieren
     vi.resetModules();
     await import('@/alpine/char-editor.js');
-
-    // alpine:init Event dispatchen, damit Alpine.data() aufgerufen wird
-    document.dispatchEvent(new CustomEvent('alpine:init'));
 });
 
 function createEditor(overrides = {}) {
@@ -33,6 +32,55 @@ function createEditor(overrides = {}) {
     instance.$watch = vi.fn();
     return instance;
 }
+
+describe('charEditor – Registrierung', () => {
+    it('registriert die Komponente sofort wenn Alpine bereits verfügbar ist', () => {
+        expect(window.Alpine.data).toHaveBeenCalledWith('charEditor', expect.any(Function));
+        expect(editorFactory).toBeTypeOf('function');
+        expect(window.Alpine.initTree).toHaveBeenCalledWith(document.querySelector('[x-data="charEditor"]'));
+    });
+
+    it('registriert die Komponente über alpine:init wenn Alpine erst später verfügbar ist', async () => {
+        vi.resetModules();
+        editorFactory = undefined;
+        delete window.Alpine;
+
+        const lateAlpine = {
+            data: vi.fn((name, factory) => {
+                if (name === 'charEditor') {
+                    editorFactory = factory;
+                }
+            }),
+            initTree: vi.fn(),
+        };
+
+        await import('@/alpine/char-editor.js');
+
+        expect(editorFactory).toBeUndefined();
+
+        window.Alpine = lateAlpine;
+        document.dispatchEvent(new CustomEvent('alpine:init'));
+
+        expect(lateAlpine.data).toHaveBeenCalledWith('charEditor', expect.any(Function));
+        expect(editorFactory).toBeTypeOf('function');
+        expect(lateAlpine.initTree).not.toHaveBeenCalled();
+    });
+
+    it('initialisiert bereits hydratisierte charEditor-Wurzeln nicht erneut', async () => {
+        vi.resetModules();
+
+        const existingRoot = document.querySelector('[x-data="charEditor"]');
+        existingRoot._x_dataStack = [{}];
+
+        window.Alpine.data.mockClear();
+        window.Alpine.initTree.mockClear();
+
+        await import('@/alpine/char-editor.js');
+
+        expect(window.Alpine.data).toHaveBeenCalledWith('charEditor', expect.any(Function));
+        expect(window.Alpine.initTree).not.toHaveBeenCalled();
+    });
+});
 
 describe('charEditor – Attribut-Clamping', () => {
     it('begrenzt Attribut auf attributeMax (Nicht-Barbar)', () => {

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -16,6 +16,12 @@ beforeEach(async () => {
             }
         }),
         initTree: vi.fn(),
+        destroyTree: vi.fn(),
+        $data: vi.fn(() => ({
+            basicsFilled: vi.fn(),
+            formValid: vi.fn(),
+            advancedUnlocked: false,
+        })),
     };
 
     document.body.innerHTML = '<form x-data="charEditor"></form>';
@@ -38,6 +44,7 @@ describe('charEditor – Registrierung', () => {
         expect(window.Alpine.data).toHaveBeenCalledWith('charEditor', expect.any(Function));
         expect(editorFactory).toBeTypeOf('function');
         expect(window.Alpine.initTree).toHaveBeenCalledWith(document.querySelector('[x-data="charEditor"]'));
+        expect(window.Alpine.destroyTree).not.toHaveBeenCalled();
     });
 
     it('registriert die Komponente über alpine:init wenn Alpine erst später verfügbar ist', async () => {
@@ -79,6 +86,25 @@ describe('charEditor – Registrierung', () => {
 
         expect(window.Alpine.data).toHaveBeenCalledWith('charEditor', expect.any(Function));
         expect(window.Alpine.initTree).not.toHaveBeenCalled();
+        expect(window.Alpine.destroyTree).not.toHaveBeenCalled();
+    });
+
+    it('reinitialisiert bereits gestartete Wurzeln mit unvollständigem Scope', async () => {
+        vi.resetModules();
+
+        const existingRoot = document.querySelector('[x-data="charEditor"]');
+        existingRoot._x_dataStack = [{}];
+
+        window.Alpine.data.mockClear();
+        window.Alpine.initTree.mockClear();
+        window.Alpine.destroyTree.mockClear();
+        window.Alpine.$data.mockReturnValueOnce({ playerName: 'alt' });
+
+        await import('@/alpine/char-editor.js');
+
+        expect(window.Alpine.data).toHaveBeenCalledWith('charEditor', expect.any(Function));
+        expect(window.Alpine.destroyTree).toHaveBeenCalledWith(existingRoot);
+        expect(window.Alpine.initTree).toHaveBeenCalledWith(existingRoot);
     });
 });
 
@@ -274,7 +300,7 @@ describe('charEditor – Computed Properties', () => {
             race: 'Barbar',
             culture: 'Landbewohner',
         });
-        expect(e.basicsFilled).toBeTruthy();
+        expect(e.basicsFilled()).toBeTruthy();
     });
 
     it('basicsFilled false wenn Angabe fehlt', () => {
@@ -284,13 +310,13 @@ describe('charEditor – Computed Properties', () => {
             race: 'Barbar',
             culture: 'Landbewohner',
         });
-        expect(e.basicsFilled).toBeFalsy();
+        expect(e.basicsFilled()).toBeFalsy();
     });
 
     it('apUsed zählt nur positive Attributwerte', () => {
         const e = createEditor();
         e.attributes = { st: 1, ge: -1, ro: 0, wi: 1, wa: 0, in: 0, au: 0 };
-        expect(e.apUsed).toBe(2); // 1 + 0 + 0 + 1 + 0 + 0 + 0
+        expect(e.apUsed()).toBe(2); // 1 + 0 + 0 + 1 + 0 + 0 + 0
     });
 
     it('fpUsed ignoriert exact-Grants', () => {
@@ -300,6 +326,6 @@ describe('charEditor – Computed Properties', () => {
             { name: 'FixSkill', value: 3 },
             { name: 'Frei', value: 2 },
         ];
-        expect(e.fpUsed).toBe(2);
+        expect(e.fpUsed()).toBe(2);
     });
 });

--- a/tests/Vitest/playwright-node-utils.test.js
+++ b/tests/Vitest/playwright-node-utils.test.js
@@ -73,7 +73,7 @@ describe('playwright docker harness', () => {
         expect(isDirectExecution('tests/e2e/other-script.mjs')).toBe(false);
     });
 
-    it('startet main ohne childEnv-Scope-Fehler und merged die Env korrekt', async () => {
+    it('baut vor Docker-Playwright standardmaessig die Vite-Assets', async () => {
         const cleanupManagedDockerPortFn = vi.fn();
         const spawnFn = vi.fn(() => {
             const handlers = new Map();
@@ -101,8 +101,12 @@ describe('playwright docker harness', () => {
         });
 
         expect(exitCode).toBe(0);
-        expect(spawnFn).toHaveBeenCalledTimes(1);
-        expect(spawnFn.mock.calls[0][2].env).toMatchObject({
+        expect(spawnFn).toHaveBeenCalledTimes(2);
+        expect(spawnFn.mock.calls[0][1]).toEqual([
+            expect.stringMatching(/node_modules[\\/]vite[\\/]bin[\\/]vite\.js$/),
+            'build',
+        ]);
+        expect(spawnFn.mock.calls[1][2].env).toMatchObject({
             PLAYWRIGHT_USE_DOCKER: '1',
             PLAYWRIGHT_RUN_TOKEN: 'provided-token',
             PLAYWRIGHT_PORT: '8100',
@@ -110,6 +114,44 @@ describe('playwright docker harness', () => {
         expect(cleanupManagedDockerPortFn).toHaveBeenCalledTimes(2);
         expect(cleanupManagedDockerPortFn).toHaveBeenNthCalledWith(1, 8100);
         expect(cleanupManagedDockerPortFn).toHaveBeenNthCalledWith(2, 8100);
+    });
+
+    it('ueberspringt den Vite-Build wenn Hotfile explizit aktiviert ist', async () => {
+        const cleanupManagedDockerPortFn = vi.fn();
+        const spawnFn = vi.fn(() => {
+            const handlers = new Map();
+
+            queueMicrotask(() => {
+                handlers.get('exit')?.(0);
+            });
+
+            return {
+                on(event, handler) {
+                    handlers.set(event, handler);
+                    return this;
+                },
+            };
+        });
+
+        const exitCode = await main({
+            argv: ['tests/e2e/homepage-performance.spec.js', '--project=webkit'],
+            env: {
+                PLAYWRIGHT_RUN_TOKEN: 'provided-token',
+                PLAYWRIGHT_PORT: '8100',
+                PLAYWRIGHT_USE_VITE_HOT: '1',
+            },
+            spawnFn,
+            cleanupManagedDockerPortFn,
+        });
+
+        expect(exitCode).toBe(0);
+        expect(spawnFn).toHaveBeenCalledTimes(1);
+        expect(spawnFn.mock.calls[0][1]).toEqual([
+            expect.stringMatching(/node_modules[\\/]playwright[\\/]cli\.js$/),
+            'test',
+            'tests/e2e/homepage-performance.spec.js',
+            '--project=webkit',
+        ]);
     });
 });
 
@@ -127,11 +169,22 @@ describe('playwright config smoke import', () => {
 
     it('laedt die Config und setzt einen konsistenten Run-Token', async () => {
         delete process.env.PLAYWRIGHT_RUN_TOKEN;
+        delete process.env.PLAYWRIGHT_USE_VITE_HOT;
         vi.resetModules();
 
         const { default: config } = await import('../../playwright.config.js');
 
         expect(process.env.PLAYWRIGHT_RUN_TOKEN).toMatch(/^local-/);
         expect(config.webServer.env.PLAYWRIGHT_RUN_TOKEN).toBe(process.env.PLAYWRIGHT_RUN_TOKEN);
+        expect(config.webServer.env.PLAYWRIGHT_USE_VITE_HOT).toBe('0');
+    });
+
+    it('reicht PLAYWRIGHT_USE_VITE_HOT explizit an den Webserver weiter', async () => {
+        process.env.PLAYWRIGHT_USE_VITE_HOT = '1';
+        vi.resetModules();
+
+        const { default: config } = await import('../../playwright.config.js');
+
+        expect(config.webServer.env.PLAYWRIGHT_USE_VITE_HOT).toBe('1');
     });
 });

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -1,0 +1,52 @@
+import { expect, test } from './test-support.js';
+
+const login = async (page, email, password = 'password') => {
+    await page.goto('/login');
+    await page.fill('input[name="email"]', email);
+    await page.fill('input[name="password"]', password);
+    await page.click('button[type="submit"]');
+    await page.waitForURL((url) => !url.pathname.endsWith('/login'));
+};
+
+test.describe('RPG Charakter-Editor', () => {
+    test('lädt ohne Persist-Fehler und sperrt den Formularfluss initial korrekt', async ({ page }) => {
+        test.setTimeout(60_000);
+
+        const consoleErrors = [];
+        const pageErrors = [];
+
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') {
+                consoleErrors.push(msg.text());
+            }
+        });
+
+        page.on('pageerror', (error) => {
+            pageErrors.push(error.message);
+        });
+
+        await login(page, 'info@maddraxikon.com');
+        await page.goto('/rpg/char-editor');
+        await page.waitForLoadState('networkidle');
+
+        await expect(page.getByTestId('page-header')).toContainText('Charakter-Editor');
+        await expect(page.getByTestId('char-editor-form')).toBeVisible();
+
+        const continueButton = page.getByTestId('char-editor-continue-button');
+        const portraitPreview = page.getByTestId('char-editor-portrait-preview');
+        await expect(continueButton).toBeHidden();
+        await expect(portraitPreview).toBeHidden();
+
+        await page.getByLabel('Spielername').fill('Playwright Spieler');
+        await page.getByLabel('Charaktername').fill('Wudan');
+        await page.locator('#race').selectOption('Barbar');
+        await page.locator('#culture').selectOption('Landbewohner');
+
+        await expect(continueButton).toBeVisible();
+        await expect(continueButton).toBeEnabled();
+        await expect(portraitPreview).toBeHidden();
+
+        expect(pageErrors).toEqual([]);
+        expect(consoleErrors.filter((message) => /\$persist|Cannot redefine property: \$persist/i.test(message))).toEqual([]);
+    });
+});

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -27,7 +27,6 @@ test.describe('RPG Charakter-Editor', () => {
 
         await login(page, 'info@maddraxikon.com');
         await page.goto('/rpg/char-editor');
-        await page.waitForLoadState('networkidle');
 
         await expect(page.getByTestId('page-header')).toContainText('Charakter-Editor');
         await expect(page.getByTestId('char-editor-form')).toBeVisible();

--- a/tests/e2e/run-playwright-docker.mjs
+++ b/tests/e2e/run-playwright-docker.mjs
@@ -5,6 +5,7 @@ import { cleanupManagedDockerPort } from './utils/docker.js';
 import { resolvePlaywrightRunToken } from './utils/playwright-run-token.js';
 
 const playwrightCli = path.resolve('node_modules/playwright/cli.js');
+const viteCli = path.resolve('node_modules/vite/bin/vite.js');
 const shouldHideWindowsShell = process.platform === 'win32';
 
 function createChildEnv(env, forwardedScreenshotFlag) {
@@ -63,6 +64,22 @@ const runPlaywright = (args, baseEnv, envOverrides = {}, { spawnFn = spawn } = {
     });
 });
 
+const runViteBuild = (baseEnv, { spawnFn = spawn } = {}) => new Promise((resolve, reject) => {
+    const child = spawnFn(process.execPath, [viteCli, 'build'], {
+        stdio: 'inherit',
+        windowsHide: shouldHideWindowsShell,
+        env: baseEnv,
+    });
+
+    child.on('exit', (code) => {
+        resolve(code ?? 1);
+    });
+
+    child.on('error', (error) => {
+        reject(error);
+    });
+});
+
 export async function main({
     argv = process.argv.slice(2),
     env = process.env,
@@ -78,6 +95,16 @@ export async function main({
         : env.PLAYWRIGHT_CAPTURE_MODAL_SCREENSHOTS ?? null;
     const basePort = Number(env.PLAYWRIGHT_PORT ?? 8001);
     const childEnv = createChildEnv(env, forwardedScreenshotFlag);
+    const shouldUseViteHot = childEnv.PLAYWRIGHT_USE_VITE_HOT === '1';
+
+    if (!shouldUseViteHot) {
+        const buildCode = await runViteBuild(childEnv, { spawnFn });
+
+        if (buildCode !== 0) {
+            return buildCode;
+        }
+    }
+
     const projectRuns = createProjectRuns({
         args: playwrightArgs,
         env: childEnv,

--- a/tests/e2e/start-playwright-webserver.sh
+++ b/tests/e2e/start-playwright-webserver.sh
@@ -14,7 +14,11 @@ trap cleanup EXIT INT TERM
 mkdir -p storage/app/public storage/framework/cache storage/framework/sessions storage/framework/testing storage/framework/views storage/logs bootstrap/cache
 touch storage/logs/laravel.log
 
-printf '%s' "${VITE_DEV_SERVER_URL:-http://localhost:${VITE_PORT:-5173}}" > /var/www/html/public/playwright.hot
+if [ "${PLAYWRIGHT_USE_VITE_HOT:-0}" = "1" ]; then
+    printf '%s' "${VITE_DEV_SERVER_URL:-http://localhost:${VITE_PORT:-5173}}" > /var/www/html/public/playwright.hot
+else
+    rm -f /var/www/html/public/playwright.hot
+fi
 
 RUN_TOKEN="${PLAYWRIGHT_RUN_TOKEN:-local-default}"
 READY_FILE="/var/www/html/storage/framework/testing/playwright-ready-${RUN_TOKEN}.flag"


### PR DESCRIPTION
This pull request refactors and improves the Alpine.js character editor integration, making the component more robust and compatible with Livewire and Alpine plugin handling. It replaces Alpine computed properties with methods for better compatibility, ensures proper hydration of existing editors, and updates the Blade template to use the new method-based API. There are also minor improvements to test and environment configuration.

**Alpine.js Character Editor Refactor and Integration:**

* Refactored `charEditor` Alpine component to use methods instead of computed properties, improving compatibility and ensuring correct reactivity. All usages in the Blade template were updated to call these methods (e.g., `basicsFilled()` instead of `basicsFilled`). [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L46-R93) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L72-R131) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L117-R155) [[4]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L156-R187) [[5]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L213-R244) [[6]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L257-R292) [[7]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L293-R324) [[8]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L399-R447) [[9]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L11-R14) [[10]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L47-R47) [[11]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L56-R75) [[12]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L119-R119) [[13]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L196-R197)
* Added a `hydrateExistingCharEditors` function and registration logic to ensure that existing editors are properly initialized or re-initialized when Alpine is already loaded (e.g., with Livewire). [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L13-R44) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L399-R447)
* Updated the initialization logic in `alpine-init.js` to avoid double-registering plugins when Alpine is already present (especially with Livewire), preventing conflicts like `$persist -> Cannot redefine property`. [[1]](diffhunk://#diff-4365dd331d8fcfe96dcc48c41baacfab3aeddb036c1facfb99607432cca3c728L18-R21) [[2]](diffhunk://#diff-4365dd331d8fcfe96dcc48c41baacfab3aeddb036c1facfb99607432cca3c728L58-R57)
* Moved `char-editor` import in `app.js` to run before Alpine initialization, ensuring the component is registered in all scenarios. [[1]](diffhunk://#diff-583a1f586bc298813341bce6fec77a1f6338f2559471fe600f15a18316fe82bdR13) [[2]](diffhunk://#diff-583a1f586bc298813341bce6fec77a1f6338f2559471fe600f15a18316fe82bdL92)

**Blade Template and Test Adjustments:**

* Updated `char-editor.blade.php` to use the new method-based API and improved testability with `x-cloak` and `data-testid` attributes for key UI elements. [[1]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L11-R14) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L47-R47) [[3]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L56-R75) [[4]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L119-R119) [[5]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2L196-R197)
* Fixed logic for skipping Vite assets in Blade layouts during minimal test layouts, and updated the corresponding test to match the new logic. [[1]](diffhunk://#diff-8dca921fb3d5ff3fe471f79b2c86a1389b3e6136c5b76376e367bd8646a47243L22-R22) [[2]](diffhunk://#diff-66a3ba2334a6e1eebc24807619f1d4e991f1e8f58c5b5af2c787198d62c547d7L35-R35) [[3]](diffhunk://#diff-2a5e3901e4905ccc986dc083771d20b3066071284e46a296000da32baf0f7a3aL71-R74)

**Environment/Config Improvements:**

* Added `PLAYWRIGHT_USE_VITE_HOT` environment variable to `playwright.config.js` for improved test configuration.