### PR TITLE
Feature: Hydrit race and Meeresbewohner culture for Charakter-Editor

### DIFF
--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -1,11 +1,13 @@
 const RACE_DESCRIPTIONS = {
     Barbar: 'Im 26. Jahrhundert besteht die Zivilisation zum größten Teil aus Barbaren. Sie leben in unterschiedlichen Kulturen, beispielsweise als Seefahrer (die Disuuslachter), Nomaden (die Wandernden Völker) oder Ruinenbewohner (die Loords von Landán). Die zeichnen sich durch Zähigkeit, Wildheit und Kampflust aus, sind zumeist primitiv und leben in Clans. Ehre und Mut werden hoch geschätzt. Technologisch bewegen sich die meisten Barbaren zwischen der späten Steinzeit und dem frühen Mittelalter.',
-    Guul: 'Guule sind bedauernswerte Mutationen des Homo Sapiens. Sie sind dürr, fast zwei Meter groß und völlig unbehaart. Ihre langen knochigen Arme enden in Krallen. Die verhornten Füße laufen an den Fersen in einem fingerdicken Stachel aus. Aus dem Maul tropft weißlicher Schleim, was ihr abstoßendes Äußeres zusätzlich verstärkt. Guule sind meist nur mit einem Lendenschurz bekleidet. Sie ernähren sich von Aas und Gebeinen, die sie u.a. aus Gräbern holen.'
+    Guul: 'Guule sind bedauernswerte Mutationen des Homo Sapiens. Sie sind dürr, fast zwei Meter groß und völlig unbehaart. Ihre langen knochigen Arme enden in Krallen. Die verhornten Füße laufen an den Fersen in einem fingerdicken Stachel aus. Aus dem Maul tropft weißlicher Schleim, was ihr abstoßendes Äußeres zusätzlich verstärkt. Guule sind meist nur mit einem Lendenschurz bekleidet. Sie ernähren sich von Aas und Gebeinen, die sie u.a. aus Gräbern holen.',
+    Hydrit: 'Hydriten, von den Menschen oft Fischmenschen genannt, sind ein friedliebendes und altes Volk. Sie leben in geheimen Unterseestädten, sind amphibisch, kultiviert und verfügen über fortgeschrittene biogenetische Technologien. Der Genuss von Fleisch verwandelt Hydriten in gefährliche Bestien, weshalb sie sich meist vegetarisch ernähren.'
 };
 
 const CULTURE_DESCRIPTIONS = {
     Landbewohner: 'Landbewohner bewirtschaften den Boden und versuchen als Bauern und Viehzüchter ihren Lebensunterhalt zu verdienen. Die meisten sind einfache Menschen, die Ruhe und Frieden suchen, nicht viel von der Welt wissen und einfache Landgötter anbeten. Aberglauben ist weit verbreitet.',
-    Stadtbewohner: 'Stadtbewohner versuchen in der dunklen Zukunft der Erde neues Leben erblühen zu lassen. Dazu haben sie sich in neu erbauten Siedlungen (zuweilen auf Ruinen aus der Zeit vor dem Kometen) angesiedelt und leben als Händler, Handwerker und Bauern. Die Mauern ihrer Siedlungen schützen sie vor den Gefahren der Wildnis. Ihre Siedlungen sind somit Lichter der Hoffnung in der Dunkelheit.'
+    Stadtbewohner: 'Stadtbewohner versuchen in der dunklen Zukunft der Erde neues Leben erblühen zu lassen. Dazu haben sie sich in neu erbauten Siedlungen (zuweilen auf Ruinen aus der Zeit vor dem Kometen) angesiedelt und leben als Händler, Handwerker und Bauern. Die Mauern ihrer Siedlungen schützen sie vor den Gefahren der Wildnis. Ihre Siedlungen sind somit Lichter der Hoffnung in der Dunkelheit.',
+    Meeresbewohner: 'Meeresbewohner sind Hydriten aus großen, seit langem verborgenen Unterseestädten. Ihre Gesellschaft ist streng hierarchisch organisiert, technisch und biotechnologisch weit fortgeschritten und meidet den Kontakt zu Oberflächenbewohnern.'
 };
 
 const ATTRIBUTE_IDS = ['st', 'ge', 'ro', 'wi', 'wa', 'in', 'au'];
