### PR TITLE
Feature: Sorting for Search Results in Kompendium

### DIFF
--- a/app/Console/Commands/BackfillKompendiumPublicationDates.php
+++ b/app/Console/Commands/BackfillKompendiumPublicationDates.php
@@ -25,6 +25,12 @@ class BackfillKompendiumPublicationDates extends Command
             ->orderBy('id')
             ->chunkById(100, function ($romane) use ($kompendiumService, $dryRun, &$updated, &$missing, &$unchanged): void {
                 foreach ($romane as $roman) {
+                    if ($roman->erstveroeffentlicht_am !== null) {
+                        $unchanged++;
+
+                        continue;
+                    }
+
                     $date = $kompendiumService->findeErstveroeffentlichtAm(
                         $roman->serie,
                         $roman->roman_nr,
@@ -38,12 +44,6 @@ class BackfillKompendiumPublicationDates extends Command
                     }
 
                     $dateString = $date->toDateString();
-
-                    if ($roman->erstveroeffentlicht_am?->toDateString() === $dateString) {
-                        $unchanged++;
-
-                        continue;
-                    }
 
                     $updated++;
 

--- a/app/Console/Commands/BackfillKompendiumPublicationDates.php
+++ b/app/Console/Commands/BackfillKompendiumPublicationDates.php
@@ -50,7 +50,10 @@ class BackfillKompendiumPublicationDates extends Command
                     if (! $dryRun) {
                         DB::table('kompendium_romane')
                             ->where('id', $roman->id)
-                            ->update(['erstveroeffentlicht_am' => $dateString]);
+                            ->update([
+                                'erstveroeffentlicht_am' => $dateString,
+                                'updated_at' => now(),
+                            ]);
                     }
                 }
             });

--- a/app/Console/Commands/BackfillKompendiumPublicationDates.php
+++ b/app/Console/Commands/BackfillKompendiumPublicationDates.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\KompendiumRoman;
+use App\Services\KompendiumService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class BackfillKompendiumPublicationDates extends Command
+{
+    protected $signature = 'kompendium:backfill-publication-dates {--dry-run : Zeigt nur, wie viele Datensaetze aktualisiert wuerden}';
+
+    protected $description = 'Befuellt Erstveroeffentlichungsdaten im Kompendium aus den Serien-Metadaten';
+
+    public function handle(KompendiumService $kompendiumService): int
+    {
+        $updated = 0;
+        $missing = 0;
+        $unchanged = 0;
+        $dryRun = (bool) $this->option('dry-run');
+
+        KompendiumRoman::query()
+            ->select(['id', 'serie', 'roman_nr', 'titel', 'erstveroeffentlicht_am'])
+            ->orderBy('id')
+            ->chunkById(100, function ($romane) use ($kompendiumService, $dryRun, &$updated, &$missing, &$unchanged): void {
+                foreach ($romane as $roman) {
+                    $date = $kompendiumService->findeErstveroeffentlichtAm(
+                        $roman->serie,
+                        $roman->roman_nr,
+                        $roman->titel,
+                    );
+
+                    if ($date === null) {
+                        $missing++;
+
+                        continue;
+                    }
+
+                    $dateString = $date->toDateString();
+
+                    if ($roman->erstveroeffentlicht_am?->toDateString() === $dateString) {
+                        $unchanged++;
+
+                        continue;
+                    }
+
+                    $updated++;
+
+                    if (! $dryRun) {
+                        DB::table('kompendium_romane')
+                            ->where('id', $roman->id)
+                            ->update(['erstveroeffentlicht_am' => $dateString]);
+                    }
+                }
+            });
+
+        $prefix = $dryRun ? 'Dry run: ' : '';
+        $this->info($prefix."{$updated} aktualisiert, {$unchanged} unveraendert, {$missing} ohne Datum.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/KompendiumController.php
+++ b/app/Http/Controllers/KompendiumController.php
@@ -7,6 +7,7 @@ use App\Models\KompendiumRoman;
 use App\Models\Reward;
 use App\Models\User;
 use App\Services\KompendiumSearchService;
+use App\Services\KompendiumSearchSorter;
 use App\Services\KompendiumService;
 use App\Services\RewardService;
 use Illuminate\Http\JsonResponse;
@@ -123,17 +124,24 @@ class KompendiumController extends Controller
 
         /* ----- Validierung ------------------------------------------------- */
         $validSerienKeys = array_keys(KompendiumService::SERIEN);
+        $sorter = app(KompendiumSearchSorter::class);
 
         $request->validate([
             'q' => 'required|string|min:2',
             'page' => 'sometimes|integer|min:1',
             'serien' => 'sometimes|array',
             'serien.*' => ['string', Rule::in($validSerienKeys)],
+            'sort' => ['sometimes', 'string', Rule::in($sorter->validSorts())],
+            'direction' => ['sometimes', 'string', Rule::in($sorter->validDirections())],
         ]);
 
         $query = mb_strtolower($request->input('q'));
         $selectedSerien = $request->input('serien', []);
         $page = (int) $request->input('page', 1);
+        $sort = $sorter->normalizeSort($request->input('sort'));
+        $direction = $request->has('direction')
+            ? $sorter->normalizeDirection($request->input('direction'), $sort)
+            : $sorter->defaultDirectionForSort($sort);
         $perPage = 5;
         $snippetsPerFile = config('kompendium.snippets_per_novel', 10) ?: 10;
         $radius = 200;
@@ -158,6 +166,8 @@ class KompendiumController extends Controller
                     'usesOrOperator' => $parsed['usesOrOperator'],
                     'usesNotOperator' => $parsed['usesNotOperator'],
                 ],
+                'sort' => $sort,
+                'direction' => $direction,
                 'message' => 'Bitte gib mindestens einen positiven Suchbegriff ein.',
             ]);
         }
@@ -181,7 +191,9 @@ class KompendiumController extends Controller
         /*  unter Last kontrollierbar bleiben. */
         /* ------------------------------------------------------------------ */
         $textCache = [];
-        $requiredMatches = ($page + 1) * $perPage;
+        $requiredMatches = $sorter->needsFullPostFilter($sort, $direction)
+            ? PHP_INT_MAX
+            : (($page + 1) * $perPage);
         $postFilterBudget = $this->searchService->postFilterBudget();
         $candidatesTruncated = false;
         $scannedCandidates = 0;
@@ -234,6 +246,10 @@ class KompendiumController extends Controller
         if (! empty($selectedSerien)) {
             $ids = array_values(array_filter($ids, fn ($path) => in_array($pathToSerie[$path], $selectedSerien, true)));
         }
+
+        $ordered = $sorter->orderPathsWithMetadata($ids, $sort, $direction);
+        $ids = $ordered['paths'];
+        $pathMetadata = $ordered['metadata'];
 
         $total = count($ids);
         $slice = array_slice($ids, ($page - 1) * $perPage, $perPage);
@@ -340,6 +356,8 @@ class KompendiumController extends Controller
                 'romanNr' => $romanNr,
                 'title' => $title,
                 'serie' => $serie,
+                'erstveroeffentlichtAm' => $pathMetadata[$path]['erstveroeffentlichtAm'] ?? null,
+                'erstveroeffentlichtAmFormatted' => $pathMetadata[$path]['erstveroeffentlichtAmFormatted'] ?? null,
                 'snippets' => $snippets,
             ];
         }
@@ -379,6 +397,8 @@ class KompendiumController extends Controller
                 'usesOrOperator' => $parsed['usesOrOperator'],
                 'usesNotOperator' => $parsed['usesNotOperator'],
             ],
+            'sort' => $sort,
+            'direction' => $direction,
         ];
 
         if ($candidatesTruncated) {

--- a/app/Livewire/KompendiumAdminDashboard.php
+++ b/app/Livewire/KompendiumAdminDashboard.php
@@ -55,6 +55,8 @@ class KompendiumAdminDashboard extends Component
 
     public string $editTitel = '';
 
+    public string $editErstveroeffentlichtAm = '';
+
     /** Timestamp für Optimistic Locking beim Bearbeiten */
     public ?string $editUpdatedAt = null;
 
@@ -179,6 +181,7 @@ class KompendiumAdminDashboard extends Component
                 'roman_nr' => $parsed['nummer'],
                 'titel' => $parsed['titel'],
                 'zyklus' => $meta['zyklus'] ?? null,
+                'erstveroeffentlicht_am' => $meta['erstveroeffentlicht_am'] ?? null,
                 'hochgeladen_am' => now(),
                 'hochgeladen_von' => auth()->id(),
             ]);
@@ -220,6 +223,7 @@ class KompendiumAdminDashboard extends Component
         $this->editZyklus = $roman->zyklus ?? '';
         $this->editNummer = $roman->roman_nr;
         $this->editTitel = $roman->titel;
+        $this->editErstveroeffentlichtAm = $roman->erstveroeffentlicht_am?->toDateString() ?? '';
         $this->editUpdatedAt = $roman->updated_at?->toISOString();
         $this->showEditModal = true;
     }
@@ -235,6 +239,7 @@ class KompendiumAdminDashboard extends Component
             'editZyklus' => 'nullable|string|max:100',
             'editNummer' => 'required|integer|min:1',
             'editTitel' => 'required|string|max:255',
+            'editErstveroeffentlichtAm' => 'nullable|date',
         ]);
 
         $roman = KompendiumRoman::findOrFail($this->editId);
@@ -305,10 +310,16 @@ class KompendiumAdminDashboard extends Component
             }
         }
 
