### PR TITLE
Chore: Workflow does not contain Permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/McNamara84/omxfc-vereinswebseite/security/code-scanning/1](https://github.com/McNamara84/omxfc-vereinswebseite/security/code-scanning/1)

Add an explicit `permissions` block to the workflow, ideally at the top level so it applies to all jobs by default.  
For this workflow, the minimal least-privilege baseline is:

- `contents: read`

This supports `actions/checkout` and typical read-only repository access during CI tests, without granting unnecessary write privileges.

**File to change:** `.github/workflows/playwright.yml`  
**Region to change:** near the top-level keys, after `on:` (or before `jobs:`), adding a new root-level `permissions:` block.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
