### PR TITLE
Feature: Profile Contact Fields and Show Workflow

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -6,6 +6,7 @@ use App\Enums\Role;
 use App\Mail\ProfileContactUpdated;
 use App\Models\Team;
 use App\Models\User;
+use Carbon\CarbonInterface;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
@@ -41,7 +42,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             'mitgliedsbeitrag' => ['required', 'numeric', 'min:12', 'max:120'],
             'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
             'alias' => ['nullable', 'string', 'max:255'],
-            'author_aliases' => ['nullable', 'array'],
+            'author_aliases' => ['nullable', 'array', 'max:10'],
             'author_aliases.*' => ['nullable', 'string', 'max:255'],
             'contact_release_email' => ['nullable', 'boolean'],
             'contact_release_phone' => ['nullable', 'boolean'],
@@ -100,8 +101,11 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             'nextcloud_username' => $updates['nextcloud_username'],
         ]);
 
+        $contactChangedAt = null;
+
         if ($changedContactLabels !== []) {
-            $updates['contact_released_at'] = now();
+            $contactChangedAt = now();
+            $updates['contact_released_at'] = $contactChangedAt;
         }
 
         if ($input['email'] !== $user->email && $user instanceof MustVerifyEmail) {
@@ -111,7 +115,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
         }
 
         if ($changedContactLabels !== []) {
-            $this->notifyBoardAboutContactUpdate($user->refresh(), $changedContactLabels);
+            $this->notifyBoardAboutContactUpdate($user->refresh(), $changedContactLabels, $contactChangedAt);
         }
     }
 
@@ -215,7 +219,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     /**
      * @param  array<int, string>  $changedContactLabels
      */
-    private function notifyBoardAboutContactUpdate(User $user, array $changedContactLabels): void
+    private function notifyBoardAboutContactUpdate(User $user, array $changedContactLabels, CarbonInterface $contactChangedAt): void
     {
         $team = Team::membersTeam();
 
@@ -248,6 +252,6 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             return;
         }
 
-        Mail::to($recipients)->queue(new ProfileContactUpdated($user, $changedContactLabels));
+        Mail::to($recipients)->queue(new ProfileContactUpdated($user, $changedContactLabels, $contactChangedAt));
     }
 }

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -24,6 +24,11 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
     public function update(User $user, array $input): void
     {
         $contactSnapshotBefore = $this->contactSnapshot($user);
+        $input = $this->normalizeNullableStringInputs($input, [
+            'telefon',
+            'maddraxikon_username',
+            'nextcloud_username',
+        ]);
 
         Validator::make($input, [
             'vorname' => ['required', 'string', 'max:255'],
@@ -143,6 +148,22 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
         $value = trim((string) $value);
 
         return $value === '' ? null : $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @param  array<int, string>  $keys
+     * @return array<string, mixed>
+     */
+    private function normalizeNullableStringInputs(array $input, array $keys): array
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $input) && is_string($input[$key])) {
+                $input[$key] = $this->nullableString($input[$key]);
+            }
+        }
+
+        return $input;
     }
 
     /**

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -2,8 +2,13 @@
 
 namespace App\Actions\Fortify;
 
+use App\Enums\Role;
+use App\Mail\ProfileContactUpdated;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
@@ -17,6 +22,8 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
      */
     public function update(User $user, array $input): void
     {
+        $contactSnapshotBefore = $this->contactSnapshot($user);
+
         Validator::make($input, [
             'vorname' => ['required', 'string', 'max:255'],
             'nachname' => ['required', 'string', 'max:255'],
@@ -25,10 +32,33 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             'plz' => ['required', 'string', 'max:10'],
             'stadt' => ['required', 'string', 'max:255'],
             'land' => ['required', Rule::in(['Deutschland', 'Österreich', 'Schweiz'])],
-            'telefon' => ['nullable', 'string', 'max:20'],
+            'telefon' => [
+                Rule::requiredIf(fn () => $this->booleanInput($input['contact_release_phone'] ?? false)),
+                'nullable',
+                'string',
+                'max:20',
+            ],
             'mitgliedsbeitrag' => ['required', 'numeric', 'min:12', 'max:120'],
             'email' => ['required', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
-            // Profilfoto: erlaubte Formate erweitern und maximale Größe erhöhen
+            'alias' => ['nullable', 'string', 'max:255'],
+            'author_aliases' => ['nullable', 'array'],
+            'author_aliases.*' => ['nullable', 'string', 'max:255'],
+            'contact_release_email' => ['nullable', 'boolean'],
+            'contact_release_phone' => ['nullable', 'boolean'],
+            'contact_release_maddraxikon' => ['nullable', 'boolean'],
+            'contact_release_nextcloud' => ['nullable', 'boolean'],
+            'maddraxikon_username' => [
+                Rule::requiredIf(fn () => $this->booleanInput($input['contact_release_maddraxikon'] ?? false)),
+                'nullable',
+                'string',
+                'max:255',
+            ],
+            'nextcloud_username' => [
+                Rule::requiredIf(fn () => $this->booleanInput($input['contact_release_nextcloud'] ?? false)),
+                'nullable',
+                'string',
+                'max:255',
+            ],
             'photo' => ['nullable', 'mimes:jpg,jpeg,png,gif,webp', 'max:8192'],
         ])->validateWithBag('updateProfileInformation');
 
@@ -44,23 +74,51 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             'plz' => $input['plz'],
             'stadt' => $input['stadt'],
             'land' => $input['land'],
-            'telefon' => $input['telefon'],
+            'telefon' => $this->nullableString($input['telefon'] ?? null),
             'mitgliedsbeitrag' => $input['mitgliedsbeitrag'],
             'email' => $input['email'],
+            'alias' => $this->nullableString($input['alias'] ?? null),
+            'author_aliases' => $user->hasRole(Role::Ehrenmitglied)
+                ? $this->cleanAuthorAliases($input['author_aliases'] ?? [])
+                : [],
+            'contact_release_email' => $this->booleanInput($input['contact_release_email'] ?? false),
+            'contact_release_phone' => $this->booleanInput($input['contact_release_phone'] ?? false),
+            'contact_release_maddraxikon' => $this->booleanInput($input['contact_release_maddraxikon'] ?? false),
+            'contact_release_nextcloud' => $this->booleanInput($input['contact_release_nextcloud'] ?? false),
+            'maddraxikon_username' => $this->nullableString($input['maddraxikon_username'] ?? null),
+            'nextcloud_username' => $this->nullableString($input['nextcloud_username'] ?? null),
         ];
 
-        // Prüfen, ob die Mail geändert wurde und Nutzer verifiziert werden muss
+        $changedContactLabels = $this->changedContactLabels($contactSnapshotBefore, [
+            'email' => (string) $updates['email'],
+            'telefon' => $updates['telefon'],
+            'contact_release_email' => $updates['contact_release_email'],
+            'contact_release_phone' => $updates['contact_release_phone'],
+            'contact_release_maddraxikon' => $updates['contact_release_maddraxikon'],
+            'contact_release_nextcloud' => $updates['contact_release_nextcloud'],
+            'maddraxikon_username' => $updates['maddraxikon_username'],
+            'nextcloud_username' => $updates['nextcloud_username'],
+        ]);
+
+        if ($changedContactLabels !== []) {
+            $updates['contact_released_at'] = now();
+        }
+
         if ($input['email'] !== $user->email && $user instanceof MustVerifyEmail) {
             $this->updateVerifiedUser($user, $updates);
         } else {
             $user->forceFill($updates)->save();
+        }
+
+        if ($changedContactLabels !== []) {
+            $this->notifyBoardAboutContactUpdate($user->refresh(), $changedContactLabels);
         }
     }
 
     /**
      * Update the given verified user's profile information.
      *
-     * @param  array<string, string>  $input
+     * @param  array<string, mixed>  $input
      */
     protected function updateVerifiedUser(User $user, array $input): void
     {
@@ -69,5 +127,127 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
         ]))->save();
 
         $user->sendEmailVerificationNotification();