+        $service = app(KompendiumService::class);
+        $erstveroeffentlichtAm = $this->editErstveroeffentlichtAm !== ''
+            ? $this->editErstveroeffentlichtAm
+            : $service->findeErstveroeffentlichtAm($this->editSerie, $this->editNummer, $sichererTitel)?->toDateString();
+
         // DB aktualisieren (ein einzelner Update-Aufruf für alle Felder)
         $updateDaten = [
             'serie' => $this->editSerie,
             'zyklus' => $this->editZyklus ?: null,
+            'erstveroeffentlicht_am' => $erstveroeffentlichtAm,
             'roman_nr' => $this->editNummer,
             'titel' => $sichererTitel,
             'dateiname' => $neuerDateiname,

--- a/app/Livewire/KompendiumAdminDashboard.php
+++ b/app/Livewire/KompendiumAdminDashboard.php
@@ -55,7 +55,7 @@ class KompendiumAdminDashboard extends Component
 
     public string $editTitel = '';
 
-    public string $editErstveroeffentlichtAm = '';
+    public ?string $editErstveroeffentlichtAm = null;
 
     /** Timestamp für Optimistic Locking beim Bearbeiten */
     public ?string $editUpdatedAt = null;
@@ -223,7 +223,7 @@ class KompendiumAdminDashboard extends Component
         $this->editZyklus = $roman->zyklus ?? '';
         $this->editNummer = $roman->roman_nr;
         $this->editTitel = $roman->titel;
-        $this->editErstveroeffentlichtAm = $roman->erstveroeffentlicht_am?->toDateString() ?? '';
+        $this->editErstveroeffentlichtAm = $roman->erstveroeffentlicht_am?->toDateString();
         $this->editUpdatedAt = $roman->updated_at?->toISOString();
         $this->showEditModal = true;
     }
@@ -233,6 +233,10 @@ class KompendiumAdminDashboard extends Component
      */
     public function speichern(): void
     {
+        $this->editErstveroeffentlichtAm = filled($this->editErstveroeffentlichtAm)
+            ? $this->editErstveroeffentlichtAm
+            : null;
+
         $this->validate([
             'editId' => 'required|integer|exists:kompendium_romane,id',
             'editSerie' => ['required', Rule::in(array_keys(KompendiumService::SERIEN))],
@@ -311,7 +315,7 @@ class KompendiumAdminDashboard extends Component
         }
 
         $service = app(KompendiumService::class);
-        $erstveroeffentlichtAm = $this->editErstveroeffentlichtAm !== ''
+        $erstveroeffentlichtAm = filled($this->editErstveroeffentlichtAm)
             ? $this->editErstveroeffentlichtAm
             : $service->findeErstveroeffentlichtAm($this->editSerie, $this->editNummer, $sichererTitel)?->toDateString();
 

--- a/app/Livewire/KompendiumSuche.php
+++ b/app/Livewire/KompendiumSuche.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use App\Models\KompendiumRoman;
 use App\Services\KompendiumSearchService;
+use App\Services\KompendiumSearchSorter;
 use App\Services\KompendiumService;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -15,6 +16,10 @@ class KompendiumSuche extends Component
     public string $query = '';
 
     public array $selectedSerien = [];
+
+    public string $sort = KompendiumSearchSorter::SORT_RELEVANCE;
+
+    public string $direction = KompendiumSearchSorter::DIRECTION_DESC;
 
     public array $results = [];
 
@@ -94,6 +99,31 @@ class KompendiumSuche extends Component
         }
     }
 
+    public function updatedSort(): void
+    {
+        $sorter = app(KompendiumSearchSorter::class);
+        $this->sort = $sorter->normalizeSort($this->sort);
+        $this->direction = $sorter->defaultDirectionForSort($this->sort);
+        $this->refreshSearchIfReady();
+    }
+
+    public function updatedDirection(): void
+    {
+        $sorter = app(KompendiumSearchSorter::class);
+        $this->sort = $sorter->normalizeSort($this->sort);
+        $this->direction = $sorter->normalizeDirection($this->direction, $this->sort);
+        $this->refreshSearchIfReady();
+    }
+
+    private function refreshSearchIfReady(): void
+    {
+        if ($this->hasSearched && mb_strlen(trim($this->query)) >= 2) {
+            $this->page = 1;
+            $this->results = [];
+            $this->executeSearch();
+        }
+    }
+
     private function executeSearch(): void
     {
         try {
@@ -101,6 +131,9 @@ class KompendiumSuche extends Component
             $this->candidatesTruncated = false;
             $this->scannedCandidates = 0;
             $searchService = app(KompendiumSearchService::class);
+            $sorter = app(KompendiumSearchSorter::class);
+            $this->sort = $sorter->normalizeSort($this->sort);
+            $this->direction = $sorter->normalizeDirection($this->direction, $this->sort);
             $query = mb_strtolower(trim($this->query));
             $perPage = 5;
             $snippetsPerFile = config('kompendium.snippets_per_novel', 10) ?: 10;
@@ -132,7 +165,9 @@ class KompendiumSuche extends Component
             $ids = array_values(array_filter($ids, fn ($path) => $this->isValidPath($path)));
 
             $textCache = [];
-            $requiredMatches = ($this->page + 1) * $perPage;
+            $requiredMatches = $sorter->needsFullPostFilter($this->sort, $this->direction)
+                ? PHP_INT_MAX
+                : (($this->page + 1) * $perPage);
             $postFilterBudget = $searchService->postFilterBudget();
             $selectedSerienLookup = array_fill_keys($this->selectedSerien, true);
 
@@ -184,6 +219,10 @@ class KompendiumSuche extends Component
                     fn ($path) => in_array($pathToSerie[$path], $this->selectedSerien, true)
                 ));
             }
+
+            $ordered = $sorter->orderPathsWithMetadata($ids, $this->sort, $this->direction);
+            $ids = $ordered['paths'];
+            $pathMetadata = $ordered['metadata'];
 
             $total = count($ids);
             $slice = array_slice($ids, ($this->page - 1) * $perPage, $perPage);
@@ -237,6 +276,8 @@ class KompendiumSuche extends Component
                     'romanNr' => $romanNr,
                     'title' => $title,
                     'serie' => $serie,
+                    'erstveroeffentlichtAm' => $pathMetadata[$path]['erstveroeffentlichtAm'] ?? null,
+                    'erstveroeffentlichtAmFormatted' => $pathMetadata[$path]['erstveroeffentlichtAmFormatted'] ?? null,
                     'snippets' => $snippets,
                 ];
             }

--- a/app/Models/KompendiumRoman.php
+++ b/app/Models/KompendiumRoman.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property int $roman_nr
  * @property string $titel
  * @property string|null $zyklus
+ * @property Carbon|null $erstveroeffentlicht_am
  * @property Carbon $hochgeladen_am
  * @property int $hochgeladen_von
  * @property Carbon|null $indexiert_am
@@ -35,6 +36,7 @@ class KompendiumRoman extends Model
         'roman_nr',
         'titel',
         'zyklus',
+        'erstveroeffentlicht_am',
         'hochgeladen_am',
         'hochgeladen_von',
         'indexiert_am',