@@ -62,6 +64,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     cultureGrants: {},
     barbarCombatSkill: null,
     citySkill: null,
+    seaProfessionSkill: null,
+    seaKnowledgeOrCombatSkill: null,
     raceCache: {},
 
     // Dynamic data
@@ -105,7 +109,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     },
 
     chosenAdvantagesCount() {
-        return this.selectedAdvantages.filter(a => a !== 'Zäh').length;
+        return this.selectedAdvantages.filter(a => a !== 'Zäh' && !this.raceLocked.advantages.includes(a)).length;
     },
 
     freeAdvantagePoints() {
@@ -223,25 +227,56 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         const grants = source === 'Rasse' ? this.raceGrants : this.cultureGrants;
         grants[name] = { type: 'min', value };
         const skill = this.ensureSkill(name);
-        skill.nameDisabled = true;
-        skill.locked = true;
-        skill.badge = source;
-        if (skill.value < value) skill.value = value;
+        this.applyGrantToSkill(skill);
     },
 
     setFreeExact(name, value, source) {
         const grants = source === 'Rasse' ? this.raceGrants : this.cultureGrants;
         grants[name] = { type: 'exact', value };
         const skill = this.ensureSkill(name);
+        this.applyGrantToSkill(skill);
+    },
+
+    applyGrantToSkill(skill) {
+        const grant = this.getGrant(skill.name);
+        if (!grant) return;
+
+        const hasRaceGrant = Boolean(this.raceGrants[skill.name]);
+        const hasCultureGrant = Boolean(this.cultureGrants[skill.name]);
+
         skill.nameDisabled = true;
-        skill.valueDisabled = true;
         skill.locked = true;
-        skill.badge = source;
-        skill.value = value;
+        skill.badge = hasRaceGrant && hasCultureGrant ? 'Rasse/Kultur' : (hasRaceGrant ? 'Rasse' : 'Kultur');
+        skill.valueDisabled = grant.type === 'exact';
+
+        if (grant.type === 'exact') {
+            skill.value = grant.value;
+        } else if (skill.value < grant.value) {
+            skill.value = grant.value;
+        }
+    },
+
+    refreshGrantedSkill(name) {
+        const skill = this.skills.find(s => s.name === name);
+        if (!skill) return;
+
+        const grant = this.getGrant(name);
+        if (!grant) {
+            this.skills = this.skills.filter(s => s !== skill);
+            return;
+        }
+
+        this.applyGrantToSkill(skill);
     },
 
     getGrant(name) {
-        return this.raceGrants[name] || this.cultureGrants[name] || null;
+        const grants = [this.raceGrants[name], this.cultureGrants[name]].filter(Boolean);
+        if (!grants.length) return null;
+
+        return {
+            type: grants.some(grant => grant.type === 'exact') ? 'exact' : 'min',
+            value: Math.max(...grants.map(grant => grant.value)),
+        };
     },
 
     getSkillMin(name) {
@@ -321,6 +356,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.clearRace();
         if (this.race === 'Barbar') this.applyRaceBarbar();
         if (this.race === 'Guul') this.applyRaceGuul();
+        if (this.race === 'Hydrit') this.applyRaceHydrit();
         this.restoreRaceState(this.race);
         this._prevRace = this.race;
         this.updateDescription();
@@ -353,10 +389,17 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     },
 
     clearRace() {
+        const previousRaceSkills = Object.keys(this.raceGrants);
+        const previousLockedAdvantages = [...this.raceLocked.advantages];
+        const previousLockedDisadvantages = [...this.raceLocked.disadvantages];
+
         this.raceAPBonus = 0;
-        this.skills = this.skills.filter(s => s.badge !== 'Rasse');
         this.raceGrants = {};
         this.barbarCombatSkill = null;
+        previousRaceSkills.forEach(name => this.refreshGrantedSkill(name));
+        this.selectedAdvantages = this.selectedAdvantages.filter(value => value === 'Zäh' || !previousLockedAdvantages.includes(value));
+        this.selectedDisadvantages = this.selectedDisadvantages.filter(value => !previousLockedDisadvantages.includes(value));
+        this.raceLocked.advantages = [];
         this.raceLocked.disadvantages = [];
     },
 