+    }
+
+    private function booleanInput(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function cleanAuthorAliases(mixed $aliases): array
+    {
+        if (! is_array($aliases)) {
+            return [];
+        }
+
+        $cleaned = [];
+
+        foreach ($aliases as $alias) {
+            $alias = $this->nullableString($alias);
+
+            if ($alias !== null) {
+                $cleaned[] = $alias;
+            }
+        }
+
+        return array_values(array_unique($cleaned));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function contactSnapshot(User $user): array
+    {
+        return [
+            'email' => (string) $user->email,
+            'telefon' => $this->nullableString($user->telefon),
+            'contact_release_email' => (bool) $user->contact_release_email,
+            'contact_release_phone' => (bool) $user->contact_release_phone,
+            'contact_release_maddraxikon' => (bool) $user->contact_release_maddraxikon,
+            'contact_release_nextcloud' => (bool) $user->contact_release_nextcloud,
+            'maddraxikon_username' => $this->nullableString($user->maddraxikon_username),
+            'nextcloud_username' => $this->nullableString($user->nextcloud_username),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $before
+     * @param  array<string, mixed>  $after
+     * @return array<int, string>
+     */
+    private function changedContactLabels(array $before, array $after): array
+    {
+        $changed = [];
+
+        if ($before['contact_release_email'] !== $after['contact_release_email']
+            || (($before['contact_release_email'] || $after['contact_release_email']) && $before['email'] !== $after['email'])) {
+            $changed[] = 'E-Mail';
+        }
+
+        if ($before['contact_release_phone'] !== $after['contact_release_phone']
+            || (($before['contact_release_phone'] || $after['contact_release_phone']) && $before['telefon'] !== $after['telefon'])) {
+            $changed[] = 'Telefon';
+        }
+
+        if ($before['contact_release_maddraxikon'] !== $after['contact_release_maddraxikon']
+            || (($before['contact_release_maddraxikon'] || $after['contact_release_maddraxikon']) && $before['maddraxikon_username'] !== $after['maddraxikon_username'])) {
+            $changed[] = 'Maddraxikon';
+        }
+
+        if ($before['contact_release_nextcloud'] !== $after['contact_release_nextcloud']
+            || (($before['contact_release_nextcloud'] || $after['contact_release_nextcloud']) && $before['nextcloud_username'] !== $after['nextcloud_username'])) {
+            $changed[] = 'Nextcloud';
+        }
+
+        return array_values(array_unique($changed));
+    }
+
+    /**
+     * @param  array<int, string>  $changedContactLabels
+     */
+    private function notifyBoardAboutContactUpdate(User $user, array $changedContactLabels): void
+    {
+        $team = Team::membersTeam();
+
+        if (! $team) {
+            Log::warning('Profil-Kontaktaktualisierung ohne Mitglieder-Team.', [
+                'user_id' => $user->id,
+            ]);
+
+            return;
+        }
+
+        $recipients = $team->activeUsers()
+            ->wherePivotIn('role', [
+                Role::Admin->value,
+                Role::Vorstand->value,
+                Role::Kassenwart->value,
+            ])
+            ->whereNotNull('users.email')
+            ->pluck('users.email')
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        if ($recipients === []) {
+            Log::warning('Profil-Kontaktaktualisierung ohne Vorstand-Empfaenger.', [
+                'user_id' => $user->id,
+            ]);
+
+            return;
+        }
+
+        Mail::to($recipients)->queue(new ProfileContactUpdated($user, $changedContactLabels));
     }
 }

--- a/app/Livewire/Profile/UpdateProfileInformationForm.php
+++ b/app/Livewire/Profile/UpdateProfileInformationForm.php
@@ -45,7 +45,24 @@ class UpdateProfileInformationForm extends Component
             'land',
             'telefon',
             'mitgliedsbeitrag',
+            'alias',
+            'author_aliases',
+            'contact_release_email',
+            'contact_release_phone',
+            'contact_release_maddraxikon',
+            'contact_release_nextcloud',
+            'maddraxikon_username',
+            'nextcloud_username',
         ]);
+
+        $this->state['alias'] = $this->state['alias'] ?? '';
+        $this->state['author_aliases'] = $this->state['author_aliases'] ?: [''];
+        $this->state['contact_release_email'] = (bool) ($this->state['contact_release_email'] ?? false);
+        $this->state['contact_release_phone'] = (bool) ($this->state['contact_release_phone'] ?? false);
+        $this->state['contact_release_maddraxikon'] = (bool) ($this->state['contact_release_maddraxikon'] ?? false);
+        $this->state['contact_release_nextcloud'] = (bool) ($this->state['contact_release_nextcloud'] ?? false);
+        $this->state['maddraxikon_username'] = $this->state['maddraxikon_username'] ?? '';
+        $this->state['nextcloud_username'] = $this->state['nextcloud_username'] ?? '';
     }
 
     /**
@@ -88,6 +105,35 @@ class UpdateProfileInformationForm extends Component
         auth()->user()->deleteProfilePhoto();
 
         $this->dispatch('refresh-navigation-menu');
+    }
+
+    public function addAuthorAlias(): void
+    {
+        $aliases = $this->state['author_aliases'] ?? [];
+
+        if (! is_array($aliases)) {
+            $aliases = [];
+        }
+
+        if (count($aliases) >= 10) {
+            return;
+        }
+
+        $aliases[] = '';
+        $this->state['author_aliases'] = $aliases;
+    }
+
+    public function removeAuthorAlias(int $index): void
+    {
+        $aliases = $this->state['author_aliases'] ?? [];
+
+        if (! is_array($aliases) || ! array_key_exists($index, $aliases)) {
+            return;
+        }
+
+        unset($aliases[$index]);
+
+        $this->state['author_aliases'] = array_values($aliases) ?: [''];
     }
 
     /**

--- a/app/Livewire/RomantauschBundleForm.php
+++ b/app/Livewire/RomantauschBundleForm.php
@@ -8,10 +8,12 @@ use App\Models\BookOffer;
 use App\Services\Romantausch\BookPhotoService;
 use App\Services\Romantausch\BundleService;
 use App\Support\ConditionOptions;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
 
 class RomantauschBundleForm extends Component
@@ -29,7 +31,7 @@ class RomantauschBundleForm extends Component
 
     public ?string $condition_max = null;
 
-    /** @var array<\Livewire\Features\SupportFileUploads\TemporaryUploadedFile> */
+    /** @var array<TemporaryUploadedFile> */
     public $photos = [];
 
     /** @var array<string> */
@@ -214,7 +216,7 @@ class RomantauschBundleForm extends Component
             if (! empty($this->photos)) {
                 try {
                     $newPhotoPaths = $photoService->uploadPhotos(
-                        array_filter($this->photos, fn ($p) => $p instanceof \Illuminate\Http\UploadedFile),
+                        array_filter($this->photos, fn ($p) => $p instanceof UploadedFile),
                     );
                 } catch (\RuntimeException $e) {
                     $this->addError('photos', 'Foto-Upload fehlgeschlagen.');
@@ -240,13 +242,13 @@ class RomantauschBundleForm extends Component
                 return;
             }
 
-            session()->flash('success', 'Stapel-Angebot aktualisiert.');
+            $successMessage = 'Stapel-Angebot aktualisiert.';
         } else {
             $photoPaths = [];
             if (! empty($this->photos)) {
                 try {
                     $photoPaths = $photoService->uploadPhotos(
-                        array_filter($this->photos, fn ($p) => $p instanceof \Illuminate\Http\UploadedFile),
+                        array_filter($this->photos, fn ($p) => $p instanceof UploadedFile),
                     );
                 } catch (\RuntimeException $e) {
                     $this->addError('photos', 'Foto-Upload fehlgeschlagen. Bitte versuche es erneut.');
@@ -270,9 +272,10 @@ class RomantauschBundleForm extends Component
                 return;
             }
 
-            session()->flash('success', 'Stapel-Angebot mit '.count($result['offers']).' Romanen erstellt.');
+            $successMessage = 'Stapel-Angebot mit '.count($result['offers']).' Romanen erstellt.';
         }
 
+        session()->put('romantausch.success', $successMessage);
         $this->redirect(route('romantausch.index'));
     }
 
@@ -295,7 +298,7 @@ class RomantauschBundleForm extends Component
         $bundleService = app(BundleService::class);
         $bundleService->deleteBundle($this->bundleId, Auth::id());
 
-        session()->flash('success', 'Stapel-Angebot gelöscht.');
+        session()->put('romantausch.success', 'Stapel-Angebot gelöscht.');
         $this->redirect(route('romantausch.index'));
     }
 

--- a/app/Livewire/RomantauschOfferForm.php
+++ b/app/Livewire/RomantauschOfferForm.php
@@ -10,13 +10,15 @@ use App\Services\Romantausch\BookPhotoService;
 use App\Services\Romantausch\RomantauschBaxxService;
 use App\Services\Romantausch\SwapMatchingService;
 use App\Support\ConditionOptions;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use LogicException;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