@@ -43,6 +45,7 @@ class KompendiumRoman extends Model
     ];
 
     protected $casts = [
+        'erstveroeffentlicht_am' => 'date',
         'hochgeladen_am' => 'datetime',
         'indexiert_am' => 'datetime',
         'roman_nr' => 'integer',

--- a/app/Services/KompendiumSearchSorter.php
+++ b/app/Services/KompendiumSearchSorter.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\KompendiumRoman;
+
+class KompendiumSearchSorter
+{
+    public const SORT_RELEVANCE = 'relevance';
+
+    public const SORT_FIRST_PUBLISHED = 'first_published';
+
+    public const DIRECTION_ASC = 'asc';
+
+    public const DIRECTION_DESC = 'desc';
+
+    private const VERY_OLD_DATE = '0000-01-01';
+
+    /**
+     * @return list<string>
+     */
+    public function validSorts(): array
+    {
+        return [self::SORT_RELEVANCE, self::SORT_FIRST_PUBLISHED];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function validDirections(): array
+    {
+        return [self::DIRECTION_ASC, self::DIRECTION_DESC];
+    }
+
+    public function normalizeSort(mixed $sort): string
+    {
+        return in_array($sort, $this->validSorts(), true)
+            ? $sort
+            : self::SORT_RELEVANCE;
+    }
+
+    public function normalizeDirection(mixed $direction, string $sort): string
+    {
+        return in_array($direction, $this->validDirections(), true)
+            ? $direction
+            : $this->defaultDirectionForSort($sort);
+    }
+
+    public function defaultDirectionForSort(string $sort): string
+    {
+        return $sort === self::SORT_FIRST_PUBLISHED
+            ? self::DIRECTION_ASC
+            : self::DIRECTION_DESC;
+    }
+
+    public function needsFullPostFilter(string $sort, string $direction): bool
+    {
+        return $sort === self::SORT_FIRST_PUBLISHED
+            || ($sort === self::SORT_RELEVANCE && $direction === self::DIRECTION_ASC);
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return array{paths: list<string>, metadata: array<string, array{erstveroeffentlichtAm: string|null, erstveroeffentlichtAmFormatted: string|null, serie: string, romanNrSort: int}>}
+     */
+    public function orderPathsWithMetadata(array $paths, string $sort, string $direction): array
+    {
+        $metadata = $this->metadataForPaths($paths);
+
+        if ($sort === self::SORT_RELEVANCE) {
+            return [
+                'paths' => $direction === self::DIRECTION_ASC ? array_reverse($paths) : $paths,
+                'metadata' => $metadata,
+            ];
+        }
+
+        $indexedPaths = [];
+
+        foreach ($paths as $position => $path) {
+            $indexedPaths[] = [
+                'path' => $path,
+                'position' => $position,
+            ];
+        }
+
+        usort($indexedPaths, function (array $a, array $b) use ($metadata, $direction): int {
+            $pathA = $a['path'];
+            $pathB = $b['path'];
+            $metaA = $metadata[$pathA] ?? $this->fallbackMetadata($pathA);
+            $metaB = $metadata[$pathB] ?? $this->fallbackMetadata($pathB);
+
+            $dateA = $metaA['erstveroeffentlichtAm'] ?? self::VERY_OLD_DATE;
+            $dateB = $metaB['erstveroeffentlichtAm'] ?? self::VERY_OLD_DATE;
+            $dateComparison = strcmp($dateA, $dateB);
+
+            if ($dateComparison !== 0) {
+                return $direction === self::DIRECTION_ASC ? $dateComparison : -$dateComparison;
+            }
+
+            $serieComparison = strcmp($metaA['serie'], $metaB['serie']);
+
+            if ($serieComparison !== 0) {
+                return $serieComparison;
+            }
+
+            $romanComparison = $metaA['romanNrSort'] <=> $metaB['romanNrSort'];
+
+            if ($romanComparison !== 0) {
+                return $romanComparison;
+            }
+
+            $pathComparison = strcmp($pathA, $pathB);
+
+            if ($pathComparison !== 0) {
+                return $pathComparison;
+            }
+
+            return $a['position'] <=> $b['position'];
+        });
+
+        return [
+            'paths' => array_values(array_map(fn (array $entry): string => $entry['path'], $indexedPaths)),
+            'metadata' => $metadata,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return array<string, array{erstveroeffentlichtAm: string|null, erstveroeffentlichtAmFormatted: string|null, serie: string, romanNrSort: int}>
+     */
+    private function metadataForPaths(array $paths): array
+    {
+        $uniquePaths = array_values(array_unique($paths));
+        $romane = KompendiumRoman::query()
+            ->whereIn('dateipfad', $uniquePaths)
+            ->get()
+            ->keyBy('dateipfad');
+
+        $metadata = [];
+
+        foreach ($uniquePaths as $path) {
+            /** @var KompendiumRoman|null $roman */
+            $roman = $romane->get($path);
+
+            $metadata[$path] = [
+                'erstveroeffentlichtAm' => $roman?->erstveroeffentlicht_am?->toDateString(),
+                'erstveroeffentlichtAmFormatted' => $roman?->erstveroeffentlicht_am?->format('d.m.Y'),
+                'serie' => $roman?->serie ?? $this->extractSerie($path),
+                'romanNrSort' => $roman?->roman_nr ?? $this->extractRomanNr($path),
+            ];
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * @return array{erstveroeffentlichtAm: string|null, erstveroeffentlichtAmFormatted: string|null, serie: string, romanNrSort: int}
+     */
+    private function fallbackMetadata(string $path): array
+    {
+        return [
+            'erstveroeffentlichtAm' => null,
+            'erstveroeffentlichtAmFormatted' => null,
+            'serie' => $this->extractSerie($path),
+            'romanNrSort' => $this->extractRomanNr($path),
+        ];
+    }
+
+    private function extractSerie(string $path): string
+    {
+        $parts = preg_split('#[\\\\\/]+#', $path);
+
+        return $parts[1] ?? 'unknown';
+    }
+
+    private function extractRomanNr(string $path): int
+    {
+        $filename = pathinfo($path, PATHINFO_FILENAME);
+
+        if (preg_match('/^(\d+)/', $filename, $matches) !== 1) {
+            return PHP_INT_MAX;
+        }
+
+        return (int) $matches[1];
+    }
+}

--- a/app/Services/KompendiumSearchSorter.php
+++ b/app/Services/KompendiumSearchSorter.php
@@ -16,6 +16,8 @@ class KompendiumSearchSorter
 
     private const VERY_OLD_DATE = '0000-01-01';
 
+    private const METADATA_PATH_CHUNK_SIZE = 500;
+
     /**
      * @return list<string>
      */
@@ -131,16 +133,29 @@ class KompendiumSearchSorter
     private function metadataForPaths(array $paths): array
     {
         $uniquePaths = array_values(array_unique($paths));
-        $romane = KompendiumRoman::query()
-            ->whereIn('dateipfad', $uniquePaths)
-            ->get()
-            ->keyBy('dateipfad');
+
+        if ($uniquePaths === []) {
+            return [];
+        }
+
+        $romane = [];
+
+        foreach (array_chunk($uniquePaths, self::METADATA_PATH_CHUNK_SIZE) as $pathChunk) {
+            foreach (
+                KompendiumRoman::query()
+                    ->select(['dateipfad', 'serie', 'roman_nr', 'erstveroeffentlicht_am'])
+                    ->whereIn('dateipfad', $pathChunk)
+                    ->get() as $roman
+            ) {
+                $romane[$roman->dateipfad] = $roman;
+            }
+        }
 
         $metadata = [];
 
         foreach ($uniquePaths as $path) {
             /** @var KompendiumRoman|null $roman */
-            $roman = $romane->get($path);
+            $roman = $romane[$path] ?? null;
 
             $metadata[$path] = [
                 'erstveroeffentlichtAm' => $roman?->erstveroeffentlicht_am?->toDateString(),

--- a/app/Services/KompendiumService.php
+++ b/app/Services/KompendiumService.php
@@ -236,7 +236,17 @@ class KompendiumService
         $dateString = preg_replace('/\s+/', ' ', $dateString) ?? $dateString;
 
         if (preg_match('/^\d{4}$/', $dateString) === 1) {
-            return Carbon::create((int) $dateString, 1, 1)->startOfDay();
+            $year = (int) $dateString;
+
+            if ($year < 1) {
+                return null;
+            }
+
+            try {
+                return Carbon::create($year, 1, 1)->startOfDay();
+            } catch (\Throwable) {
+                return null;
+            }
         }
 
         if (preg_match('/^\d{4}-\d{1,2}$/', $dateString) === 1) {

--- a/app/Services/KompendiumService.php
+++ b/app/Services/KompendiumService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\KompendiumRoman;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 /**
@@ -25,6 +26,17 @@ class KompendiumService
         'volkdertiefe' => 'Das Volk der Tiefe',
         '2012' => '2012 - Das Jahr der Apokalypse',
         'abenteurer' => 'Die Abenteurer',
+    ];
+
+    private const PUBLICATION_DATE_FIELDS = [
+        'erstveroeffentlicht_am',
+        'erstveroeffentlicht',
+        'erstveroeffentlichung',
+        'evt',
+        'release_date',
+        'published_at',
+        'publication_date',
+        'datum',
     ];
 
     public function __construct(
@@ -53,7 +65,7 @@ class KompendiumService
     /**
      * Findet Metadaten (Zyklus) für einen Roman aus allen Serien.
      *
-     * @return array{serie: string, serie_name: string, zyklus: string|null, roman: array}|null
+     * @return array{serie: string, serie_name: string, zyklus: string|null, erstveroeffentlicht_am: Carbon|null, roman: array}|null
      */
     public function findeMetadaten(int $nummer, string $titel): ?array
     {
@@ -69,6 +81,7 @@ class KompendiumService
                     'serie' => $serienKey,
                     'serie_name' => $serienName,
                     'zyklus' => $roman['zyklus'] ?? null,
+                    'erstveroeffentlicht_am' => $this->erstveroeffentlichtAmAusMetadaten($roman),
                     'roman' => $roman,
                 ];
             }
@@ -85,7 +98,7 @@ class KompendiumService
      * 2. Normalisierter Match (case-insensitive + Sonderzeichen bereinigt)
      * 3. Nummer-Match (eindeutig über alle Serien)
      *
-     * @return array{serie: string, serie_name: string, zyklus: string|null, roman: array, match_typ: string}|null
+     * @return array{serie: string, serie_name: string, zyklus: string|null, erstveroeffentlicht_am: Carbon|null, roman: array, match_typ: string}|null
      */
     public function findeMetadatenMitFuzzy(int $nummer, string $titel): ?array
     {
@@ -106,6 +119,7 @@ class KompendiumService
                     'serie' => $serienKey,
                     'serie_name' => $serienName,
                     'zyklus' => $roman['zyklus'] ?? null,
+                    'erstveroeffentlicht_am' => $this->erstveroeffentlichtAmAusMetadaten($roman),
                     'roman' => $roman,
                     'match_typ' => 'exakt',
                 ];
@@ -121,6 +135,7 @@ class KompendiumService
                     'serie' => $serienKey,
                     'serie_name' => $serienName,
                     'zyklus' => $roman['zyklus'] ?? null,
+                    'erstveroeffentlicht_am' => $this->erstveroeffentlichtAmAusMetadaten($roman),
                     'roman' => $roman,
                     'match_typ' => 'normalisiert',
                 ];
@@ -135,6 +150,8 @@ class KompendiumService
                     'nummer' => $r['nummer'],
                     'titel' => $r['titel'] ?? '',
                     'zyklus' => $r['zyklus'] ?? null,
+                    'erstveroeffentlicht_am' => $this->erstveroeffentlichtAmAusMetadaten($r),
+                    'roman' => $r,
                 ]);
             }
         }
@@ -147,12 +164,118 @@ class KompendiumService
                 'serie' => $match['serie'],
                 'serie_name' => $match['serie_name'],
                 'zyklus' => $match['zyklus'],
-                'roman' => $match,
+                'erstveroeffentlicht_am' => $match['erstveroeffentlicht_am'],
+                'roman' => $match['roman'],
                 'match_typ' => 'nummer',
             ];
         }
 
         return null;
+    }
+
+    public function findeErstveroeffentlichtAm(string $serienKey, int $nummer, string $titel): ?Carbon
+    {
+        if (! array_key_exists($serienKey, self::SERIEN)) {
+            return null;
+        }
+
+        $serie = $this->maddraxDataService->getSeries($serienKey);
+        $normalisiertTitel = $this->normalisiereTitel($titel);
+
+        $roman = $serie->first(fn ($r) => ($r['nummer'] ?? null) === $nummer &&
+            ($r['titel'] ?? '') === $titel
+        );
+
+        if (! $roman) {
+            $roman = $serie->first(fn ($r) => ($r['nummer'] ?? null) === $nummer &&
+                $this->normalisiereTitel($r['titel'] ?? '') === $normalisiertTitel
+            );
+        }
+
+        if (! $roman) {
+            return null;
+        }
+
+        return $this->erstveroeffentlichtAmAusMetadaten($roman);
+    }
+
+    public function erstveroeffentlichtAmAusMetadaten(array $roman): ?Carbon
+    {
+        foreach (self::PUBLICATION_DATE_FIELDS as $field) {
+            if (! array_key_exists($field, $roman)) {
+                continue;
+            }
+
+            $date = $this->parseErstveroeffentlichtAm($roman[$field]);
+
+            if ($date !== null) {
+                return $date;
+            }
+        }
+
+        return null;
+    }
+
+    public function parseErstveroeffentlichtAm(mixed $value): ?Carbon
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value)->startOfDay();
+        }
+
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $dateString = trim((string) $value);
+
+        if ($dateString === '') {
+            return null;
+        }
+
+        $dateString = str_replace("\u{00A0}", ' ', $dateString);
+        $dateString = preg_replace('/\s+/', ' ', $dateString) ?? $dateString;
+
+        if (preg_match('/^\d{4}$/', $dateString) === 1) {
+            return Carbon::create((int) $dateString, 1, 1)->startOfDay();
+        }
+
+        if (preg_match('/^\d{4}-\d{1,2}$/', $dateString) === 1) {
+            try {
+                return Carbon::createFromFormat('Y-m', $dateString)->startOfMonth();
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        if (preg_match('/^\d{1,2}\.\s*\d{1,2}\.\s*\d{4}$/', $dateString) === 1) {
+            try {
+                return Carbon::createFromFormat('d.m.Y', str_replace(' ', '', $dateString))->startOfDay();
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        $normalisiert = strtr($dateString, [
+            'Januar' => 'January',
+            'Februar' => 'February',
+            'Maerz' => 'March',
+            'März' => 'March',
+            'April' => 'April',
+            'Mai' => 'May',
+            'Juni' => 'June',
+            'Juli' => 'July',
+            'August' => 'August',
+            'September' => 'September',
+            'Oktober' => 'October',
+            'November' => 'November',
+            'Dezember' => 'December',
+        ]);
+
+        try {
+            return Carbon::parse($normalisiert)->startOfDay();
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/database/migrations/2026_06_07_120000_add_erstveroeffentlicht_am_to_kompendium_romane_table.php
+++ b/database/migrations/2026_06_07_120000_add_erstveroeffentlicht_am_to_kompendium_romane_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('kompendium_romane', function (Blueprint $table) {
+            $table->date('erstveroeffentlicht_am')->nullable()->after('zyklus');
+            $table->index(['status', 'serie', 'erstveroeffentlicht_am'], 'komp_romane_status_serie_evt_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('kompendium_romane', function (Blueprint $table) {
+            $table->dropIndex('komp_romane_status_serie_evt_idx');
+            $table->dropColumn('erstveroeffentlicht_am');
+        });
+    }
+};

--- a/resources/views/livewire/kompendium-admin-dashboard.blade.php
+++ b/resources/views/livewire/kompendium-admin-dashboard.blade.php
@@ -220,7 +220,7 @@
         <x-ui.panel title="Romanliste" description="Bearbeite Metadaten, starte Indexierung oder bereinige Einträge direkt aus der tabellarischen Übersicht." data-testid="novels-table-card" wire:poll.5s>
             {{-- Skeleton Loading State --}}
             <div wire:loading.delay wire:target="bearbeiten, indexieren, deIndexieren, retryFehler, loeschen, alleIndexieren, alleDeIndexieren, filterStatus, suchbegriff">
-                <x-skeleton-table :columns="6" :rows="10" />
+                <x-skeleton-table :columns="7" :rows="10" />
             </div>
             <div wire:loading.remove wire:target="bearbeiten, indexieren, deIndexieren, retryFehler, loeschen, alleIndexieren, alleDeIndexieren, filterStatus, suchbegriff">
             <div class="overflow-x-auto">
@@ -230,6 +230,7 @@
                             <th>Nr.</th>
                             <th>Titel</th>
                             <th>Zyklus</th>
+                            <th>Erstveroeffentlicht</th>
                             <th>Status</th>
                             <th>Hochgeladen</th>
                             <th class="text-right">Aktionen</th>
@@ -251,6 +252,9 @@
                                 </td>
                                 <td class="text-base-content">
                                     {{ $roman->zyklus ?? '-' }}
+                                </td>
+                                <td class="text-base-content">
+                                    {{ $roman->erstveroeffentlicht_am?->format('d.m.Y') ?? '-' }}
                                 </td>
                                 <td>
                                     @switch($roman->status)
@@ -322,7 +326,7 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="6" class="text-center py-8 text-base-content">
+                                <td colspan="7" class="text-center py-8 text-base-content">
                                     @if($filterStatus || $suchbegriff)
                                         <x-icon name="o-funnel" class="w-12 h-12 mx-auto mb-2 opacity-30" />
                                         Keine Romane gefunden, die den Filterkriterien entsprechen.
@@ -386,7 +390,18 @@
                     wire:model="editTitel"
                     data-testid="edit-titel" />
 
+                <x-input
+                    label="Erstveroeffentlicht am"
+                    type="date"
+                    wire:model="editErstveroeffentlichtAm"
+                    hint="Leer lassen, um das Datum aus den Serien-Metadaten zu uebernehmen, falls vorhanden."
+                    data-testid="edit-erstveroeffentlicht-am" />
+
                 @error('editTitel')
+                    <span class="text-error text-sm">{{ $message }}</span>
+                @enderror
+
+                @error('editErstveroeffentlichtAm')
                     <span class="text-error text-sm">{{ $message }}</span>
                 @enderror
             </div>

--- a/resources/views/livewire/kompendium-suche.blade.php
+++ b/resources/views/livewire/kompendium-suche.blade.php
@@ -49,6 +49,36 @@
                 wire:target="performSearch"
             />
         </div>
+
+        <div class="mt-4 grid gap-3 sm:grid-cols-2">
+            <label class="form-control w-full">
+                <span class="label">
+                    <span class="label-text text-sm font-semibold text-base-content/70">Sortieren nach</span>
+                </span>
+                <select
+                    wire:model.live="sort"
+                    class="select select-bordered w-full"
+                    data-testid="kompendium-sort-field"
+                >
+                    <option value="relevance">Relevanz</option>
+                    <option value="first_published">Erstveroeffentlichung</option>
+                </select>
+            </label>
+
+            <label class="form-control w-full">
+                <span class="label">
+                    <span class="label-text text-sm font-semibold text-base-content/70">Reihenfolge</span>
+                </span>
+                <select
+                    wire:model.live="direction"
+                    class="select select-bordered w-full"
+                    data-testid="kompendium-sort-direction"
+                >
+                    <option value="desc">Absteigend</option>
+                    <option value="asc">Aufsteigend</option>
+                </select>
+            </label>
+        </div>
     </section>
 
     @if(count($this->verfuegbareSerien) >= 2)
@@ -183,6 +213,11 @@
                 <h3 class="mb-2 font-semibold text-primary">
                     {{ $hit['cycle'] }} – {{ $hit['romanNr'] }}: {{ $hit['title'] }}
                 </h3>
+                @if(!empty($hit['erstveroeffentlichtAmFormatted']))
+                    <p class="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-base-content/50">
+                        Erstveroeffentlicht: {{ $hit['erstveroeffentlichtAmFormatted'] }}
+                    </p>
+                @endif
                 {{-- Snippet-HTML ist sicher: Segmente werden mit e() escaped,
                      nur <mark>-Tags werden für Treffer-Highlighting eingefügt. --}}
                 @foreach($hit['snippets'] as $snippet)

--- a/tests/Feature/BackfillKompendiumPublicationDatesTest.php
+++ b/tests/Feature/BackfillKompendiumPublicationDatesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\KompendiumRoman;
+use App\Models\User;
+use App\Services\KompendiumService;
+use App\Services\MaddraxDataService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BackfillKompendiumPublicationDatesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_backfills_publication_dates_from_metadata(): void
+    {
+        $maddraxDataService = $this->createStub(MaddraxDataService::class);
+        $maddraxDataService
+            ->method('getSeries')
+            ->willReturnCallback(fn (string $key) => collect($key === 'maddrax' ? [
+                ['nummer' => 1, 'titel' => 'Der Gott aus dem Eis', 'zyklus' => 'Euree', 'evt' => '1999-02-16'],
+            ] : []));
+
+        $this->app->instance(KompendiumService::class, new KompendiumService($maddraxDataService));
+
+        $user = User::factory()->create();
+
+        $roman = KompendiumRoman::create([
+            'dateiname' => '001 - Der Gott aus dem Eis.txt',
+            'dateipfad' => 'romane/maddrax/001 - Der Gott aus dem Eis.txt',
+            'serie' => 'maddrax',
+            'roman_nr' => 1,
+            'titel' => 'Der Gott aus dem Eis',
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $user->id,
+            'status' => 'indexiert',
+        ]);
+
+        $this->artisan('kompendium:backfill-publication-dates')
+            ->expectsOutput('1 aktualisiert, 0 unveraendert, 0 ohne Datum.')
+            ->assertSuccessful();
+
+        $this->assertSame('1999-02-16', $roman->fresh()->erstveroeffentlicht_am?->toDateString());
+    }
+}

--- a/tests/Feature/BackfillKompendiumPublicationDatesTest.php
+++ b/tests/Feature/BackfillKompendiumPublicationDatesTest.php
@@ -7,6 +7,8 @@ use App\Models\User;
 use App\Services\KompendiumService;
 use App\Services\MaddraxDataService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class BackfillKompendiumPublicationDatesTest extends TestCase
@@ -49,6 +51,46 @@ class BackfillKompendiumPublicationDatesTest extends TestCase
             ->assertSuccessful();
 
         $this->assertSame('1999-02-16', $roman->fresh()->erstveroeffentlicht_am?->toDateString());
+    }
+
+    public function test_command_updates_timestamp_when_backfilling_publication_date(): void
+    {
+        $this->bindKompendiumMetadata([
+            'maddrax' => [
+                ['nummer' => 1, 'titel' => 'Der Gott aus dem Eis', 'zyklus' => 'Euree', 'evt' => '1999-02-16'],
+            ],
+        ]);
+
+        $user = User::factory()->create();
+
+        $roman = KompendiumRoman::create([
+            'dateiname' => '001 - Der Gott aus dem Eis.txt',
+            'dateipfad' => 'romane/maddrax/001 - Der Gott aus dem Eis.txt',
+            'serie' => 'maddrax',
+            'roman_nr' => 1,
+            'titel' => 'Der Gott aus dem Eis',
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $user->id,
+            'status' => 'indexiert',
+        ]);
+
+        DB::table('kompendium_romane')
+            ->where('id', $roman->id)
+            ->update(['updated_at' => '2026-01-01 00:00:00']);
+
+        Carbon::setTestNow($now = Carbon::parse('2026-06-07 12:34:56'));
+
+        try {
+            $this->artisan('kompendium:backfill-publication-dates')
+                ->expectsOutput('1 aktualisiert, 0 unveraendert, 0 ohne Datum.')
+                ->assertSuccessful();
+        } finally {
+            Carbon::setTestNow();
+        }
+
+        $roman->refresh();
+        $this->assertSame('1999-02-16', $roman->erstveroeffentlicht_am?->toDateString());
+        $this->assertSame($now->toDateTimeString(), $roman->updated_at?->toDateTimeString());
     }
 
     public function test_command_does_not_overwrite_existing_publication_dates(): void

--- a/tests/Feature/BackfillKompendiumPublicationDatesTest.php
+++ b/tests/Feature/BackfillKompendiumPublicationDatesTest.php
@@ -13,16 +13,23 @@ class BackfillKompendiumPublicationDatesTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_command_backfills_publication_dates_from_metadata(): void
+    private function bindKompendiumMetadata(array $seriesByKey): void
     {
         $maddraxDataService = $this->createStub(MaddraxDataService::class);
         $maddraxDataService
             ->method('getSeries')
-            ->willReturnCallback(fn (string $key) => collect($key === 'maddrax' ? [
-                ['nummer' => 1, 'titel' => 'Der Gott aus dem Eis', 'zyklus' => 'Euree', 'evt' => '1999-02-16'],
-            ] : []));
+            ->willReturnCallback(fn (string $key) => collect($seriesByKey[$key] ?? []));
 
         $this->app->instance(KompendiumService::class, new KompendiumService($maddraxDataService));
+    }
+
+    public function test_command_backfills_publication_dates_from_metadata(): void
+    {
+        $this->bindKompendiumMetadata([
+            'maddrax' => [
+                ['nummer' => 1, 'titel' => 'Der Gott aus dem Eis', 'zyklus' => 'Euree', 'evt' => '1999-02-16'],
+            ],
+        ]);
 
         $user = User::factory()->create();
 
@@ -42,5 +49,34 @@ class BackfillKompendiumPublicationDatesTest extends TestCase
             ->assertSuccessful();
 
         $this->assertSame('1999-02-16', $roman->fresh()->erstveroeffentlicht_am?->toDateString());
+    }
+
+    public function test_command_does_not_overwrite_existing_publication_dates(): void
+    {
+        $this->bindKompendiumMetadata([
+            'maddrax' => [
+                ['nummer' => 1, 'titel' => 'Der Gott aus dem Eis', 'zyklus' => 'Euree', 'evt' => '1999-02-16'],
+            ],
+        ]);
+
+        $user = User::factory()->create();
+
+        $roman = KompendiumRoman::create([
+            'dateiname' => '001 - Der Gott aus dem Eis.txt',
+            'dateipfad' => 'romane/maddrax/001 - Der Gott aus dem Eis.txt',
+            'serie' => 'maddrax',
+            'roman_nr' => 1,
+            'titel' => 'Der Gott aus dem Eis',
+            'erstveroeffentlicht_am' => '2000-01-01',
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $user->id,
+            'status' => 'indexiert',
+        ]);
+
+        $this->artisan('kompendium:backfill-publication-dates')
+            ->expectsOutput('0 aktualisiert, 1 unveraendert, 0 ohne Datum.')
+            ->assertSuccessful();
+
+        $this->assertSame('2000-01-01', $roman->fresh()->erstveroeffentlicht_am?->toDateString());
     }
 }

--- a/tests/Feature/KompendiumAdminTest.php
+++ b/tests/Feature/KompendiumAdminTest.php
@@ -56,6 +56,39 @@ class KompendiumAdminTest extends TestCase
         $this->app->instance(KompendiumService::class, new KompendiumService($maddraxDataService));
     }
 