@@ -376,19 +419,28 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.selectedDisadvantages = [...new Set([...this.selectedDisadvantages, 'Primitiv', 'Gejagt'])];
     },
 
+    applyRaceHydrit() {
+        this.setFreeMin('Athletik', 2, 'Rasse');
+        this.setFreeMin('Bildung', 1, 'Rasse');
+        this.setFreeMin('Natürliche Waffen', 1, 'Rasse');
+        this.raceLocked.advantages = ['Kiemen', 'Natürliche Waffen'];
+        this.raceLocked.disadvantages = ['Anfälligkeit gegen Wahnsinn'];
+        this.selectedAdvantages = [...new Set([...this.selectedAdvantages, 'Kiemen', 'Natürliche Waffen'])];
+        this.selectedDisadvantages = [...new Set([...this.selectedDisadvantages, 'Anfälligkeit gegen Wahnsinn'])];
+    },
+
     setBarbarCombatSkill(skillName) {
-        const prev = this.barbarCombatSkill;
-        if (prev && prev !== skillName) {
-            this.skills = this.skills.filter(s => s.name !== prev || s.badge !== 'Rasse');
-            delete this.raceGrants[prev];
-        }
+        ['Nahkampf', 'Fernkampf']
+            .filter(name => name !== skillName && this.raceGrants[name])
+            .forEach(name => {
+                delete this.raceGrants[name];
+                this.refreshGrantedSkill(name);
+            });
+
         this.barbarCombatSkill = skillName;
         this.raceGrants[skillName] = { type: 'min', value: 1 };
         const skill = this.ensureSkill(skillName);
-        skill.nameDisabled = true;
-        skill.locked = true;
-        skill.badge = 'Rasse';
-        if (skill.value < 1) skill.value = 1;
+        this.applyGrantToSkill(skill);
     },
 
     // --- Culture handling ---
@@ -396,13 +448,18 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.clearCulture();
         if (this.culture === 'Landbewohner') this.applyCultureLandbewohner();
         if (this.culture === 'Stadtbewohner') this.applyCultureStadtbewohner();
+        if (this.culture === 'Meeresbewohner') this.applyCultureMeeresbewohner();
         this.updateDescription();
     },
 
     clearCulture() {
-        this.skills = this.skills.filter(s => s.badge !== 'Kultur');
+        const previousCultureSkills = Object.keys(this.cultureGrants);
+
         this.cultureGrants = {};
         this.citySkill = null;
+        this.seaProfessionSkill = null;
+        this.seaKnowledgeOrCombatSkill = null;
+        previousCultureSkills.forEach(name => this.refreshGrantedSkill(name));
     },
 
     applyCultureLandbewohner() {
@@ -417,27 +474,62 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.setFreeMin('Kunde', 1, 'Kultur');
     },
 