+use LogicException;
 
 class RomantauschOfferForm extends Component
 {
@@ -31,7 +33,7 @@ class RomantauschOfferForm extends Component
 
     public string $condition = 'Z0';
 
-    /** @var array<\Livewire\Features\SupportFileUploads\TemporaryUploadedFile> */
+    /** @var array<TemporaryUploadedFile> */
     public $photos = [];
 
     /** @var array<string> */
@@ -180,7 +182,7 @@ class RomantauschOfferForm extends Component
             if (! empty($this->photos)) {
                 try {
                     $newPhotoPaths = $photoService->uploadPhotos(
-                        array_filter($this->photos, fn ($p) => $p instanceof \Illuminate\Http\UploadedFile),
+                        array_filter($this->photos, fn ($p) => $p instanceof UploadedFile),
                     );
                 } catch (\RuntimeException $e) {
                     $this->addError('photos', 'Foto-Upload fehlgeschlagen. Bitte versuche es erneut.');
@@ -206,7 +208,7 @@ class RomantauschOfferForm extends Component
             if (! empty($this->photos)) {
                 try {
                     $photoPaths = $photoService->uploadPhotos(
-                        array_filter($this->photos, fn ($p) => $p instanceof \Illuminate\Http\UploadedFile),
+                        array_filter($this->photos, fn ($p) => $p instanceof UploadedFile),
                     );
                 } catch (\RuntimeException $e) {
                     $this->addError('photos', 'Foto-Upload fehlgeschlagen. Bitte versuche es erneut.');
@@ -251,7 +253,7 @@ class RomantauschOfferForm extends Component
             $matchingService->matchSwap($offer, 'offer');
         }
 
-        session()->flash('success', $this->isEditing ? 'Angebot aktualisiert.' : 'Angebot erstellt.');
+        session()->put('romantausch.success', $this->isEditing ? 'Angebot aktualisiert.' : 'Angebot erstellt.');
         $this->redirect(route('romantausch.index'));
     }
 

--- a/app/Livewire/RomantauschRequestForm.php
+++ b/app/Livewire/RomantauschRequestForm.php
@@ -12,10 +12,10 @@ use App\Support\ConditionOptions;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
-use LogicException;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
+use LogicException;
 
 class RomantauschRequestForm extends Component
 {
@@ -167,7 +167,7 @@ class RomantauschRequestForm extends Component
             $matchingService->matchSwap($bookRequest, 'request');
         }
 
-        session()->flash('success', $this->isEditing ? 'Gesuch aktualisiert.' : 'Gesuch erstellt.');
+        session()->put('romantausch.success', $this->isEditing ? 'Gesuch aktualisiert.' : 'Gesuch erstellt.');
         $this->redirect(route('romantausch.index'));
     }
 

--- a/app/Mail/ProfileContactUpdated.php
+++ b/app/Mail/ProfileContactUpdated.php
@@ -3,6 +3,7 @@
 namespace App\Mail;
 
 use App\Models\User;
+use Carbon\CarbonInterface;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
@@ -10,6 +11,7 @@ use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
 
 class ProfileContactUpdated extends Mailable implements ShouldQueue
 {
@@ -18,10 +20,15 @@ class ProfileContactUpdated extends Mailable implements ShouldQueue
     /**
      * @param  array<int, string>  $changedContactLabels
      */
+    public Carbon $contactChangedAt;
+
     public function __construct(
         public User $user,
         public array $changedContactLabels,
-    ) {}
+        CarbonInterface|string|null $contactChangedAt = null,
+    ) {
+        $this->contactChangedAt = Carbon::parse($contactChangedAt ?? $user->contact_released_at ?? now());
+    }
 
     public function envelope(): Envelope
     {
@@ -37,6 +44,7 @@ class ProfileContactUpdated extends Mailable implements ShouldQueue
             with: [
                 'user' => $this->user,
                 'changedContactLabels' => $this->changedContactLabels,
+                'contactChangedAt' => $this->contactChangedAt,
                 'profileUrl' => route('profile.view', $this->user),
             ],
         );

--- a/app/Mail/ProfileContactUpdated.php
+++ b/app/Mail/ProfileContactUpdated.php
@@ -17,11 +17,11 @@ class ProfileContactUpdated extends Mailable implements ShouldQueue
 {
     use Queueable, SerializesModels;
 
+    public Carbon $contactChangedAt;
+
     /**
      * @param  array<int, string>  $changedContactLabels
      */
-    public Carbon $contactChangedAt;
-
     public function __construct(
         public User $user,
         public array $changedContactLabels,

--- a/app/Mail/ProfileContactUpdated.php
+++ b/app/Mail/ProfileContactUpdated.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ProfileContactUpdated extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @param  array<int, string>  $changedContactLabels
+     */
+    public function __construct(
+        public User $user,
+        public array $changedContactLabels,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Kontaktdaten im Profil aktualisiert',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.profile.contact-updated',
+            with: [
+                'user' => $this->user,
+                'changedContactLabels' => $this->changedContactLabels,
+                'profileUrl' => route('profile.view', $this->user),
+            ],
+        );
+    }
+
+    /**
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -419,22 +419,26 @@ class User extends Authenticatable
             ];
         }
 
-        if ($this->contact_release_maddraxikon && filled($this->maddraxikon_username) && $this->maddraxikonProfileUrl()) {
+        $maddraxikonProfileUrl = $this->maddraxikonProfileUrl();
+
+        if ($this->contact_release_maddraxikon && filled($this->maddraxikon_username) && $maddraxikonProfileUrl) {
             $methods[] = [
                 'key' => 'maddraxikon',
                 'label' => 'Maddraxikon',
                 'value' => (string) $this->maddraxikon_username,
-                'href' => $this->maddraxikonProfileUrl(),
+                'href' => $maddraxikonProfileUrl,
                 'icon' => 'o-book-open',
             ];
         }
 
-        if ($this->contact_release_nextcloud && filled($this->nextcloud_username) && $this->nextcloudProfileUrl()) {
+        $nextcloudProfileUrl = $this->nextcloudProfileUrl();
+
+        if ($this->contact_release_nextcloud && filled($this->nextcloud_username) && $nextcloudProfileUrl) {
             $methods[] = [
                 'key' => 'nextcloud',
                 'label' => 'Nextcloud',
                 'value' => (string) $this->nextcloud_username,
-                'href' => $this->nextcloudProfileUrl(),
+                'href' => $nextcloudProfileUrl,
                 'icon' => 'o-cloud',
             ];
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -368,9 +368,10 @@ class User extends Authenticatable
     public function displayAliases(): array
     {
         $aliases = [];
+        $displayAlias = $this->displayAlias();
 
-        if ($this->displayAlias()) {
-            $aliases[] = $this->displayAlias();
+        if ($displayAlias) {
+            $aliases[] = $displayAlias;
         }
 
         foreach ($this->author_aliases ?? [] as $authorAlias) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -70,6 +70,15 @@ class User extends Authenticatable
         'lat',
         'lon',
         'telefon',
+        'alias',
+        'author_aliases',
+        'contact_release_email',
+        'contact_release_phone',
+        'contact_release_maddraxikon',
+        'contact_release_nextcloud',
+        'maddraxikon_username',
+        'nextcloud_username',
+        'contact_released_at',
         'verein_gefunden',
         'mitgliedsbeitrag',
         'einstiegsroman',
@@ -126,6 +135,12 @@ class User extends Authenticatable
             'last_activity' => 'integer',
             'lat' => 'float',
             'lon' => 'float',
+            'author_aliases' => 'array',
+            'contact_release_email' => 'boolean',
+            'contact_release_phone' => 'boolean',
+            'contact_release_maddraxikon' => 'boolean',
+            'contact_release_nextcloud' => 'boolean',
+            'contact_released_at' => 'datetime',
         ];
     }
 
@@ -338,6 +353,116 @@ class User extends Authenticatable
         }
 
         return $nameParts[0] ?: null;
+    }
+
+    public function displayAlias(): ?string
+    {
+        $alias = trim((string) $this->alias);
+
+        return $alias === '' ? null : $alias;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function displayAliases(): array
+    {
+        $aliases = [];
+
+        if ($this->displayAlias()) {
+            $aliases[] = $this->displayAlias();
+        }
+
+        foreach ($this->author_aliases ?? [] as $authorAlias) {
+            $authorAlias = trim((string) $authorAlias);
+
+            if ($authorAlias !== '') {
+                $aliases[] = $authorAlias;
+            }
+        }
+
+        return array_values(array_unique($aliases));
+    }
+
+    public function hasReleasedContactMethods(): bool
+    {
+        return $this->releasedContactMethods() !== [];
+    }
+
+    /**
+     * @return array<int, array{key:string,label:string,value:string,href:string,icon:string}>
+     */
+    public function releasedContactMethods(): array
+    {
+        $methods = [];
+
+        if ($this->contact_release_email && filled($this->email)) {
+            $methods[] = [
+                'key' => 'email',
+                'label' => 'E-Mail',
+                'value' => (string) $this->email,
+                'href' => 'mailto:'.$this->email,
+                'icon' => 'o-envelope',
+            ];
+        }
+
+        if ($this->contact_release_phone && filled($this->telefon)) {
+            $phoneHref = preg_replace('/[^\d+]/', '', (string) $this->telefon) ?: (string) $this->telefon;
+
+            $methods[] = [
+                'key' => 'phone',
+                'label' => 'Telefon',
+                'value' => (string) $this->telefon,
+                'href' => 'tel:'.$phoneHref,
+                'icon' => 'o-phone',
+            ];
+        }
+
+        if ($this->contact_release_maddraxikon && filled($this->maddraxikon_username) && $this->maddraxikonProfileUrl()) {
+            $methods[] = [
+                'key' => 'maddraxikon',
+                'label' => 'Maddraxikon',
+                'value' => (string) $this->maddraxikon_username,
+                'href' => $this->maddraxikonProfileUrl(),
+                'icon' => 'o-book-open',
+            ];
+        }
+
+        if ($this->contact_release_nextcloud && filled($this->nextcloud_username) && $this->nextcloudProfileUrl()) {
+            $methods[] = [
+                'key' => 'nextcloud',
+                'label' => 'Nextcloud',
+                'value' => (string) $this->nextcloud_username,
+                'href' => $this->nextcloudProfileUrl(),
+                'icon' => 'o-cloud',
+            ];
+        }
+
+        return $methods;
+    }
+
+    public function maddraxikonProfileUrl(): ?string
+    {
+        $username = trim((string) $this->maddraxikon_username);
+
+        if ($username === '') {
+            return null;
+        }
+
+        $username = preg_replace('/\s+/u', '_', $username) ?: $username;
+
+        return 'https://de.maddraxikon.com/index.php?title=Benutzer:'.rawurlencode($username);
+    }
+
+    public function nextcloudProfileUrl(): ?string
+    {
+        $username = trim((string) $this->nextcloud_username);
+
+        if ($username === '') {
+            return null;
+        }
+
+        return 'https://cloud.maddrax-fanclub.de/u/'.rawurlencode($username);
     }
 
     /**

--- a/database/migrations/2026_06_06_120000_add_profile_contact_fields_to_users_table.php
+++ b/database/migrations/2026_06_06_120000_add_profile_contact_fields_to_users_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('alias')->nullable();
+            $table->json('author_aliases')->nullable();
+            $table->boolean('contact_release_email')->default(false);
+            $table->boolean('contact_release_phone')->default(false);
+            $table->boolean('contact_release_maddraxikon')->default(false);
+            $table->boolean('contact_release_nextcloud')->default(false);
+            $table->string('maddraxikon_username')->nullable();
+            $table->string('nextcloud_username')->nullable();
+            $table->timestamp('contact_released_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'alias',
+                'author_aliases',
+                'contact_release_email',
+                'contact_release_phone',
+                'contact_release_maddraxikon',
+                'contact_release_nextcloud',
+                'maddraxikon_username',
+                'nextcloud_username',
+                'contact_released_at',
+            ]);
+        });
+    }
+};

--- a/resources/views/emails/profile/contact-updated.blade.php
+++ b/resources/views/emails/profile/contact-updated.blade.php
@@ -1,0 +1,13 @@
+<x-mail::message>
+# Kontaktdaten aktualisiert
+
+{{ $user->name }} hat freigegebene Kontaktdaten im Profil aktualisiert.
+
+- **Profil:** [{{ $user->name }}]({{ $profileUrl }})
+- **Geaenderte Kontaktwege:** {{ implode(', ', $changedContactLabels) }}
+- **Zeitpunkt:** {{ now()->format('d.m.Y H:i') }}
+
+<x-mail::panel>
+Newsletter-Versand, CSV-Export und die Funktion zum Kopieren aller E-Mail-Adressen verwenden weiterhin die hinterlegte Konto-E-Mail-Adresse.
+</x-mail::panel>
+</x-mail::message>

--- a/resources/views/emails/profile/contact-updated.blade.php
+++ b/resources/views/emails/profile/contact-updated.blade.php
@@ -4,8 +4,8 @@
 {{ $user->name }} hat freigegebene Kontaktdaten im Profil aktualisiert.
 
 - **Profil:** [{{ $user->name }}]({{ $profileUrl }})
-- **Geaenderte Kontaktwege:** {{ implode(', ', $changedContactLabels) }}
-- **Zeitpunkt:** {{ now()->format('d.m.Y H:i') }}
+- **Geänderte Kontaktwege:** {{ implode(', ', $changedContactLabels) }}
+- **Zeitpunkt:** {{ $contactChangedAt->timezone(config('app.timezone'))->format('d.m.Y H:i') }}
 
 <x-mail::panel>
 Newsletter-Versand, CSV-Export und die Funktion zum Kopieren aller E-Mail-Adressen verwenden weiterhin die hinterlegte Konto-E-Mail-Adresse.

--- a/resources/views/livewire/mitglieder-index.blade.php
+++ b/resources/views/livewire/mitglieder-index.blade.php
@@ -226,6 +226,13 @@
     </thead>
     <tbody>
     @forelse($this->members as $member)
+    @php
+        $memberAlias = $member->displayAlias();
+        $memberAuthorAliases = collect($member->displayAliases())
+            ->reject(fn (string $alias) => $memberAlias && $alias === $memberAlias)
+            ->values();
+        $memberContactMethods = $member->releasedContactMethods();
+    @endphp
     <tr wire:key="member-{{ $member->id }}" class="hover:bg-base-200">
         {{-- Name --}}
         <td>
@@ -236,11 +243,36 @@
                         <span class="inline-block w-2 h-2 rounded-full mr-2 {{ isset($this->onlineUserIdSet[$member->id]) ? 'bg-success' : 'bg-base-content/40' }}" title="{{ isset($this->onlineUserIdSet[$member->id]) ? 'Online' : 'Offline' }}"></span>
                         {{ $member->name }}
                     </div>
+                    @if($memberAlias)
+                        <div class="text-sm font-medium text-primary">Alias: {{ $memberAlias }}</div>
+                    @endif
+                    @if($memberAuthorAliases->isNotEmpty())
+                        <div class="mt-1 flex flex-wrap gap-1">
+                            @foreach($memberAuthorAliases as $authorAlias)
+                                <span class="badge badge-outline badge-sm">{{ $authorAlias }}</span>
+                            @endforeach
+                        </div>
+                    @endif
                     @if($this->canViewDetails)
                     <div class="text-sm text-base-content">{{ $member->vorname }} {{ $member->nachname }}</div>
                     @endif
                 </div>
             </a>
+            @if($memberContactMethods !== [])
+                <div class="mt-2 flex flex-wrap gap-1 pl-14">
+                    @foreach($memberContactMethods as $method)
+                        <a
+                            href="{{ $method['href'] }}"
+                            @if(in_array($method['key'], ['maddraxikon', 'nextcloud'], true)) target="_blank" rel="noopener noreferrer" @endif
+                            class="inline-flex items-center gap-1 rounded-full bg-base-200 px-2 py-1 text-xs text-base-content hover:bg-primary hover:text-primary-content"
+                            aria-label="{{ $method['label'] }} von {{ $member->name }}"
+                        >
+                            <x-icon name="{{ $method['icon'] }}" class="h-3.5 w-3.5" />
+                            <span>{{ $method['label'] }}</span>
+                        </a>
+                    @endforeach
+                </div>
+            @endif
         </td>
 
         {{-- Mitglied seit --}}
@@ -408,6 +440,13 @@
         </div>
 
         @forelse($this->members as $member)
+        @php
+            $memberAlias = $member->displayAlias();
+            $memberAuthorAliases = collect($member->displayAliases())
+                ->reject(fn (string $alias) => $memberAlias && $alias === $memberAlias)
+                ->values();
+            $memberContactMethods = $member->releasedContactMethods();
+        @endphp
         <x-ui.panel class="!p-4" wire:key="member-mobile-{{ $member->id }}">
             <a href="{{ route('profile.view', $member->id) }}" wire:navigate class="flex items-center mb-4">
                 <x-avatar :image="$member->profile_photo_url" :alt="$member->name" class="!w-12 !h-12" />
@@ -416,12 +455,38 @@
                         <span class="inline-block w-2 h-2 rounded-full mr-2 {{ isset($this->onlineUserIdSet[$member->id]) ? 'bg-success' : 'bg-base-content/40' }}" title="{{ isset($this->onlineUserIdSet[$member->id]) ? 'Online' : 'Offline' }}"></span>
                         {{ $member->name }}
                     </div>
+                    @if($memberAlias)
+                        <div class="text-sm font-medium text-primary">Alias: {{ $memberAlias }}</div>
+                    @endif
+                    @if($memberAuthorAliases->isNotEmpty())
+                        <div class="mt-1 flex flex-wrap gap-1">
+                            @foreach($memberAuthorAliases as $authorAlias)
+                                <span class="badge badge-outline badge-sm">{{ $authorAlias }}</span>
+                            @endforeach
+                        </div>
+                    @endif
                     <div class="text-xs text-base-content">
                         {{ $member->membership->role }} •
                         Mitglied seit {{ $member->mitglied_seit ? $member->mitglied_seit->format('d.m.Y') : 'k.A.' }}
                     </div>
                 </div>
             </a>
+
+            @if($memberContactMethods !== [])
+            <div class="mb-4 flex flex-wrap gap-1">
+                @foreach($memberContactMethods as $method)
+                    <a
+                        href="{{ $method['href'] }}"
+                        @if(in_array($method['key'], ['maddraxikon', 'nextcloud'], true)) target="_blank" rel="noopener noreferrer" @endif
+                        class="inline-flex items-center gap-1 rounded-full bg-base-200 px-2 py-1 text-xs text-base-content hover:bg-primary hover:text-primary-content"
+                        aria-label="{{ $method['label'] }} von {{ $member->name }}"
+                    >
+                        <x-icon name="{{ $method['icon'] }}" class="h-3.5 w-3.5" />
+                        <span>{{ $method['label'] }}</span>
+                    </a>
+                @endforeach
+            </div>
+            @endif
 
             <div class="mb-4">
                 <div class="grid grid-cols-2 gap-4">

--- a/resources/views/livewire/romantausch-index.blade.php
+++ b/resources/views/livewire/romantausch-index.blade.php
@@ -1,8 +1,13 @@
 <x-member-page class="space-y-8">
-    @if(session('success'))
+    @php
+        $romantauschSuccessMessage = session()->pull('romantausch.success');
+        $successMessage = session('success') ?? $romantauschSuccessMessage;
+    @endphp
+
+    @if($successMessage)
         <x-alert class="alert-success mb-4" icon="o-check-circle" dismissible
                  role="alert" data-testid="flash-success">
-            {{ session('success') }}
+            {{ $successMessage }}
         </x-alert>
     @endif
 

--- a/resources/views/profile/update-profile-information-form.blade.php
+++ b/resources/views/profile/update-profile-information-form.blade.php
@@ -1,16 +1,15 @@
 <div>
     <x-form wire:submit="updateProfileInformation" class="max-w-xl">
-        <!-- Profilfoto -->
         @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
             <div x-data="{photoName: null, photoPreview: null}">
                 <input type="file" id="photo" class="hidden" wire:model.live="photo" x-ref="photo" x-on:change="
-                                        photoName = $refs.photo.files[0].name;
-                                        const reader = new FileReader();
-                                        reader.onload = (e) => {
-                                            photoPreview = e.target.result;
-                                        };
-                                        reader.readAsDataURL($refs.photo.files[0]);
-                                " />
+                    photoName = $refs.photo.files[0].name;
+                    const reader = new FileReader();
+                    reader.onload = (e) => {
+                        photoPreview = e.target.result;
+                    };
+                    reader.readAsDataURL($refs.photo.files[0]);
+                " />
 
                 <label class="fieldset-legend">{{ __('Foto') }}</label>
 
@@ -47,37 +46,76 @@
         @endif
 
         <div class="grid grid-cols-6 gap-4">
-            <!-- Vorname -->
             <div class="col-span-6 sm:col-span-3">
                 <x-input id="vorname" label="{{ __('Vorname') }}" wire:model="state.vorname" required />
             </div>
 
-            <!-- Nachname -->
             <div class="col-span-6 sm:col-span-3">
                 <x-input id="nachname" label="{{ __('Nachname') }}" wire:model="state.nachname" required />
             </div>
 
-            <!-- Straße -->
+            <div class="col-span-6 sm:col-span-4">
+                <x-input id="alias" label="{{ __('Alias / Nickname (optional)') }}" wire:model="state.alias" maxlength="255" />
+            </div>
+
+            @if (auth()->user()?->hasRole(\App\Enums\Role::Ehrenmitglied))
+                <div class="col-span-6 space-y-3">
+                    <div>
+                        <h3 class="text-sm font-semibold text-base-content">{{ __('Autorennamen (optional)') }}</h3>
+                        <p class="mt-1 text-sm text-base-content/70">
+                            {{ __('Diese Namen werden ergänzend zu deinem Alias im Profil angezeigt.') }}
+                        </p>
+                    </div>
+
+                    @foreach (($state['author_aliases'] ?? ['']) as $index => $authorAlias)
+                        <div class="flex items-end gap-2" wire:key="author-alias-{{ $index }}">
+                            <div class="flex-1">
+                                <x-input
+                                    id="author_alias_{{ $index }}"
+                                    label="{{ $index === 0 ? __('Autorenname') : __('Weiterer Autorenname') }}"
+                                    wire:model="state.author_aliases.{{ $index }}"
+                                    maxlength="255"
+                                />
+                            </div>
+
+                            @if (count($state['author_aliases'] ?? []) > 1)
+                                <x-button
+                                    type="button"
+                                    icon="o-trash"
+                                    class="btn-ghost text-error"
+                                    wire:click="removeAuthorAlias({{ $index }})"
+                                    tooltip="Autorenname entfernen"
+                                />
+                            @endif
+                        </div>
+                    @endforeach
+
+                    <x-button
+                        type="button"
+                        icon="o-plus"
+                        label="{{ __('Autorenname hinzufügen') }}"
+                        class="btn-outline btn-sm"
+                        wire:click="addAuthorAlias"
+                    />
+                </div>
+            @endif
+
             <div class="col-span-4">
                 <x-input id="strasse" label="{{ __('Straße') }}" wire:model="state.strasse" required title="Deine Adresse wird für die interaktive Mitgliederkarte und den Postversand verwendet." />
             </div>
 
-            <!-- Hausnummer -->
             <div class="col-span-2">
                 <x-input id="hausnummer" label="{{ __('Hausnummer') }}" wire:model="state.hausnummer" required />
             </div>
 
-            <!-- PLZ -->
             <div class="col-span-2">
                 <x-input id="plz" label="{{ __('PLZ') }}" wire:model="state.plz" required />
             </div>
 
-            <!-- Stadt -->
             <div class="col-span-4">
                 <x-input id="stadt" label="{{ __('Stadt') }}" wire:model="state.stadt" required />
             </div>
 
-            <!-- Land -->
             <div class="col-span-6 sm:col-span-4">
                 @php
                     $landOptions = [
@@ -89,19 +127,81 @@
                 <x-select id="land" label="{{ __('Land') }}" wire:model="state.land" :options="$landOptions" required />
             </div>
 
-            <!-- Telefon -->
             <div class="col-span-6 sm:col-span-4">
                 <x-input id="telefon" label="{{ __('Telefonnummer (optional)') }}" type="tel" wire:model="state.telefon" />
             </div>
 
-            <!-- Mitgliedsbeitrag -->
             <div class="col-span-6 sm:col-span-4">
                 <x-input id="mitgliedsbeitrag" label="{{ __('Mitgliedsbeitrag (jährlich, min. 12€)') }}" type="number" min="12" wire:model="state.mitgliedsbeitrag" required title="Dein gewählter Jahresbeitrag wird beim nächsten Fälligkeitsdatum wirksam." />
             </div>
 
-            <!-- E-Mail -->
             <div class="col-span-6 sm:col-span-4">
                 <x-input id="email" label="{{ __('E-Mail') }}" type="email" wire:model="state.email" required autocomplete="username" />
+            </div>
+
+            <div class="col-span-6 border-t border-base-300 pt-4">
+                <div class="space-y-4">
+                    <div>
+                        <h3 class="text-sm font-semibold text-base-content">{{ __('Kontaktfreigabe') }}</h3>
+                        <p class="mt-1 text-sm text-base-content/70">
+                            {{ __('Diese Kontaktwege sind nur für eingeloggte Mitglieder sichtbar.') }}
+                        </p>
+                    </div>
+
+                    <div class="grid gap-3">
+                        <x-checkbox
+                            label="{{ __('E-Mail für andere Mitglieder freigeben') }}"
+                            wire:model.live="state.contact_release_email"
+                        />
+
+                        <x-checkbox
+                            label="{{ __('Telefonnummer für andere Mitglieder freigeben') }}"
+                            wire:model.live="state.contact_release_phone"
+                        />
+
+                        <div class="space-y-2">
+                            <x-checkbox
+                                label="{{ __('Maddraxikon-Profil freigeben') }}"
+                                wire:model.live="state.contact_release_maddraxikon"
+                            />
+
+                            @if ($state['contact_release_maddraxikon'] ?? false)
+                                <div class="pl-7">
+                                    <x-input
+                                        id="maddraxikon_username"
+                                        label="{{ __('Maddraxikon-Account') }}"
+                                        wire:model="state.maddraxikon_username"
+                                        placeholder="Stefan K"
+                                    />
+                                    <p class="mt-1 text-sm text-base-content/70">
+                                        {{ __('Trage deinen Benutzernamen aus dem Maddraxikon ein. Leerzeichen werden für den Profil-Link automatisch zu Unterstrichen.') }}
+                                    </p>
+                                </div>
+                            @endif
+                        </div>
+
+                        <div class="space-y-2">
+                            <x-checkbox
+                                label="{{ __('Nextcloud-Profil freigeben') }}"
+                                wire:model.live="state.contact_release_nextcloud"
+                            />
+
+                            @if ($state['contact_release_nextcloud'] ?? false)
+                                <div class="pl-7">
+                                    <x-input
+                                        id="nextcloud_username"
+                                        label="{{ __('Nextcloud-Account') }}"
+                                        wire:model="state.nextcloud_username"
+                                        placeholder="Holger"
+                                    />
+                                    <p class="mt-1 text-sm text-base-content/70">
+                                        {{ __('Trage den Accountnamen aus der Fanclub-Cloud ein, wie er in deinem Profil-Link nach /u/ steht.') }}
+                                    </p>
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/resources/views/profile/view.blade.php
+++ b/resources/views/profile/view.blade.php
@@ -22,6 +22,12 @@
                 ['label' => 'Lieblingszyklus', 'value' => $user->lieblingszyklus ? $user->lieblingszyklus . '-Zyklus' : null],
                 ['label' => 'Lieblingsthema', 'value' => $user->lieblingsthema],
             ])->filter(fn (array $entry) => filled($entry['value']))->values();
+
+            $displayAlias = $user->displayAlias();
+            $authorAliases = collect($user->displayAliases())
+                ->reject(fn (string $alias) => $displayAlias && $alias === $displayAlias)
+                ->values();
+            $releasedContactMethods = $user->releasedContactMethods();
         @endphp
 
         <div class="space-y-8">
@@ -65,7 +71,18 @@
                                 <div class="space-y-1">
                                     <h1 class="font-display text-3xl font-semibold tracking-tight text-base-content">{{ $user->name }}</h1>
                                     <p class="text-base text-base-content/72">{{ $user->vorname }} {{ $user->nachname }}</p>
+                                    @if($displayAlias)
+                                        <p class="text-base font-medium text-primary">{{ __('Alias') }}: {{ $displayAlias }}</p>
+                                    @endif
                                 </div>
+
+                                @if($authorAliases->isNotEmpty())
+                                    <div class="flex flex-wrap gap-2">
+                                        @foreach($authorAliases as $authorAlias)
+                                            <x-badge :value="$authorAlias" class="badge-outline" icon="o-pencil" />
+                                        @endforeach
+                                    </div>
+                                @endif
 
                                 <div class="flex flex-wrap items-center gap-3 text-sm text-base-content/78">
                                     <x-badge value="{{ $memberRole }}" class="badge-primary" icon="o-identification" />
@@ -106,6 +123,26 @@
                                         <h3 class="text-sm font-semibold text-base-content">{{ $badge['name'] }}</h3>
                                         <p class="mt-1 text-xs leading-relaxed text-base-content/72">{{ $badge['description'] }}</p>
                                     </div>
+                                @endforeach
+                            </div>
+                        </x-ui.panel>
+                    @endif
+
+                    @if($releasedContactMethods !== [])
+                        <x-ui.panel title="Freigegebene Kontaktwege" description="Diese Kontaktmöglichkeiten hat das Mitglied für andere Mitglieder freigegeben.">
+                            <div class="grid gap-3">
+                                @foreach($releasedContactMethods as $method)
+                                    <a
+                                        href="{{ $method['href'] }}"
+                                        @if(in_array($method['key'], ['maddraxikon', 'nextcloud'], true)) target="_blank" rel="noopener noreferrer" @endif
+                                        class="flex items-center gap-3 rounded-lg border border-base-300 bg-base-100 px-4 py-3 text-base-content transition hover:border-primary/40 hover:bg-base-200"
+                                    >
+                                        <x-icon name="{{ $method['icon'] }}" class="h-5 w-5 text-primary" />
+                                        <span class="min-w-0">
+                                            <span class="block text-sm font-semibold">{{ $method['label'] }}</span>
+                                            <span class="block truncate text-sm text-base-content/72">{{ $method['value'] }}</span>
+                                        </span>
+                                    </a>
                                 @endforeach
                             </div>
                         </x-ui.panel>

--- a/tests/Feature/ActivityFeedTest.php
+++ b/tests/Feature/ActivityFeedTest.php
@@ -5,14 +5,16 @@ namespace Tests\Feature;
 use App\Enums\BookType;
 use App\Enums\Role;
 use App\Enums\TodoStatus;
+use App\Livewire\RezensionForm;
+use App\Livewire\RomantauschOfferForm;
+use App\Livewire\RomantauschRequestForm;
+use App\Livewire\TodoIndex;
 use App\Models\Activity;
 use App\Models\AdminMessage;
 use App\Models\Book;
-use App\Models\BookSwap;
-use App\Livewire\RomantauschOfferForm;
-use App\Livewire\RomantauschRequestForm;
 use App\Models\BookOffer;
 use App\Models\BookRequest;
+use App\Models\BookSwap;
 use App\Models\Fanfiction;
 use App\Models\FanfictionComment;
 use App\Models\FantreffenAnmeldung;
@@ -22,7 +24,6 @@ use App\Models\Reward;
 use App\Models\RewardPurchase;
 use App\Models\Team;
 use App\Models\Todo;
-use App\Livewire\TodoIndex;
 use App\Models\TodoCategory;
 use App\Models\User;
 use App\Models\UserPoint;
@@ -66,7 +67,7 @@ class ActivityFeedTest extends TestCase
         $user = $this->actingMember();
 
         Livewire::actingAs($user)
-            ->test(\App\Livewire\RezensionForm::class, ['book' => $book])
+            ->test(RezensionForm::class, ['book' => $book])
             ->set('title', 'Tolle Rezension')
             ->set('content', str_repeat('A', 140))
             ->call('save');
@@ -753,7 +754,7 @@ class ActivityFeedTest extends TestCase
             ]);
             $this->fail('Activity creation with null user_id should fail after down migration.');
         } catch (QueryException $exception) {
-            $this->assertStringContainsString('NOT NULL', $exception->getMessage());
+            $this->assertMatchesRegularExpression('/NOT NULL|cannot be null/i', $exception->getMessage());
         } finally {
             $migration->up();
         }

--- a/tests/Feature/MitgliederIndexLivewireTest.php
+++ b/tests/Feature/MitgliederIndexLivewireTest.php
@@ -87,6 +87,35 @@ class MitgliederIndexLivewireTest extends TestCase
             ]);
     }
 
+    public function test_index_shows_alias_author_aliases_and_released_contact_links(): void
+    {
+        $team = Team::membersTeam();
+
+        $member = User::factory()->create([
+            'name' => 'Stefan Kontakt',
+            'vorname' => 'Stefan',
+            'nachname' => 'Kontakt',
+            'current_team_id' => $team->id,
+            'alias' => 'Stefan K',
+            'author_aliases' => ['Ian Rolf Hill'],
+            'contact_release_maddraxikon' => true,
+            'contact_release_nextcloud' => true,
+            'maddraxikon_username' => 'Stefan K',
+            'nextcloud_username' => 'Holger',
+        ]);
+        $team->users()->attach($member, ['role' => Role::Ehrenmitglied->value]);
+
+        $this->actingAs($this->actingMember('Mitglied'));
+
+        Livewire::test(MitgliederIndex::class)
+            ->assertSee('Alias: Stefan K')
+            ->assertSee('Ian Rolf Hill')
+            ->assertSee('Maddraxikon')
+            ->assertSee('Nextcloud')
+            ->assertSee('https://de.maddraxikon.com/index.php?title=Benutzer:Stefan_K', false)
+            ->assertSee('https://cloud.maddrax-fanclub.de/u/Holger', false);
+    }
+
     public function test_index_sorts_members_by_last_activity_desc(): void
     {
         $team = Team::membersTeam();

--- a/tests/Feature/ProfileViewControllerTest.php
+++ b/tests/Feature/ProfileViewControllerTest.php
@@ -26,10 +26,10 @@ class ProfileViewControllerTest extends TestCase
 {
     use RefreshDatabase;
 
-    private function createMember(string $role = 'Mitglied'): User
+    private function createMember(string $role = 'Mitglied', array $attributes = []): User
     {
         $team = Team::membersTeam();
-        $user = User::factory()->create(['current_team_id' => $team->id]);
+        $user = User::factory()->create(array_merge(['current_team_id' => $team->id], $attributes));
         $team->users()->attach($user, ['role' => Role::from($role)->value]);
 
         return $user;
@@ -106,6 +106,43 @@ class ProfileViewControllerTest extends TestCase
         $response->assertViewHas('isOwnProfile', false);
         $response->assertViewHas('memberRole', Role::Mitglied);
         $response->assertViewHas('canViewDetails', false);
+        $response->assertDontSee($target->email);
+        $response->assertDontSee($target->telefon);
+    }
+
+    public function test_view_other_member_shows_released_contact_methods_and_aliases(): void
+    {
+        $viewer = $this->createMember();
+        $target = $this->createMember('Ehrenmitglied', [
+            'name' => 'Stefan Kontakt',
+            'vorname' => 'Stefan',
+            'nachname' => 'Kontakt',
+            'email' => 'stefan@example.com',
+            'telefon' => '0123 45 67',
+            'alias' => 'Stefan K',
+            'author_aliases' => ['Ian Rolf Hill', 'Jo Zybell'],
+            'contact_release_email' => true,
+            'contact_release_phone' => true,
+            'contact_release_maddraxikon' => true,
+            'contact_release_nextcloud' => true,
+            'maddraxikon_username' => 'Stefan K',
+            'nextcloud_username' => 'Holger',
+        ]);
+        $this->actingAs($viewer);
+
+        $response = $this->get("/profil/{$target->id}");
+
+        $response->assertOk();
+        $response->assertViewHas('canViewDetails', false);
+        $response->assertSee('Alias');
+        $response->assertSee('Stefan K');
+        $response->assertSee('Ian Rolf Hill');
+        $response->assertSee('Jo Zybell');
+        $response->assertSee('Freigegebene Kontaktwege');
+        $response->assertSee('mailto:stefan@example.com', false);
+        $response->assertSee('tel:01234567', false);
+        $response->assertSee('https://de.maddraxikon.com/index.php?title=Benutzer:Stefan_K', false);
+        $response->assertSee('https://cloud.maddrax-fanclub.de/u/Holger', false);
     }
 
     public function test_view_other_member_with_admin_role_shows_contact(): void

--- a/tests/Feature/RomantauschLivewireTest.php
+++ b/tests/Feature/RomantauschLivewireTest.php
@@ -7,7 +7,6 @@ use App\Livewire\RomantauschBundleForm;
 use App\Livewire\RomantauschIndex;
 use App\Livewire\RomantauschOfferForm;
 use App\Livewire\RomantauschRequestForm;
-use App\Livewire\RomantauschShowOffer;
 use App\Models\BookOffer;
 use App\Models\BookRequest;
 use App\Models\BookSwap;
@@ -20,9 +19,9 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Livewire\Livewire;
 use LogicException;
 use RuntimeException;
-use Livewire\Livewire;
 use Tests\Concerns\CreatesTestData;
 use Tests\Concerns\CreatesUserWithRole;
 use Tests\TestCase;
@@ -43,6 +42,18 @@ class RomantauschLivewireTest extends TestCase
         $this->actingMember();
 
         $this->get('/romantauschboerse')->assertOk();
+    }
+
+    public function test_index_displays_romantausch_success_message_from_session(): void
+    {
+        $this->actingMember();
+        session()->put('romantausch.success', 'Gesuch erstellt.');
+
+        $this->get('/romantauschboerse')
+            ->assertOk()
+            ->assertSeeText('Gesuch erstellt.');
+
+        $this->assertNull(session('romantausch.success'));
     }
 
     public function test_index_displays_structured_information_panel(): void
@@ -236,10 +247,10 @@ class RomantauschLivewireTest extends TestCase
             'photos' => [],
         ]);
 
-        $description = BookType::MissionMars->value . ' 2 - Roman ohne Foto';
+        $description = BookType::MissionMars->value.' 2 - Roman ohne Foto';
 
         Livewire::test(RomantauschIndex::class)
-            ->assertSee('Kein Foto vorhanden für ' . e($description), false);
+            ->assertSee('Kein Foto vorhanden für '.e($description), false);
     }
 
     // ──────────────────────────────────────────────
@@ -438,6 +449,8 @@ class RomantauschLivewireTest extends TestCase
             ->call('save')
             ->assertRedirect(route('romantausch.index'));
 
+        $this->assertSame('Angebot erstellt.', session('romantausch.success'));
+
         $this->assertDatabaseHas('book_offers', [
             'user_id' => $user->id,
             'series' => BookType::MaddraxDieDunkleZukunftDerErde->value,
@@ -566,7 +579,7 @@ class RomantauschLivewireTest extends TestCase
                 'user_id' => $user->id,
                 'series' => BookType::MaddraxDieDunkleZukunftDerErde->value,
                 'book_number' => $i,
-                'book_title' => 'Roman' . $i,
+                'book_title' => 'Roman'.$i,
                 'condition' => 'neu',
             ]);
         }
@@ -826,6 +839,8 @@ class RomantauschLivewireTest extends TestCase
             ->set('condition', 'neu')
             ->call('save')
             ->assertRedirect(route('romantausch.index'));
+
+        $this->assertSame('Gesuch erstellt.', session('romantausch.success'));
 
         $this->assertDatabaseHas('book_requests', [
             'user_id' => $user->id,
@@ -1204,7 +1219,7 @@ class RomantauschLivewireTest extends TestCase
     {
         $this->seedBooksForRomantausch();
         $user = $this->actingMember();
-        $bundleId = (string) \Illuminate\Support\Str::uuid();
+        $bundleId = (string) Str::uuid();
 
         BookOffer::create([
             'user_id' => $user->id,
@@ -1305,7 +1320,7 @@ class RomantauschLivewireTest extends TestCase
         $this->mock(BookPhotoService::class, function ($mock) {
             $mock->shouldReceive('uploadPhotos')
                 ->once()
-                ->andThrow(new \RuntimeException('Foto-Upload fehlgeschlagen.'));
+                ->andThrow(new RuntimeException('Foto-Upload fehlgeschlagen.'));
         });
 
         Livewire::test(RomantauschOfferForm::class)

--- a/tests/Feature/UpdateProfileInformationFormTest.php
+++ b/tests/Feature/UpdateProfileInformationFormTest.php
@@ -2,10 +2,14 @@
 
 namespace Tests\Feature;
 
+use App\Enums\Role;
 use App\Livewire\Profile\UpdateProfileInformationForm;
+use App\Mail\ProfileContactUpdated;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
@@ -28,6 +32,17 @@ class UpdateProfileInformationFormTest extends TestCase
         return User::factory()->create($this->userAttributes());
     }
 
+    private function createMember(Role $role = Role::Mitglied, array $attributes = []): User
+    {
+        $team = Team::membersTeam();
+        $user = User::factory()->create(array_merge($this->userAttributes(), [
+            'current_team_id' => $team->id,
+        ], $attributes));
+        $team->users()->attach($user, ['role' => $role->value]);
+
+        return $user->refresh();
+    }
+
     private function userAttributes(): array
     {
         return [
@@ -41,7 +56,25 @@ class UpdateProfileInformationFormTest extends TestCase
             'land' => 'Deutschland',
             'telefon' => '0123',
             'mitgliedsbeitrag' => 12.00,
+            'alias' => 'Maxi',
+            'author_aliases' => ['Max Power'],
+            'maddraxikon_username' => 'Max Muster',
+            'nextcloud_username' => 'MaxCloud',
         ];
+    }
+
+    private function profileFormData(array $overrides = []): array
+    {
+        return array_merge($this->userAttributes(), [
+            'alias' => null,
+            'author_aliases' => [''],
+            'contact_release_email' => false,
+            'contact_release_phone' => false,
+            'contact_release_maddraxikon' => false,
+            'contact_release_nextcloud' => false,
+            'maddraxikon_username' => null,
+            'nextcloud_username' => null,
+        ], $overrides);
     }
 
     public function test_mount_populates_state_from_user(): void
@@ -62,10 +95,33 @@ class UpdateProfileInformationFormTest extends TestCase
             'land',
             'telefon',
             'mitgliedsbeitrag',
+            'alias',
+            'author_aliases',
+            'contact_release_email',
+            'contact_release_phone',
+            'contact_release_maddraxikon',
+            'contact_release_nextcloud',
+            'maddraxikon_username',
+            'nextcloud_username',
         ];
 
         foreach ($expectedFields as $key) {
-            $this->assertEquals($user->{$key}, $component->state[$key]);
+            $expected = match ($key) {
+                'author_aliases' => $user->author_aliases ?: [''],
+                'alias', 'maddraxikon_username', 'nextcloud_username' => $user->{$key} ?? '',
+                default => $user->{$key},
+            };
+            $actual = $component->state[$key] ?? match ($key) {
+                'author_aliases' => [''],
+                'alias', 'maddraxikon_username', 'nextcloud_username' => '',
+                'contact_release_email',
+                'contact_release_phone',
+                'contact_release_maddraxikon',
+                'contact_release_nextcloud' => false,
+                default => null,
+            };
+
+            $this->assertEquals($expected, $actual);
         }
     }
 
@@ -149,6 +205,113 @@ class UpdateProfileInformationFormTest extends TestCase
         $this->assertEquals($data, $inputWithoutPhoto);
         $this->assertArrayHasKey('photo', $receivedInput);
         $this->assertInstanceOf(TemporaryUploadedFile::class, $receivedInput['photo']);
+    }
+
+    public function test_member_can_store_alias_but_not_author_aliases(): void
+    {
+        Mail::fake();
+        $this->actingAs($user = $this->createMember());
+
+        Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', $this->profileFormData([
+                'alias' => 'Stefan K',
+                'author_aliases' => ['Soll nicht bleiben'],
+            ]))
+            ->call('updateProfileInformation')
+            ->assertHasNoErrors();
+
+        $user->refresh();
+
+        $this->assertSame('Stefan K', $user->alias);
+        $this->assertSame([], $user->author_aliases);
+        Mail::assertNotQueued(ProfileContactUpdated::class);
+    }
+
+    public function test_ehrenmitglied_can_store_multiple_author_aliases(): void
+    {
+        Mail::fake();
+        $this->actingAs($user = $this->createMember(Role::Ehrenmitglied));
+
+        Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', $this->profileFormData([
+                'alias' => 'Lucy',
+                'author_aliases' => ['Ian Rolf Hill', '', 'Jo Zybell', 'Ian Rolf Hill'],
+            ]))
+            ->call('updateProfileInformation')
+            ->assertHasNoErrors();
+
+        $user->refresh();
+
+        $this->assertSame('Lucy', $user->alias);
+        $this->assertSame(['Ian Rolf Hill', 'Jo Zybell'], $user->author_aliases);
+        Mail::assertNotQueued(ProfileContactUpdated::class);
+    }
+
+    public function test_contact_release_requires_matching_contact_values(): void
+    {
+        Mail::fake();
+        $this->actingAs($this->createMember());
+
+        Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', $this->profileFormData([
+                'telefon' => '',
+                'contact_release_phone' => true,
+                'contact_release_maddraxikon' => true,
+                'maddraxikon_username' => '',
+                'contact_release_nextcloud' => true,
+                'nextcloud_username' => '',
+            ]))
+            ->call('updateProfileInformation')
+            ->assertHasErrors([
+                'telefon',
+                'maddraxikon_username',
+                'nextcloud_username',
+            ]);
+
+        Mail::assertNotQueued(ProfileContactUpdated::class);
+    }
+
+    public function test_contact_update_notifies_board_roles(): void
+    {
+        Mail::fake();
+        $user = $this->createMember(attributes: [
+            'email' => 'member@example.com',
+            'telefon' => '0123 456789',
+        ]);
+        $this->actingAs($user);
+
+        Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', $this->profileFormData([
+                'email' => $user->email,
+                'telefon' => '0123 456789',
+                'contact_release_email' => true,
+                'contact_release_phone' => true,
+                'contact_release_maddraxikon' => true,
+                'contact_release_nextcloud' => true,
+                'maddraxikon_username' => 'Stefan K',
+                'nextcloud_username' => 'Holger',
+            ]))
+            ->call('updateProfileInformation')
+            ->assertHasNoErrors();
+
+        $user->refresh();
+
+        $this->assertTrue($user->contact_release_email);
+        $this->assertTrue($user->contact_release_phone);
+        $this->assertTrue($user->contact_release_maddraxikon);
+        $this->assertTrue($user->contact_release_nextcloud);
+        $this->assertSame('https://de.maddraxikon.com/index.php?title=Benutzer:Stefan_K', $user->maddraxikonProfileUrl());
+        $this->assertSame('https://cloud.maddrax-fanclub.de/u/Holger', $user->nextcloudProfileUrl());
+        $this->assertNotNull($user->contact_released_at);
+
+        Mail::assertQueued(ProfileContactUpdated::class, function (ProfileContactUpdated $mail) {
+            $rendered = $mail->render();
+
+            return $mail->hasTo('info@maddraxikon.com')
+                && $mail->changedContactLabels === ['E-Mail', 'Telefon', 'Maddraxikon', 'Nextcloud']
+                && str_contains($rendered, 'Kontaktdaten aktualisiert')
+                && str_contains($rendered, 'E-Mail, Telefon, Maddraxikon, Nextcloud');
+        });
     }
 
     public function test_delete_profile_photo_removes_file_and_dispatches_event(): void

--- a/tests/Feature/UpdateProfileInformationFormTest.php
+++ b/tests/Feature/UpdateProfileInformationFormTest.php
@@ -9,6 +9,7 @@ use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
@@ -247,6 +248,23 @@ class UpdateProfileInformationFormTest extends TestCase
         Mail::assertNotQueued(ProfileContactUpdated::class);
     }
 
+    public function test_author_aliases_are_limited_to_ten_entries(): void
+    {
+        Mail::fake();
+        $this->actingAs($this->createMember(Role::Ehrenmitglied));
+
+        Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', $this->profileFormData([
+                'author_aliases' => collect(range(1, 11))
+                    ->map(fn (int $index): string => "Autor {$index}")
+                    ->all(),
+            ]))
+            ->call('updateProfileInformation')
+            ->assertHasErrors(['author_aliases']);
+
+        Mail::assertNotQueued(ProfileContactUpdated::class);
+    }
+
     public function test_contact_release_requires_matching_contact_values(): void
     {
         Mail::fake();
@@ -310,8 +328,27 @@ class UpdateProfileInformationFormTest extends TestCase
             return $mail->hasTo('info@maddraxikon.com')
                 && $mail->changedContactLabels === ['E-Mail', 'Telefon', 'Maddraxikon', 'Nextcloud']
                 && str_contains($rendered, 'Kontaktdaten aktualisiert')
+                && str_contains($rendered, 'Geänderte Kontaktwege')
                 && str_contains($rendered, 'E-Mail, Telefon, Maddraxikon, Nextcloud');
         });
+    }
+
+    public function test_contact_update_mail_uses_change_timestamp_instead_of_render_time(): void
+    {
+        $user = $this->createMember(attributes: ['name' => 'Mail Test']);
+        $changedAt = Carbon::parse('2026-06-06 10:15:00');
+
+        Carbon::setTestNow('2026-06-06 12:45:00');
+
+        try {
+            $rendered = (new ProfileContactUpdated($user, ['E-Mail'], $changedAt))->render();
+        } finally {
+            Carbon::setTestNow();
+        }
+
+        $this->assertStringContainsString('Geänderte Kontaktwege', $rendered);
+        $this->assertStringContainsString('06.06.2026 10:15', $rendered);
+        $this->assertStringNotContainsString('06.06.2026 12:45', $rendered);
     }
 
     public function test_delete_profile_photo_removes_file_and_dispatches_event(): void

--- a/tests/Feature/UpdateProfileInformationFormTest.php
+++ b/tests/Feature/UpdateProfileInformationFormTest.php
@@ -265,19 +265,19 @@ class UpdateProfileInformationFormTest extends TestCase
         Mail::assertNotQueued(ProfileContactUpdated::class);
     }
 
-    public function test_contact_release_requires_matching_contact_values(): void
+    public function test_contact_release_requires_non_blank_matching_contact_values(): void
     {
         Mail::fake();
-        $this->actingAs($this->createMember());
+        $this->actingAs($user = $this->createMember());
 
         Livewire::test(UpdateProfileInformationForm::class)
             ->set('state', $this->profileFormData([
-                'telefon' => '',
+                'telefon' => '   ',
                 'contact_release_phone' => true,
                 'contact_release_maddraxikon' => true,
-                'maddraxikon_username' => '',
+                'maddraxikon_username' => '   ',
                 'contact_release_nextcloud' => true,
-                'nextcloud_username' => '',
+                'nextcloud_username' => '   ',
             ]))
             ->call('updateProfileInformation')
             ->assertHasErrors([
@@ -285,6 +285,15 @@ class UpdateProfileInformationFormTest extends TestCase
                 'maddraxikon_username',
                 'nextcloud_username',
             ]);
+
+        $user->refresh();
+
+        $this->assertFalse($user->contact_release_phone);
+        $this->assertFalse($user->contact_release_maddraxikon);
+        $this->assertFalse($user->contact_release_nextcloud);
+        $this->assertSame('0123', $user->telefon);
+        $this->assertSame('Max Muster', $user->maddraxikon_username);
+        $this->assertSame('MaxCloud', $user->nextcloud_username);
 
         Mail::assertNotQueued(ProfileContactUpdated::class);
     }

--- a/tests/e2e/romantausch-single-offer.spec.js
+++ b/tests/e2e/romantausch-single-offer.spec.js
@@ -89,7 +89,7 @@ test.describe('Romantauschbörse - Einzelangebote', () => {
             await page.locator('#offer-form button[type="submit"]').click();
 
             // Sollte zur Übersicht weiterleiten
-            await expect(page).toHaveURL(/romantauschboerse$/);
+            await page.waitForURL(/romantauschboerse$/);
 
             // WICHTIG: Erfolgsmeldung prüfen - dieser Check fängt DB-Fehler wie den
             // Activity::create() Bug, bei dem ein nicht existierendes 'properties'-Feld
@@ -118,7 +118,7 @@ test.describe('Romantauschbörse - Einzelangebote', () => {
             await page.locator('#offer-form button[type="submit"]').click();
 
             // Warte auf Weiterleitung
-            await expect(page).toHaveURL(/romantauschboerse$/);
+            await page.waitForURL(/romantauschboerse$/);
 
             // Prüfe, dass das Angebot in der Liste erscheint
             // (Maddrax Band 77 sollte jetzt sichtbar sein)
@@ -166,7 +166,7 @@ test.describe('Romantauschbörse - Einzelangebote', () => {
             await page.locator('#request-form button[type="submit"]').click();
 
             // Sollte zur Übersicht weiterleiten
-            await expect(page).toHaveURL(/romantauschboerse$/);
+            await page.waitForURL(/romantauschboerse$/);
 
             // Erfolgsmeldung prüfen
             const successMessage = page.locator('[data-testid="flash-success"], [role="alert"]').filter({ hasText: /Gesuch erstellt/i });
@@ -192,7 +192,7 @@ test.describe('Romantauschbörse - Einzelangebote', () => {
             await page.selectOption('select[name="condition"]', CONDITION_Z1);
             await page.locator('#offer-form button[type="submit"]').click();
             
-            await expect(page).toHaveURL(/romantauschboerse$/);
+            await page.waitForURL(/romantauschboerse$/);
 
             // Bearbeiten-Link sollte sichtbar sein
             const editLink = page.locator('a[href*="/angebot/"][href*="/bearbeiten"]').first();
@@ -216,7 +216,7 @@ test.describe('Romantauschbörse - Einzelangebote', () => {
             await page.selectOption('select[name="condition"]', CONDITION_Z1);
             await page.locator('#offer-form button[type="submit"]').click();
             
-            await expect(page).toHaveURL(/romantauschboerse$/);
+            await page.waitForURL(/romantauschboerse$/);
 
             // Klicke auf Bearbeiten
             const editLink = page.locator('a[href*="/angebot/"][href*="/bearbeiten"]').first();
@@ -247,7 +247,7 @@ test.describe('Romantauschbörse - Einzelangebote', () => {
             await page.selectOption('select[name="condition"]', CONDITION_Z1);
             await page.locator('#offer-form button[type="submit"]').click();
             
-            await expect(page).toHaveURL(/romantauschboerse$/);
+            await page.waitForURL(/romantauschboerse$/);
 
             // Löschen-Button ist im Formular mit dem Text "Löschen" in einem span
             // Der Button enthält <span>Löschen</span>, daher suchen wir nach dem Text im Button

--- a/tests/e2e/umfragen-admin.spec.js
+++ b/tests/e2e/umfragen-admin.spec.js
@@ -245,21 +245,23 @@ test.describe('Umfragen Admin Dashboard', () => {
             await expect(page.locator('.tooltip, [data-tip]')).toHaveCount(0);
         }
     });
+});
 
+test.describe('Umfragen Admin Dashboard Access Control', () => {
     test('member cannot access poll management', async ({ page }) => {
-        // Skip beforeEach admin login - wir starten frisch
+        // Der Zugriffsschutz-Test startet ohne Admin-Login.
         test.setTimeout(60000);
-        
+
         // Clear all cookies and storage to ensure fresh session
         await page.context().clearCookies();
-        
+
         // Login as regular member (created by TodoPlaywrightSeeder)
         await page.goto('/login');
         await page.waitForLoadState('domcontentloaded');
         await page.fill('input[name="email"]', 'playwright-member@example.com');
         await page.fill('input[name="password"]', 'password');
         await page.click('button[type="submit"]');
-        
+
         // Wait for login to complete (redirect away from /login)
         await page.waitForURL((url) => !url.pathname.endsWith('/login'), { timeout: 30000 });
 
@@ -278,7 +280,7 @@ test.describe('Umfragen Admin Dashboard', () => {
     });
 
     test('guest is redirected from poll management', async ({ page }) => {
-        // Visit page without login
+        // Der Zugriffsschutz-Test startet ohne Admin-Login.
         await page.context().clearCookies();
         await page.goto('/admin/umfragen', { waitUntil: 'domcontentloaded' });
 


### PR DESCRIPTION
This pull request introduces several enhancements and improvements across the user profile update process and the Romantausch (book swap) forms. The most significant changes are the addition of new profile fields and contact release options, improved validation and normalization of user input, and a new notification system for board members when key contact information is changed. Additionally, the Romantausch forms have been refactored for better file upload handling and improved user feedback via session messaging.

**User Profile Enhancements and Contact Information Management:**

* Added new profile fields (`alias`, `author_aliases`, `maddraxikon_username`, `nextcloud_username`) and contact release options (for email, phone, Maddraxikon, and Nextcloud) to the user profile update logic, with appropriate validation and normalization. Required fields are now conditionally enforced based on the user's contact release choices. (`app/Actions/Fortify/UpdateUserProfileInformation.php`, `app/Livewire/Profile/UpdateProfileInformationForm.php`) [[1]](diffhunk://#diff-83aa1538b4dfb05f0a07973b306e51307a3a16212d1c29e2bc988f451affd0beR5-R12) [[2]](diffhunk://#diff-83aa1538b4dfb05f0a07973b306e51307a3a16212d1c29e2bc988f451affd0beR26-R32) [[3]](diffhunk://#diff-83aa1538b4dfb05f0a07973b306e51307a3a16212d1c29e2bc988f451affd0beL28-R67) [[4]](diffhunk://#diff-dd899b2c2c469af48d2967716e86b49b9b77bdbb0f00ab937030872882181979R48-R65)
* Implemented logic to snapshot contact information before updates, detect changes in contact release fields, and set a `contact_released_at` timestamp when relevant fields change. (`app/Actions/Fortify/UpdateUserProfileInformation.php`)
* Added a notification system that sends an email to board members when a user's released contact information changes, including which fields were updated and when. (`app/Actions/Fortify/UpdateUserProfileInformation.php`)
* Improved handling of nullable and boolean fields, as well as array normalization for author aliases. (`app/Actions/Fortify/UpdateUserProfileInformation.php`, `app/Livewire/Profile/UpdateProfileInformationForm.php`) [[1]](diffhunk://#diff-83aa1538b4dfb05f0a07973b306e51307a3a16212d1c29e2bc988f451affd0beR140-R277) [[2]](diffhunk://#diff-dd899b2c2c469af48d2967716e86b49b9b77bdbb0f00ab937030872882181979R110-R138)

**Romantausch Forms Improvements:**

* Refactored file upload handling in both `RomantauschBundleForm` and `RomantauschOfferForm` to use the correct `UploadedFile` type, improving type safety and consistency. (`app/Livewire/RomantauschBundleForm.php`, `app/Livewire/RomantauschOfferForm.php`) [[1]](diffhunk://#diff-04cacbdea77175064879810c6ac966f529fe1f0d1dc24c8e183df5551431f70bR11-R16) [[2]](diffhunk://#diff-d900105d1f095fb938293c3d529e16058be0e9c8bd872f54830fcbd22c3b09f6R13-R21) [[3]](diffhunk://#diff-04cacbdea77175064879810c6ac966f529fe1f0d1dc24c8e183df5551431f70bL32-R34) [[4]](diffhunk://#diff-d900105d1f095fb938293c3d529e16058be0e9c8bd872f54830fcbd22c3b09f6L34-R36) [[5]](diffhunk://#diff-04cacbdea77175064879810c6ac966f529fe1f0d1dc24c8e183df5551431f70bL217-R219) [[6]](diffhunk://#diff-d900105d1f095fb938293c3d529e16058be0e9c8bd872f54830fcbd22c3b09f6L183-R185) [[7]](diffhunk://#diff-04cacbdea77175064879810c6ac966f529fe1f0d1dc24c8e183df5551431f70bL243-R251) [[8]](diffhunk://#diff-d900105d1f095fb938293c3d529e16058be0e9c8bd872f54830fcbd22c3b09f6L209-R211)
* Updated user feedback after form submissions: success messages are now stored in the session under a dedicated key (`romantausch.success`) instead of using flash messaging, ensuring better control over displaying feedback after redirects. (`app/Livewire/RomantauschBundleForm.php`, `app/Livewire/RomantauschOfferForm.php`, `app/Livewire/RomantauschRequestForm.php`) [[1]](diffhunk://#diff-04cacbdea77175064879810c6ac966f529fe1f0d1dc24c8e183df5551431f70bL273-R278) [[2]](diffhunk://#diff-04cacbdea77175064879810c6ac966f529fe1f0d1dc24c8e183df5551431f70bL298-R301) [[3]](diffhunk://#diff-d900105d1f095fb938293c3d529e16058be0e9c8bd872f54830fcbd22c3b09f6L254-R256) [[4]](diffhunk://#diff-6412800e7d1cd1ea4482827c3e4c0c783f2b734b9c60ce5b903f29d7939b8c0eL170-R170)

These changes collectively improve the robustness, usability, and maintainability of both the user profile and Romantausch features.