+    private function assertSpeichernNutztMetadatenFallbackBeiGeleertemDatum(?string $datum): void
+    {
+        $this->bindKompendiumMetadata([
+            'maddrax' => [
+                ['nummer' => 1, 'titel' => 'Der Gott aus dem Eis', 'zyklus' => 'Euree', 'evt' => '1999-02-16'],
+            ],
+        ]);
+
+        Storage::disk('private')->put('romane/maddrax/001 - Der Gott aus dem Eis.txt', 'Inhalt');
+
+        $roman = KompendiumRoman::create([
+            'dateiname' => '001 - Der Gott aus dem Eis.txt',
+            'dateipfad' => 'romane/maddrax/001 - Der Gott aus dem Eis.txt',
+            'serie' => 'maddrax',
+            'roman_nr' => 1,
+            'titel' => 'Der Gott aus dem Eis',
+            'erstveroeffentlicht_am' => '2000-01-01',
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $this->admin->id,
+            'status' => 'hochgeladen',
+        ]);
+
+        Livewire::actingAs($this->admin)
+            ->test(KompendiumAdminDashboard::class)
+            ->call('bearbeiten', $roman->id)
+            ->set('editErstveroeffentlichtAm', $datum)
+            ->call('speichern')
+            ->assertHasNoErrors()
+            ->assertSet('showEditModal', false);
+
+        $this->assertSame('1999-02-16', $roman->fresh()->erstveroeffentlicht_am?->toDateString());
+    }
+
     #[Test]
     public function admin_kann_kompendium_admin_seite_aufrufen(): void
     {
@@ -515,6 +548,18 @@ class KompendiumAdminTest extends TestCase
         // Datei wurde verschoben
         Storage::disk('private')->assertExists('romane/missionmars/005 - NeuerTitel.txt');
         Storage::disk('private')->assertMissing('romane/maddrax/001 - AlterTitel.txt');
+    }
+
+    #[Test]
+    public function speichern_nutzt_metadaten_fallback_wenn_erstveroeffentlichungsdatum_als_leerer_string_geleert_wird(): void
+    {
+        $this->assertSpeichernNutztMetadatenFallbackBeiGeleertemDatum('');
+    }
+
+    #[Test]
+    public function speichern_nutzt_metadaten_fallback_wenn_erstveroeffentlichungsdatum_null_ist(): void
+    {
+        $this->assertSpeichernNutztMetadatenFallbackBeiGeleertemDatum(null);
     }
 
     #[Test]