+    applyCultureMeeresbewohner() {
+        this.setFreeMin('Athletik', 1, 'Kultur');
+        this.setSeaProfessionSkill('Beruf: Farmer');
+        this.setSeaKnowledgeOrCombatSkill('Wissenschaftler');
+    },
+
     setCitySkill(skillName) {
-        const prev = this.citySkill;
-        if (prev && prev !== skillName) {
-            this.skills = this.skills.filter(s => s.name !== prev || s.badge !== 'Kultur');
-            delete this.cultureGrants[prev];
-        }
+        ['Unterhalten', 'Sprachen']
+            .filter(name => name !== skillName && this.cultureGrants[name])
+            .forEach(name => {
+                delete this.cultureGrants[name];
+                this.refreshGrantedSkill(name);
+            });
+
         this.citySkill = skillName;
         this.cultureGrants[skillName] = { type: 'min', value: 1 };
         const skill = this.ensureSkill(skillName);
-        skill.nameDisabled = true;
-        skill.locked = true;
-        skill.badge = 'Kultur';
-        if (skill.value < 1) skill.value = 1;
+        this.applyGrantToSkill(skill);
+    },
+
+    setSeaProfessionSkill(skillName) {
+        ['Beruf: Farmer', 'Beruf: Künstler']
+            .filter(name => name !== skillName && this.cultureGrants[name])
+            .forEach(name => {
+                delete this.cultureGrants[name];
+                this.refreshGrantedSkill(name);
+            });
+
+        this.seaProfessionSkill = skillName;
+        this.cultureGrants[skillName] = { type: 'min', value: 1 };
+        const skill = this.ensureSkill(skillName);
+        this.applyGrantToSkill(skill);
+    },
+
+    setSeaKnowledgeOrCombatSkill(skillName) {
+        ['Wissenschaftler', 'Techniker', 'Nahkampf']
+            .filter(name => name !== skillName && this.cultureGrants[name])
+            .forEach(name => {
+                delete this.cultureGrants[name];
+                this.refreshGrantedSkill(name);
+            });
+
+        this.seaKnowledgeOrCombatSkill = skillName;
+        this.cultureGrants[skillName] = { type: 'min', value: 1 };
+        const skill = this.ensureSkill(skillName);
+        this.applyGrantToSkill(skill);
     },
 
     // --- Advantages ---
     enforceAdvantageLimit() {
         const max = this.base.freeAdvantages;
-        const chosen = this.selectedAdvantages.filter(a => a !== 'Zäh');
+        const locked = this.selectedAdvantages.filter(a => this.raceLocked.advantages.includes(a));
+        const chosen = this.selectedAdvantages.filter(a => a !== 'Zäh' && !this.raceLocked.advantages.includes(a));
+
         if (chosen.length > max) {
-            this.selectedAdvantages = ['Zäh', ...chosen.slice(0, max)];
+            this.selectedAdvantages = [...new Set(['Zäh', ...locked, ...chosen.slice(0, max)])];
         }
         if (!this.selectedAdvantages.includes('Zäh')) {
             this.selectedAdvantages = ['Zäh', ...this.selectedAdvantages];

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -71,6 +71,7 @@
                             <option value="" disabled>Rasse wählen</option>
                             <option value="Barbar">Barbar</option>
                             <option value="Guul">Guul</option>
+                            <option value="Hydrit">Hydrit</option>
                         </select>
                     </div>
 
@@ -80,6 +81,7 @@
                             <option value="" disabled>Kultur wählen</option>
                             <option value="Landbewohner">Landbewohner</option>
                             <option value="Stadtbewohner">Stadtbewohner</option>
+                            <option value="Meeresbewohner">Meeresbewohner</option>
                         </select>
                     </div>
 
@@ -129,6 +131,23 @@
                                 <option value="Sprachen">Sprachen (+1)</option>
                             </select>
                         </div>
+                        <div x-show="culture === 'Meeresbewohner'" class="mb-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                            <div>
+                                <label for="sea-profession-select" class="text-sm font-medium text-base-content mb-1">Meeresbewohner Beruf-Bonus</label>
+                                <select id="sea-profession-select" class="select select-bordered w-full" x-model="seaProfessionSkill" @change="setSeaProfessionSkill(seaProfessionSkill)">
+                                    <option value="Beruf: Farmer">Beruf: Farmer (+1)</option>
+                                    <option value="Beruf: Künstler">Beruf: Künstler (+1)</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label for="sea-knowledge-combat-select" class="text-sm font-medium text-base-content mb-1">Meeresbewohner Zusatzbonus</label>
+                                <select id="sea-knowledge-combat-select" class="select select-bordered w-full" x-model="seaKnowledgeOrCombatSkill" @change="setSeaKnowledgeOrCombatSkill(seaKnowledgeOrCombatSkill)">
+                                    <option value="Wissenschaftler">Wissenschaftler (+1)</option>
+                                    <option value="Techniker">Techniker (+1)</option>
+                                    <option value="Nahkampf">Nahkampf (+1)</option>
+                                </select>
+                            </div>
+                        </div>
                         <div class="space-y-2">
                             <template x-for="(skill, index) in skills" :key="index">
                                 <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 items-center">
@@ -172,6 +191,8 @@
                         <datalist id="skills-list">
                             <option value="Athletik"></option>
                             <option value="Beruf"></option>
+                            <option value="Beruf: Farmer"></option>
+                            <option value="Beruf: Künstler"></option>
                             <option value="Bildung"></option>
                             <option value="Diebeskunst"></option>
                             <option value="Fahren"></option>
@@ -226,6 +247,8 @@
                                             <span class="min-w-0 flex-1 leading-5">{{ $advantage }}</span>
                                             @if($advantage === 'Zäh')
                                                 <span class="badge badge-primary badge-outline shrink-0">Pflicht</span>
+                                            @else
+                                                <template x-if="raceLocked.advantages.includes(@js($advantage))"><span class="badge badge-primary badge-outline shrink-0">Pflicht</span></template>
                                             @endif
                                         </label>
                                     @endforeach

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -252,6 +252,46 @@ describe('charEditor – Rassen-Logik', () => {
         expect(e.raceLocked.disadvantages).toContain('Gejagt');
         expect(e.selectedDisadvantages).toContain('Primitiv');
     });
+
+    it('Hydrit erhält Athletik, Bildung, natürliche Waffen und Pflichtmerkmale', () => {
+        const e = createEditor();
+        e.applyRaceHydrit();
+
+        expect(e.raceGrants.Athletik).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Bildung).toEqual({ type: 'min', value: 1 });
+        expect(e.raceGrants['Natürliche Waffen']).toEqual({ type: 'min', value: 1 });
+        expect(e.skills.find(s => s.name === 'Athletik')).toMatchObject({ value: 2, badge: 'Rasse' });
+        expect(e.selectedAdvantages).toEqual(expect.arrayContaining(['Kiemen', 'Natürliche Waffen']));
+        expect(e.raceLocked.advantages).toEqual(['Kiemen', 'Natürliche Waffen']);
+        expect(e.selectedDisadvantages).toContain('Anfälligkeit gegen Wahnsinn');
+        expect(e.raceLocked.disadvantages).toEqual(['Anfälligkeit gegen Wahnsinn']);
+    });
+
+    it('Hydrit-Pflichtvorteile verbrauchen keine freien Vorteilspunkte', () => {
+        const e = createEditor();
+        e.applyRaceHydrit();
+
+        expect(e.chosenAdvantagesCount()).toBe(0);
+        expect(e.freeAdvantagePoints()).toBe(2);
+        expect(e.selectedDisabledAdvantages()).toEqual(['Zäh', 'Kiemen', 'Natürliche Waffen']);
+
+        e.selectedAdvantages.push('Schnell', 'Kampfreflexe', 'Nachtsicht');
+        e.enforceAdvantageLimit();
+
+        expect(e.selectedAdvantages).toEqual(['Zäh', 'Kiemen', 'Natürliche Waffen', 'Schnell', 'Kampfreflexe']);
+    });
+
+    it('Rassenwechsel entfernt Hydrit-Pflichtmerkmale und behält nur übrige Grants', () => {
+        const e = createEditor();
+        e.applyRaceHydrit();
+        e.clearRace();
+
+        expect(e.raceLocked.advantages).toEqual([]);
+        expect(e.raceLocked.disadvantages).toEqual([]);
+        expect(e.selectedAdvantages).toEqual(['Zäh']);
+        expect(e.selectedDisadvantages).not.toContain('Anfälligkeit gegen Wahnsinn');
+        expect(e.skills.find(s => s.name === 'Athletik')).toBeUndefined();
+    });
 });
 
 describe('charEditor – Kultur-Logik', () => {
@@ -268,6 +308,83 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.cultureGrants).toHaveProperty('Unterhalten');
         expect(e.cultureGrants).toHaveProperty('Beruf');
         expect(e.cultureGrants).toHaveProperty('Kunde');
+    });
+
+    it('Meeresbewohner erhält Athletik und die Standard-Wahlboni', () => {
+        const e = createEditor();
+        e.applyCultureMeeresbewohner();
+
+        expect(e.cultureGrants.Athletik).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants['Beruf: Farmer']).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Wissenschaftler).toEqual({ type: 'min', value: 1 });
+        expect(e.seaProfessionSkill).toBe('Beruf: Farmer');
+        expect(e.seaKnowledgeOrCombatSkill).toBe('Wissenschaftler');
+    });
+
+    it('Meeresbewohner-Wahlboni ersetzen den vorherigen Kulturbonus', () => {
+        const e = createEditor();
+        e.applyCultureMeeresbewohner();
+
+        e.setSeaProfessionSkill('Beruf: Künstler');
+        e.setSeaKnowledgeOrCombatSkill('Nahkampf');
+
+        expect(e.cultureGrants['Beruf: Farmer']).toBeUndefined();
+        expect(e.cultureGrants.Wissenschaftler).toBeUndefined();
+        expect(e.cultureGrants['Beruf: Künstler']).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.skills.find(s => s.name === 'Beruf: Farmer')).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Wissenschaftler')).toBeUndefined();
+    });
+
+    it('Wahlboni ersetzen alte Optionen auch wenn x-model bereits den neuen Wert gesetzt hat', () => {
+        const e = createEditor();
+        e.applyRaceBarbar();
+        e.applyCultureStadtbewohner();
+        e.applyCultureMeeresbewohner();
+
+        e.barbarCombatSkill = 'Fernkampf';
+        e.setBarbarCombatSkill(e.barbarCombatSkill);
+        e.citySkill = 'Sprachen';
+        e.setCitySkill(e.citySkill);
+        e.seaProfessionSkill = 'Beruf: Künstler';
+        e.setSeaProfessionSkill(e.seaProfessionSkill);
+        e.seaKnowledgeOrCombatSkill = 'Nahkampf';
+        e.setSeaKnowledgeOrCombatSkill(e.seaKnowledgeOrCombatSkill);
+
+        expect(e.raceGrants.Nahkampf).toBeUndefined();
+        expect(e.raceGrants.Fernkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Unterhalten).toBeUndefined();
+        expect(e.cultureGrants.Sprachen).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants['Beruf: Farmer']).toBeUndefined();
+        expect(e.cultureGrants['Beruf: Künstler']).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Wissenschaftler).toBeUndefined();
+        expect(e.cultureGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+    });
+
+    it('kombiniert überlappende Rassen- und Kultur-Grants über den höchsten Mindestwert', () => {
+        const e = createEditor();
+        e.applyRaceHydrit();
+        e.applyCultureMeeresbewohner();
+
+        const athletik = e.skills.find(s => s.name === 'Athletik');
+
+        expect(e.getGrant('Athletik')).toEqual({ type: 'min', value: 2 });
+        expect(athletik).toMatchObject({ value: 2, badge: 'Rasse/Kultur' });
+        expect(e.fpUsed()).toBe(0);
+    });
+
+    it('Kulturwechsel entfernt Meeresbewohner-Boni ohne überlappende Rassen-Grants zu löschen', () => {
+        const e = createEditor();
+        e.applyRaceHydrit();
+        e.applyCultureMeeresbewohner();
+        e.clearCulture();
+
+        const athletik = e.skills.find(s => s.name === 'Athletik');
+
+        expect(athletik).toMatchObject({ value: 2, badge: 'Rasse' });
+        expect(e.cultureGrants).toEqual({});
+        expect(e.skills.find(s => s.name === 'Beruf: Farmer')).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Wissenschaftler')).toBeUndefined();
     });
 });
 

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -158,4 +158,63 @@ test.describe('RPG Charakter-Editor', () => {
         expect(payload).toContain('Primitiv');
         expect(payload).toContain('Gejagt');
     });