--- a/tests/Feature/KompendiumAdminTest.php
+++ b/tests/Feature/KompendiumAdminTest.php
@@ -9,6 +9,8 @@ use App\Livewire\KompendiumAdminDashboard;
 use App\Models\KompendiumRoman;
 use App\Models\Team;
 use App\Models\User;
+use App\Services\KompendiumService;
+use App\Services\MaddraxDataService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Log;
@@ -42,6 +44,16 @@ class KompendiumAdminTest extends TestCase
         // Normaler User
         $this->normalUser = User::factory()->create(['current_team_id' => $team->id]);
         $team->users()->attach($this->normalUser, ['role' => Role::Mitglied->value]);
+    }
+
+    private function bindKompendiumMetadata(array $seriesByKey): void
+    {
+        $maddraxDataService = $this->createStub(MaddraxDataService::class);
+        $maddraxDataService
+            ->method('getSeries')
+            ->willReturnCallback(fn (string $key) => collect($seriesByKey[$key] ?? []));
+
+        $this->app->instance(KompendiumService::class, new KompendiumService($maddraxDataService));
     }
 
     #[Test]
@@ -92,6 +104,30 @@ class KompendiumAdminTest extends TestCase
         ]);
 
         Storage::disk('private')->assertExists('romane/maddrax/001 - Der Gott aus dem Eis.txt');
+    }
+
+    #[Test]
+    public function upload_uebernimmt_erstveroeffentlichungsdatum_aus_metadaten(): void
+    {
+        $this->bindKompendiumMetadata([
+            'maddrax' => [
+                ['nummer' => 1, 'titel' => 'Der Gott aus dem Eis', 'zyklus' => 'Euree', 'evt' => '1999-02-16'],
+            ],
+        ]);
+
+        $file = UploadedFile::fake()->create('001 - Der Gott aus dem Eis.txt', 100, 'text/plain');
+
+        Livewire::actingAs($this->admin)
+            ->test(KompendiumAdminDashboard::class)
+            ->set('uploads', [$file])
+            ->set('ausgewaehlteSerie', 'maddrax')
+            ->call('hochladen')
+            ->assertHasNoErrors();
+
+        $roman = KompendiumRoman::query()->firstWhere('dateipfad', 'romane/maddrax/001 - Der Gott aus dem Eis.txt');
+
+        $this->assertNotNull($roman);
+        $this->assertSame('1999-02-16', $roman->erstveroeffentlicht_am?->toDateString());
     }
 
     #[Test]
@@ -402,6 +438,7 @@ class KompendiumAdminTest extends TestCase
             'roman_nr' => 1,
             'titel' => 'TestRoman',
             'zyklus' => 'Euree',
+            'erstveroeffentlicht_am' => '2001-02-03',
             'hochgeladen_am' => now(),
             'hochgeladen_von' => $this->admin->id,
             'status' => 'hochgeladen',
@@ -415,7 +452,8 @@ class KompendiumAdminTest extends TestCase
             ->assertSet('editSerie', 'maddrax')
             ->assertSet('editZyklus', 'Euree')
             ->assertSet('editNummer', 1)
-            ->assertSet('editTitel', 'TestRoman');
+            ->assertSet('editTitel', 'TestRoman')
+            ->assertSet('editErstveroeffentlichtAm', '2001-02-03');
     }
 
     #[Test]
@@ -462,6 +500,7 @@ class KompendiumAdminTest extends TestCase
             ->set('editZyklus', '')
             ->set('editNummer', 5)
             ->set('editTitel', 'NeuerTitel')
+            ->set('editErstveroeffentlichtAm', '2005-06-07')
             ->call('speichern')
             ->assertSet('showEditModal', false);
 
@@ -470,6 +509,7 @@ class KompendiumAdminTest extends TestCase
         $this->assertNull($roman->zyklus);
         $this->assertEquals(5, $roman->roman_nr);
         $this->assertEquals('NeuerTitel', $roman->titel);
+        $this->assertSame('2005-06-07', $roman->erstveroeffentlicht_am?->toDateString());
         $this->assertEquals('romane/missionmars/005 - NeuerTitel.txt', $roman->dateipfad);
 
         // Datei wurde verschoben

--- a/tests/Feature/KompendiumControllerTest.php
+++ b/tests/Feature/KompendiumControllerTest.php
@@ -842,6 +842,8 @@ class KompendiumControllerTest extends TestCase
     {
         $user = $this->actingMemberWithPoints(150);
         $this->purchaseKompendiumForUser($user);
+        Config::set('kompendium.post_filter.initial_batch_size', 5);
+        Config::set('kompendium.post_filter.max_candidates_per_request', 20);
 
         $files = [];
         $searchResultPaths = [];

--- a/tests/Feature/KompendiumSearchTest.php
+++ b/tests/Feature/KompendiumSearchTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\KompendiumRoman;
 use App\Models\Reward;
 use App\Models\RewardPurchase;
 use App\Models\User;
@@ -25,6 +26,31 @@ class KompendiumSearchTest extends TestCase
             'reward_id' => $reward->id,
             'cost_baxx' => $reward->cost_baxx,
             'purchased_at' => now(),
+        ]);
+    }
+
+    private function createIndexedSearchRoman(
+        User $user,
+        string $path,
+        string $content,
+        string $serie,
+        int $romanNr,
+        string $titel,
+        ?string $erstveroeffentlichtAm = null,
+    ): void {
+        Storage::disk('private')->put($path, $content);
+
+        KompendiumRoman::create([
+            'dateiname' => basename($path),
+            'dateipfad' => $path,
+            'serie' => $serie,
+            'roman_nr' => $romanNr,
+            'titel' => $titel,
+            'erstveroeffentlicht_am' => $erstveroeffentlichtAm,
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $user->id,
+            'status' => 'indexiert',
+            'indexiert_am' => now(),
         ]);
     }
 
@@ -227,6 +253,20 @@ class KompendiumSearchTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_search_validates_invalid_sort_parameter(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+        $this->purchaseKompendiumForUser($user);
+
+        $this->getJson('/kompendium/suche?q=test&sort=ungueltig')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['sort']);
+
+        $this->getJson('/kompendium/suche?q=test&direction=seitwaerts')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['direction']);
+    }
+
     public function test_search_ignores_path_traversal_attempts(): void
     {
         $user = $this->actingMemberWithPoints(150);
@@ -303,6 +343,117 @@ class KompendiumSearchTest extends TestCase
         $response->assertOk();
         $this->assertCount(2, $response->json('data'));
         $this->assertEquals(2, $response->json('currentPage'));
+    }
+
+    public function test_search_can_reverse_relevance_order(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+        $this->purchaseKompendiumForUser($user);
+
+        Storage::fake('private');
+
+        $ids = [
+            'romane/maddrax/001 - RelevantA.txt',
+            'romane/maddrax/002 - RelevantB.txt',
+            'romane/maddrax/003 - RelevantC.txt',
+        ];
+
+        $this->createIndexedSearchRoman($user, $ids[0], 'Content reverseorder', 'maddrax', 1, 'RelevantA');
+        $this->createIndexedSearchRoman($user, $ids[1], 'Content reverseorder', 'maddrax', 2, 'RelevantB');
+        $this->createIndexedSearchRoman($user, $ids[2], 'Content reverseorder', 'maddrax', 3, 'RelevantC');
+
+        $this->partialMock(KompendiumSearchService::class, function ($mock) use ($ids) {
+            $mock->shouldReceive('search')
+                ->with('reverseorder')
+                ->once()
+                ->andReturn([
+                    'hits' => ['total_hits' => 3],
+                    'ids' => $ids,
+                ]);
+        });
+
+        $response = $this->getJson('/kompendium/suche?q=reverseorder&sort=relevance&direction=asc');
+
+        $response->assertOk();
+        $this->assertSame(['RelevantC', 'RelevantB', 'RelevantA'], array_column($response->json('data'), 'title'));
+        $this->assertSame('relevance', $response->json('sort'));
+        $this->assertSame('asc', $response->json('direction'));
+    }
+
+    public function test_search_sorts_by_publication_date_in_both_directions_with_missing_dates_as_oldest(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+        $this->purchaseKompendiumForUser($user);
+
+        Storage::fake('private');
+
+        $ids = [
+            'romane/maddrax/003 - Neuer Treffer.txt',
+            'romane/maddrax/001 - Ohne Datum.txt',
+            'romane/maddrax/002 - Alter Treffer.txt',
+        ];
+
+        $this->createIndexedSearchRoman($user, $ids[0], 'Content datumsortierung', 'maddrax', 3, 'Neuer Treffer', '2024-01-01');
+        $this->createIndexedSearchRoman($user, $ids[1], 'Content datumsortierung', 'maddrax', 1, 'Ohne Datum');
+        $this->createIndexedSearchRoman($user, $ids[2], 'Content datumsortierung', 'maddrax', 2, 'Alter Treffer', '2020-01-01');
+
+        $this->partialMock(KompendiumSearchService::class, function ($mock) use ($ids) {
+            $mock->shouldReceive('search')
+                ->with('datumsortierung')
+                ->twice()
+                ->andReturn([
+                    'hits' => ['total_hits' => 3],
+                    'ids' => $ids,
+                ]);
+        });
+
+        $ascending = $this->getJson('/kompendium/suche?q=datumsortierung&sort=first_published');
+        $ascending->assertOk();
+        $this->assertSame(['Ohne Datum', 'Alter Treffer', 'Neuer Treffer'], array_column($ascending->json('data'), 'title'));
+        $this->assertSame('first_published', $ascending->json('sort'));
+        $this->assertSame('asc', $ascending->json('direction'));
+
+        $descending = $this->getJson('/kompendium/suche?q=datumsortierung&sort=first_published&direction=desc');
+        $descending->assertOk();
+        $this->assertSame(['Neuer Treffer', 'Alter Treffer', 'Ohne Datum'], array_column($descending->json('data'), 'title'));
+        $this->assertSame('desc', $descending->json('direction'));
+    }
+
+    public function test_search_keeps_series_filter_counts_when_sorting_by_publication_date(): void
+    {
+        $user = $this->actingMemberWithPoints(150);
+        $this->purchaseKompendiumForUser($user);
+
+        Storage::fake('private');
+
+        $ids = [
+            'romane/missionmars/002 - Mars Neuer.txt',
+            'romane/maddrax/002 - Maddrax Neuer.txt',
+            'romane/missionmars/001 - Mars Alter.txt',
+            'romane/maddrax/001 - Maddrax Alter.txt',
+        ];
+
+        $this->createIndexedSearchRoman($user, $ids[0], 'Content serienfilter', 'missionmars', 2, 'Mars Neuer', '2024-01-01');
+        $this->createIndexedSearchRoman($user, $ids[1], 'Content serienfilter', 'maddrax', 2, 'Maddrax Neuer', '2023-01-01');
+        $this->createIndexedSearchRoman($user, $ids[2], 'Content serienfilter', 'missionmars', 1, 'Mars Alter', '2020-01-01');
+        $this->createIndexedSearchRoman($user, $ids[3], 'Content serienfilter', 'maddrax', 1, 'Maddrax Alter', '2019-01-01');
+
+        $this->partialMock(KompendiumSearchService::class, function ($mock) use ($ids) {
+            $mock->shouldReceive('search')
+                ->with('serienfilter')
+                ->once()
+                ->andReturn([
+                    'hits' => ['total_hits' => 4],
+                    'ids' => $ids,
+                ]);
+        });
+
+        $response = $this->getJson('/kompendium/suche?q=serienfilter&sort=first_published&direction=asc&serien[]=maddrax');
+
+        $response->assertOk();
+        $this->assertSame(['Maddrax Alter', 'Maddrax Neuer'], array_column($response->json('data'), 'title'));
+        $this->assertSame(2, $response->json('serienCounts.maddrax'));
+        $this->assertSame(2, $response->json('serienCounts.missionmars'));
     }
 
     /* --------------------------------------------------------------------- */