+
+    test('setzt Hydrit- und Meeresbewohner-Regeln inklusive Wahlboni im Formularpayload um', async ({ page }) => {
+        await openAdvancedEditor(page, { race: 'Hydrit', culture: 'Meeresbewohner' });
+
+        await expect(checkbox(page, 'advantages[]', 'Kiemen')).toBeChecked();
+        await expect(checkbox(page, 'advantages[]', 'Kiemen')).toBeDisabled();
+        await expect(checkbox(page, 'advantages[]', 'Natürliche Waffen')).toBeChecked();
+        await expect(checkbox(page, 'advantages[]', 'Natürliche Waffen')).toBeDisabled();
+        await expect(checkbox(page, 'disadvantages[]', 'Anfälligkeit gegen Wahnsinn')).toBeChecked();
+        await expect(checkbox(page, 'disadvantages[]', 'Anfälligkeit gegen Wahnsinn')).toBeDisabled();
+        await expect(page.getByText('Freie Vorteile: 2')).toBeVisible();
+
+        await page.locator('#sea-profession-select').selectOption('Beruf: Künstler');
+        await page.locator('#sea-knowledge-combat-select').selectOption('Nahkampf');
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+            const skillsByIndex = {};
+
+            for (const [key, value] of data.entries()) {
+                const match = key.match(/^skills\[(\d+)]\[(name|value)]$/);
+
+                if (!match) {
+                    continue;
+                }
+
+                const [, index, field] = match;
+                skillsByIndex[index] ??= {};
+                skillsByIndex[index][field] = value;
+            }
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+                advantages: data.getAll('advantages[]'),
+                disadvantages: data.getAll('disadvantages[]'),
+                skills: Object.values(skillsByIndex),
+            };
+        });
+
+        expect(payload.race).toBe('Hydrit');
+        expect(payload.culture).toBe('Meeresbewohner');
+        expect(payload.advantages).toEqual(expect.arrayContaining(['Zäh', 'Kiemen', 'Natürliche Waffen']));
+        expect(payload.disadvantages).toContain('Anfälligkeit gegen Wahnsinn');
+        expect(payload.skills).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Athletik', value: '2' }),
+            expect.objectContaining({ name: 'Bildung', value: '1' }),
+            expect.objectContaining({ name: 'Natürliche Waffen', value: '1' }),
+            expect.objectContaining({ name: 'Beruf: Künstler', value: '1' }),
+            expect.objectContaining({ name: 'Nahkampf', value: '1' }),
+        ]));
+        expect(payload.skills.filter((skill) => skill.name === 'Athletik')).toHaveLength(1);
+        expect(payload.skills).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Beruf: Farmer' }),
+        ]));
+        expect(payload.skills).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Wissenschaftler' }),
+        ]));
+    });
 });


### PR DESCRIPTION
This pull request adds support for the new "Hydrit" (fish people) race and "Meeresbewohner" (sea dwellers) culture to the character editor, including all necessary logic, UI, and tests. It also refactors the way skill grants and locked advantages/disadvantages are handled to better support overlapping and dynamic grants from both race and culture.

**New Race and Culture Support:**

* Added "Hydrit" as a selectable race with a full description and specific grants: automatic skill minimums, locked advantages ("Kiemen", "Natürliche Waffen"), and a locked disadvantage ("Anfälligkeit gegen Wahnsinn"). [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L3-R10) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R74)
* Added "Meeresbewohner" as a culture, including UI for selecting sea-profession and knowledge/combat skills, and logic for applying the correct grants. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L3-R10) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R84) [[3]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R134-R150) [[4]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R194-R195)

**Skill Grant and Locking Refactor:**

* Refactored the logic for applying, combining, and removing skill grants from race and culture, ensuring correct badge labeling, value locking, and dynamic updates when changing selections. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L226-R279) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R392-R402) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R422-R462) [[4]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R477-R532)
* Improved handling of locked advantages and disadvantages, so that required traits from race/culture are always enforced and do not consume free advantage points. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L108-R112) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R392-R402) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R477-R532) [[4]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R250-R251)

**Testing:**

* Added comprehensive tests for the "Hydrit" race, checking skill grants, locked traits, advantage point calculation, and correct cleanup when changing race.

These changes ensure that the new race and culture work seamlessly with the existing character editor logic and provide a more robust and maintainable system for future expansions.