--- a/tests/Feature/KompendiumSucheTest.php
+++ b/tests/Feature/KompendiumSucheTest.php
@@ -42,6 +42,10 @@ class KompendiumSucheTest extends TestCase
         Livewire::test(KompendiumSuche::class)
             ->assertSee('Suchbegriff')
             ->assertSeeHtml('data-testid="kompendium-search-help-button"')
+            ->assertSeeHtml('data-testid="kompendium-sort-field"')
+            ->assertSeeHtml('data-testid="kompendium-sort-direction"')
+            ->assertSet('sort', 'relevance')
+            ->assertSet('direction', 'desc')
             ->assertOk();
     }
 
@@ -225,6 +229,58 @@ class KompendiumSucheTest extends TestCase
             ->set('candidatesTruncated', true)
             ->set('scannedCandidates', 400)
             ->assertSee('Für die Suchlogik wurden bisher 400 Kandidaten nachgeprüft.');
+    }
+
+    public function test_sort_wechsel_auf_erstveroeffentlichung_setzt_richtung_auf_aufsteigend(): void
+    {
+        Livewire::test(KompendiumSuche::class)
+            ->set('direction', 'desc')
+            ->set('sort', 'first_published')
+            ->assertSet('direction', 'asc');
+    }
+
+    public function test_component_sortiert_nach_erstveroeffentlichungsdatum(): void
+    {
+        $files = [
+            'romane/maddrax/002 - Neuer Treffer.txt' => 'Aruula sortiert diesen Treffer.',
+            'romane/maddrax/001 - Alter Treffer.txt' => 'Aruula sortiert diesen Treffer.',
+        ];
+
+        $searchResultPaths = array_keys($files);
+        $this->setupSearchMock($files, $searchResultPaths);
+
+        $user = User::factory()->create();
+
+        KompendiumRoman::create([
+            'dateiname' => '002 - Neuer Treffer.txt',
+            'dateipfad' => 'romane/maddrax/002 - Neuer Treffer.txt',
+            'serie' => 'maddrax',
+            'roman_nr' => 2,
+            'titel' => 'Neuer Treffer',
+            'erstveroeffentlicht_am' => '2024-01-01',
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $user->id,
+            'status' => 'indexiert',
+        ]);
+
+        KompendiumRoman::create([
+            'dateiname' => '001 - Alter Treffer.txt',
+            'dateipfad' => 'romane/maddrax/001 - Alter Treffer.txt',
+            'serie' => 'maddrax',
+            'roman_nr' => 1,
+            'titel' => 'Alter Treffer',
+            'erstveroeffentlicht_am' => '2020-01-01',
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $user->id,
+            'status' => 'indexiert',
+        ]);
+
+        Livewire::test(KompendiumSuche::class)
+            ->set('sort', 'first_published')
+            ->set('query', 'Aruula')
+            ->call('performSearch')
+            ->assertSeeInOrder(['Alter Treffer', 'Neuer Treffer'])
+            ->assertSee('Erstveroeffentlicht: 01.01.2020');
     }
 
     public function test_component_serienfilter_fuellt_die_seite_mit_spaeteren_treffern_aus_der_ausgewaehlten_serie(): void

--- a/tests/Unit/Services/KompendiumSearchSorterTest.php
+++ b/tests/Unit/Services/KompendiumSearchSorterTest.php
@@ -6,6 +6,7 @@ use App\Models\KompendiumRoman;
 use App\Models\User;
 use App\Services\KompendiumSearchSorter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Tests\TestCase;
 
@@ -80,6 +81,39 @@ class KompendiumSearchSorterTest extends TestCase
         $this->assertSame([$newest, $maddraxOne, $maddraxTen, $missionMars, $missing], $descending['paths']);
         $this->assertNull($ascending['metadata'][$missing]['erstveroeffentlichtAm']);
         $this->assertSame(99, $ascending['metadata'][$missing]['romanNrSort']);
+    }
+
+    public function test_metadata_lookup_chunks_large_path_lists_and_selects_needed_columns(): void
+    {
+        $paths = array_map(
+            fn (int $number): string => sprintf('romane/maddrax/%03d - Chunk %d.txt', $number, $number),
+            range(1, 1001)
+        );
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        $result = (new KompendiumSearchSorter)->orderPathsWithMetadata($paths, 'relevance', 'desc');
+
+        DB::disableQueryLog();
+
+        $metadataQueries = collect(DB::getQueryLog())
+            ->filter(fn (array $query): bool => str_contains($query['query'], 'kompendium_romane'))
+            ->values();
+
+        $this->assertSame($paths, $result['paths']);
+        $this->assertCount(3, $metadataQueries);
+
+        foreach ($metadataQueries as $query) {
+            $this->assertLessThanOrEqual(500, count($query['bindings']));
+        }
+
+        $firstQuery = strtolower($metadataQueries->first()['query']);
+        $this->assertStringNotContainsString('select *', $firstQuery);
+        $this->assertStringContainsString('dateipfad', $firstQuery);
+        $this->assertStringContainsString('serie', $firstQuery);
+        $this->assertStringContainsString('roman_nr', $firstQuery);
+        $this->assertStringContainsString('erstveroeffentlicht_am', $firstQuery);
     }
 
     private function createRoman(

--- a/tests/Unit/Services/KompendiumSearchSorterTest.php
+++ b/tests/Unit/Services/KompendiumSearchSorterTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\KompendiumRoman;
+use App\Models\User;
+use App\Services\KompendiumSearchSorter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Tests\TestCase;
+
+#[CoversClass(KompendiumSearchSorter::class)]
+class KompendiumSearchSorterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_normalisiert_sortierung_richtung_und_post_filter_bedarf(): void
+    {
+        $sorter = new KompendiumSearchSorter;
+
+        $this->assertSame('relevance', $sorter->normalizeSort('ungueltig'));
+        $this->assertSame('first_published', $sorter->normalizeSort('first_published'));
+
+        $this->assertSame('desc', $sorter->defaultDirectionForSort('relevance'));
+        $this->assertSame('asc', $sorter->defaultDirectionForSort('first_published'));
+        $this->assertSame('asc', $sorter->normalizeDirection('seitwaerts', 'first_published'));
+        $this->assertSame('desc', $sorter->normalizeDirection('desc', 'first_published'));
+
+        $this->assertFalse($sorter->needsFullPostFilter('relevance', 'desc'));
+        $this->assertTrue($sorter->needsFullPostFilter('relevance', 'asc'));
+        $this->assertTrue($sorter->needsFullPostFilter('first_published', 'asc'));
+        $this->assertTrue($sorter->needsFullPostFilter('first_published', 'desc'));
+    }
+
+    public function test_relevanz_sortierung_belaesst_oder_dreht_tnt_reihenfolge(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $sorter = new KompendiumSearchSorter;
+        $paths = [
+            'romane/maddrax/001 - A.txt',
+            'romane/maddrax/002 - B.txt',
+            'romane/maddrax/003 - C.txt',
+        ];
+
+        foreach ($paths as $index => $path) {
+            $this->createRoman($user, $path, 'maddrax', $index + 1, chr(65 + $index), '2020-01-0'.($index + 1));
+        }
+
+        $descending = $sorter->orderPathsWithMetadata($paths, 'relevance', 'desc');
+        $ascending = $sorter->orderPathsWithMetadata($paths, 'relevance', 'asc');
+
+        $this->assertSame($paths, $descending['paths']);
+        $this->assertSame(array_reverse($paths), $ascending['paths']);
+        $this->assertSame('2020-01-01', $descending['metadata'][$paths[0]]['erstveroeffentlichtAm']);
+        $this->assertSame('01.01.2020', $descending['metadata'][$paths[0]]['erstveroeffentlichtAmFormatted']);
+    }
+
+    public function test_erstveroeffentlichung_sortiert_beide_richtungen_mit_fallbacks(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $sorter = new KompendiumSearchSorter;
+
+        $missing = 'romane/maddrax/099 - Ohne Datum.txt';
+        $maddraxOne = 'romane/maddrax/001 - Maddrax Eins.txt';
+        $maddraxTen = 'romane/maddrax/010 - Maddrax Zehn.txt';
+        $missionMars = 'romane/missionmars/002 - Mission Zwei.txt';
+        $newest = 'romane/maddrax/200 - Neuer Treffer.txt';
+        $paths = [$newest, $missionMars, $missing, $maddraxTen, $maddraxOne];
+
+        $this->createRoman($user, $missing, 'maddrax', 99, 'Ohne Datum');
+        $this->createRoman($user, $maddraxOne, 'maddrax', 1, 'Maddrax Eins', '2020-01-01');
+        $this->createRoman($user, $maddraxTen, 'maddrax', 10, 'Maddrax Zehn', '2020-01-01');
+        $this->createRoman($user, $missionMars, 'missionmars', 2, 'Mission Zwei', '2020-01-01');
+        $this->createRoman($user, $newest, 'maddrax', 200, 'Neuer Treffer', '2024-01-01');
+
+        $ascending = $sorter->orderPathsWithMetadata($paths, 'first_published', 'asc');
+        $descending = $sorter->orderPathsWithMetadata($paths, 'first_published', 'desc');
+
+        $this->assertSame([$missing, $maddraxOne, $maddraxTen, $missionMars, $newest], $ascending['paths']);
+        $this->assertSame([$newest, $maddraxOne, $maddraxTen, $missionMars, $missing], $descending['paths']);
+        $this->assertNull($ascending['metadata'][$missing]['erstveroeffentlichtAm']);
+        $this->assertSame(99, $ascending['metadata'][$missing]['romanNrSort']);
+    }
+
+    private function createRoman(
+        User $user,
+        string $path,
+        string $serie,
+        int $romanNr,
+        string $titel,
+        ?string $erstveroeffentlichtAm = null,
+    ): KompendiumRoman {
+        return KompendiumRoman::create([
+            'dateiname' => basename($path),
+            'dateipfad' => $path,
+            'serie' => $serie,
+            'roman_nr' => $romanNr,
+            'titel' => $titel,
+            'erstveroeffentlicht_am' => $erstveroeffentlichtAm,
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $user->id,
+            'status' => 'indexiert',
+            'indexiert_am' => now(),
+        ]);
+    }
+}

--- a/tests/Unit/Services/KompendiumServiceTest.php
+++ b/tests/Unit/Services/KompendiumServiceTest.php
@@ -139,6 +139,36 @@ class KompendiumServiceTest extends TestCase
     }
 
     #[Test]
+    public function finde_metadaten_liefert_erstveroeffentlichungsdatum_aus_evt(): void
+    {
+        $this->maddraxDataService
+            ->shouldReceive('getSeries')
+            ->with('maddrax')
+            ->andReturn(collect([
+                ['nummer' => 1, 'titel' => 'Der Gott aus dem Eis', 'zyklus' => 'Euree', 'evt' => '2024-01'],
+            ]));
+
+        $this->maddraxDataService
+            ->shouldReceive('getSeries')
+            ->withAnyArgs()
+            ->andReturn(collect([]));
+
+        $result = $this->service->findeMetadaten(1, 'Der Gott aus dem Eis');
+
+        $this->assertNotNull($result);
+        $this->assertSame('2024-01-01', $result['erstveroeffentlicht_am']?->toDateString());
+    }
+
+    #[Test]
+    public function parse_erstveroeffentlicht_am_normalisiert_gaengige_datumsformate(): void
+    {
+        $this->assertSame('2024-01-01', $this->service->parseErstveroeffentlichtAm('2024-01')?->toDateString());
+        $this->assertSame('2024-05-07', $this->service->parseErstveroeffentlichtAm('7.5.2024')?->toDateString());
+        $this->assertSame('2024-01-01', $this->service->parseErstveroeffentlichtAm('2024')?->toDateString());
+        $this->assertNull($this->service->parseErstveroeffentlichtAm('kein datum'));
+    }
+
+    #[Test]
     public function get_serien_liste_gibt_alle_serien_zurueck(): void
     {
         $serien = $this->service->getSerienListe();

--- a/tests/Unit/Services/KompendiumServiceTest.php
+++ b/tests/Unit/Services/KompendiumServiceTest.php
@@ -169,6 +169,12 @@ class KompendiumServiceTest extends TestCase
     }
 
     #[Test]
+    public function parse_erstveroeffentlicht_am_gibt_null_fuer_ungueltiges_jahresformat_zurueck(): void
+    {
+        $this->assertNull($this->service->parseErstveroeffentlichtAm('0000'));
+    }
+
+    #[Test]
     public function get_serien_liste_gibt_alle_serien_zurueck(): void
     {
         $serien = $this->service->getSerienListe();

--- a/tests/e2e/umfragen-admin.spec.js
+++ b/tests/e2e/umfragen-admin.spec.js
@@ -2,11 +2,29 @@ import { expect, test } from './test-support.js';
 import { createDatetimeLocalRange } from './utils/temporal.js';
 
 const login = async (page, email, password = 'password') => {
-    await page.goto('/login');
-    await page.fill('input[name="email"]', email);
-    await page.fill('input[name="password"]', password);
-    await page.click('button[type="submit"]');
-    await page.waitForURL((url) => !url.pathname.endsWith('/login'));
+    let lastError;
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+        await page.goto('/login');
+        await page.fill('input[name="email"]', email);
+        await page.fill('input[name="password"]', password);
+
+        try {
+            await Promise.all([
+                page.waitForURL((url) => !url.pathname.endsWith('/login'), {
+                    timeout: 45000,
+                    waitUntil: 'domcontentloaded',
+                }),
+                page.click('button[type="submit"]'),
+            ]);
+
+            return;
+        } catch (error) {
+            lastError = error;
+        }
+    }
+
+    throw lastError;
 };
 
 const answerOptionCards = (page) => page.locator('[data-testid^="answer-option-"]');


### PR DESCRIPTION
This pull request introduces significant improvements to the Kompendium search and administration features. The main changes include the implementation of sorting and direction options in the search UI and backend, support for managing and displaying publication dates (`erstveroeffentlicht_am`), and the addition of a console command to backfill missing publication dates. These enhancements improve both the user experience and data quality in the Kompendium module.

**Kompendium Search: Sorting and Publication Dates**

- Added support for sorting search results by various criteria (e.g., relevance, publication date) with configurable direction (ascending/descending) in both the Livewire and API-based search interfaces. This includes validation, normalization, and UI state management for sort and direction. [[1]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173R10) [[2]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173R127-R144) [[3]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173R169-R170) [[4]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173L184-R196) [[5]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173R250-R253) [[6]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173R359-R360) [[7]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173R400-R401) [[8]](diffhunk://#diff-37dd62a66c4e6b0e41077bf1aac80c4bf1d759fb90490434fbe7ec36c6f3fda8R7) [[9]](diffhunk://#diff-37dd62a66c4e6b0e41077bf1aac80c4bf1d759fb90490434fbe7ec36c6f3fda8R20-R23) [[10]](diffhunk://#diff-37dd62a66c4e6b0e41077bf1aac80c4bf1d759fb90490434fbe7ec36c6f3fda8R102-R136) [[11]](diffhunk://#diff-37dd62a66c4e6b0e41077bf1aac80c4bf1d759fb90490434fbe7ec36c6f3fda8L135-R170) [[12]](diffhunk://#diff-37dd62a66c4e6b0e41077bf1aac80c4bf1d759fb90490434fbe7ec36c6f3fda8R223-R226)
- Search results now include `erstveroeffentlichtAm` and its formatted version, making publication dates available in the API and Livewire search output. [[1]](diffhunk://#diff-41da13134bf743e59ee5399b4c1884e0c3751fc04a08851cf64ed9d4123cb173R359-R360) [[2]](diffhunk://#diff-37dd62a66c4e6b0e41077bf1aac80c4bf1d759fb90490434fbe7ec36c6f3fda8R279-R280)

**Kompendium Admin Dashboard: Publication Date Management**

- The admin dashboard now allows viewing and editing the publication date (`erstveroeffentlicht_am`) for each novel, including validation and fallback logic to auto-fill the date if not provided. [[1]](diffhunk://#diff-1652cc71d23c16d48850ba7d893e896f2da8d3da55a71b6ca7001299d024f030R58-R59) [[2]](diffhunk://#diff-1652cc71d23c16d48850ba7d893e896f2da8d3da55a71b6ca7001299d024f030R184) [[3]](diffhunk://#diff-1652cc71d23c16d48850ba7d893e896f2da8d3da55a71b6ca7001299d024f030R226) [[4]](diffhunk://#diff-1652cc71d23c16d48850ba7d893e896f2da8d3da55a71b6ca7001299d024f030R236-R246) [[5]](diffhunk://#diff-1652cc71d23c16d48850ba7d893e896f2da8d3da55a71b6ca7001299d024f030R317-R326)

**Data Model and Backfilling**

- Updated the `KompendiumRoman` model to support the new `erstveroeffentlicht_am` field, including casting and mass assignment. [[1]](diffhunk://#diff-64c94880604f33934d15ead78efdb99c3d59d30b95f816db97ece4fbe591ceadR19) [[2]](diffhunk://#diff-64c94880604f33934d15ead78efdb99c3d59d30b95f816db97ece4fbe591ceadR39) [[3]](diffhunk://#diff-64c94880604f33934d15ead78efdb99c3d59d30b95f816db97ece4fbe591ceadR48)
- Added a new Artisan console command (`BackfillKompendiumPublicationDates`) to backfill missing publication dates from series metadata, with a dry-run option for safe execution.