### PR TITLE
Fix: Export PDF char sheet does not work

### DIFF
--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Spatie\LaravelPdf\Facades\Pdf;
@@ -57,7 +58,7 @@ class RpgCharEditorController extends Controller
         ]);
         $request->session()->put(self::PDF_EXPORT_SESSION_ACTIVE_TOKEN_KEY, $token);
 
-        return redirect()->route('rpg.char-editor.pdf.show', ['token' => $token]);
+        return redirect()->route('rpg.char-editor.pdf.show', ['token' => $token], Response::HTTP_SEE_OTHER);
     }
 
     /**

--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -30,6 +30,8 @@ class RpgCharEditorController extends Controller
 
     private const PDF_EXPORT_SESSION_MINUTES = 10;
 
+    private const PDF_EXPORT_SESSION_ACTIVE_TOKEN_KEY = 'rpg-char-editor-pdf.active-token';
+
     /**
      * Show the character editor form.
      */
@@ -46,11 +48,14 @@ class RpgCharEditorController extends Controller
         $data = $this->pdfPayload($request);
         $token = (string) Str::uuid();
 
+        $this->forgetPreviousPdfExport($request);
+
         $request->session()->put($this->pdfExportSessionKey($token), [
             'user_id' => (string) $request->user()->getAuthIdentifier(),
             'expires_at' => now()->addMinutes(self::PDF_EXPORT_SESSION_MINUTES)->getTimestamp(),
             'data' => $data,
         ]);
+        $request->session()->put(self::PDF_EXPORT_SESSION_ACTIVE_TOKEN_KEY, $token);
 
         return redirect()->route('rpg.char-editor.pdf.show', ['token' => $token]);
     }
@@ -65,6 +70,7 @@ class RpgCharEditorController extends Controller
 
         if (! $this->isValidPdfExport($request, $export)) {
             $request->session()->forget($sessionKey);
+            $this->forgetActivePdfExport($request, $token);
             abort(404);
         }
 
@@ -102,6 +108,24 @@ class RpgCharEditorController extends Controller
     private function pdfExportSessionKey(string $token): string
     {
         return 'rpg-char-editor-pdf.'.$token;
+    }
+
+    private function forgetPreviousPdfExport(Request $request): void
+    {
+        $previousToken = $request->session()->pull(self::PDF_EXPORT_SESSION_ACTIVE_TOKEN_KEY);
+
+        if (is_string($previousToken)) {
+            $request->session()->forget($this->pdfExportSessionKey($previousToken));
+        }
+    }
+
+    private function forgetActivePdfExport(Request $request, string $token): void
+    {
+        if ($request->session()->get(self::PDF_EXPORT_SESSION_ACTIVE_TOKEN_KEY) !== $token) {
+            return;
+        }
+
+        $request->session()->forget(self::PDF_EXPORT_SESSION_ACTIVE_TOKEN_KEY);
     }
 
     private function isValidPdfExport(Request $request, mixed $export): bool

--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -28,6 +28,8 @@ class RpgCharEditorController extends Controller
 
     private const PORTRAIT_DATA_URL_MAX_CHARS = self::PORTRAIT_DATA_URL_PREFIX_MAX_CHARS + self::PORTRAIT_MAX_BASE64_CHARS;
 
+    private const PDF_EXPORT_SESSION_MINUTES = 10;
+
     /**
      * Show the character editor form.
      */
@@ -37,16 +39,46 @@ class RpgCharEditorController extends Controller
     }
 
     /**
-     * Generate a character sheet PDF.
+     * Prepare a character sheet PDF and redirect to a GET viewer URL.
      */
-    public function pdf(Request $request)
+    public function storePdfExport(Request $request)
+    {
+        $data = $this->pdfPayload($request);
+        $token = (string) Str::uuid();
+
+        $request->session()->put($this->pdfExportSessionKey($token), [
+            'user_id' => (string) $request->user()->getAuthIdentifier(),
+            'expires_at' => now()->addMinutes(self::PDF_EXPORT_SESSION_MINUTES)->getTimestamp(),
+            'data' => $data,
+        ]);
+
+        return redirect()->route('rpg.char-editor.pdf.show', ['token' => $token]);
+    }
+
+    /**
+     * Generate a character sheet PDF from a prepared export payload.
+     */
+    public function showPdf(Request $request, string $token)
+    {
+        $sessionKey = $this->pdfExportSessionKey($token);
+        $export = $request->session()->get($sessionKey);
+
+        if (! $this->isValidPdfExport($request, $export)) {
+            $request->session()->forget($sessionKey);
+            abort(404);
+        }
+
+        return $this->pdfResponse($export['data']);
+    }
+
+    private function pdfPayload(Request $request): array
     {
         $request->validate([
             'portrait' => 'nullable|image|max:2048',
             'portrait_data_url' => 'nullable|string|max:'.self::PORTRAIT_DATA_URL_MAX_CHARS,
         ]);
 
-        $data = [
+        return [
             'character' => $this->characterPayload($request),
             'attributes' => $this->attributesPayload($request->input('attributes', [])),
             'skills' => $this->skillsPayload($request->input('skills', [])),
@@ -54,7 +86,10 @@ class RpgCharEditorController extends Controller
             'disadvantages' => $this->listPayload($request->input('disadvantages', [])),
             'portrait' => $this->portraitPayload($request),
         ];
+    }
 
+    private function pdfResponse(array $data)
+    {
         $name = Str::slug($data['character']['character_name'] ?: 'charakter') ?: 'charakter';
 
         return Pdf::view('rpg.char-sheet', $data)
@@ -62,6 +97,20 @@ class RpgCharEditorController extends Controller
             ->format('a4')
             ->margins(10, 10, 10, 10)
             ->inline($name.'.pdf');
+    }
+
+    private function pdfExportSessionKey(string $token): string
+    {
+        return 'rpg-char-editor-pdf.'.$token;
+    }
+
+    private function isValidPdfExport(Request $request, mixed $export): bool
+    {
+        return is_array($export)
+            && ($export['user_id'] ?? null) === (string) $request->user()->getAuthIdentifier()
+            && is_numeric($export['expires_at'] ?? null)
+            && (int) $export['expires_at'] >= now()->getTimestamp()
+            && is_array($export['data'] ?? null);
     }
 
     private function characterPayload(Request $request): array

--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Spatie\LaravelPdf\Facades\Pdf;
@@ -31,6 +33,10 @@ class RpgCharEditorController extends Controller
 
     private const PDF_EXPORT_SESSION_MINUTES = 10;
 
+    private const PDF_EXPORT_CACHE_STORE = 'rpg_pdf_exports';
+
+    private const PDF_EXPORT_CACHE_KEY_PREFIX = 'rpg-char-editor-pdf:';
+
     private const PDF_EXPORT_SESSION_ACTIVE_TOKEN_KEY = 'rpg-char-editor-pdf.active-token';
 
     /**
@@ -50,12 +56,12 @@ class RpgCharEditorController extends Controller
         $token = (string) Str::uuid();
 
         $this->forgetPreviousPdfExport($request);
-
-        $request->session()->put($this->pdfExportSessionKey($token), [
+        $this->putPdfExport($token, [
             'user_id' => (string) $request->user()->getAuthIdentifier(),
             'expires_at' => now()->addMinutes(self::PDF_EXPORT_SESSION_MINUTES)->getTimestamp(),
             'data' => $data,
         ]);
+
         $request->session()->put(self::PDF_EXPORT_SESSION_ACTIVE_TOKEN_KEY, $token);
 
         return redirect()->route('rpg.char-editor.pdf.show', ['token' => $token], Response::HTTP_SEE_OTHER);
@@ -66,11 +72,13 @@ class RpgCharEditorController extends Controller
      */
     public function showPdf(Request $request, string $token)
     {
-        $sessionKey = $this->pdfExportSessionKey($token);
-        $export = $request->session()->get($sessionKey);
+        $export = $this->getPdfExport($token);
 
         if (! $this->isValidPdfExport($request, $export)) {
-            $request->session()->forget($sessionKey);
+            if (! $this->isFreshPdfExportOwnedByAnotherUser($request, $export)) {
+                $this->forgetPdfExport($token);
+            }
+
             $this->forgetActivePdfExport($request, $token);
             abort(404);
         }
@@ -106,9 +114,33 @@ class RpgCharEditorController extends Controller
             ->inline($name.'.pdf');
     }
 
-    private function pdfExportSessionKey(string $token): string
+    private function pdfExportCache(): CacheRepository
     {
-        return 'rpg-char-editor-pdf.'.$token;
+        return Cache::store(self::PDF_EXPORT_CACHE_STORE);
+    }
+
+    private function pdfExportCacheKey(string $token): string
+    {
+        return self::PDF_EXPORT_CACHE_KEY_PREFIX.$token;
+    }
+
+    private function putPdfExport(string $token, array $export): void
+    {
+        $this->pdfExportCache()->put(
+            $this->pdfExportCacheKey($token),
+            $export,
+            now()->addMinutes(self::PDF_EXPORT_SESSION_MINUTES),
+        );
+    }
+
+    private function getPdfExport(string $token): mixed
+    {
+        return $this->pdfExportCache()->get($this->pdfExportCacheKey($token));
+    }
+
+    private function forgetPdfExport(string $token): void
+    {
+        $this->pdfExportCache()->forget($this->pdfExportCacheKey($token));
     }
 
     private function forgetPreviousPdfExport(Request $request): void
@@ -116,7 +148,7 @@ class RpgCharEditorController extends Controller
         $previousToken = $request->session()->pull(self::PDF_EXPORT_SESSION_ACTIVE_TOKEN_KEY);
 
         if (is_string($previousToken)) {
-            $request->session()->forget($this->pdfExportSessionKey($previousToken));
+            $this->forgetPdfExport($previousToken);
         }
     }
 
@@ -133,6 +165,16 @@ class RpgCharEditorController extends Controller
     {
         return is_array($export)
             && ($export['user_id'] ?? null) === (string) $request->user()->getAuthIdentifier()
+            && is_numeric($export['expires_at'] ?? null)
+            && (int) $export['expires_at'] >= now()->getTimestamp()
+            && is_array($export['data'] ?? null);
+    }
+
+    private function isFreshPdfExportOwnedByAnotherUser(Request $request, mixed $export): bool
+    {
+        return is_array($export)
+            && is_string($export['user_id'] ?? null)
+            && ($export['user_id'] ?? null) !== (string) $request->user()->getAuthIdentifier()
             && is_numeric($export['expires_at'] ?? null)
             && (int) $export['expires_at'] >= now()->getTimestamp()
             && is_array($export['data'] ?? null);

--- a/config/cache.php
+++ b/config/cache.php
@@ -46,6 +46,12 @@ return [
             'lock_table' => env('DB_CACHE_LOCK_TABLE'),
         ],
 
+        'rpg_pdf_exports' => [
+            'driver' => 'file',
+            'path' => storage_path('framework/cache/rpg-char-editor-pdf'),
+            'lock_path' => storage_path('framework/cache/rpg-char-editor-pdf'),
+        ],
+
         'file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),

--- a/routes/web.php
+++ b/routes/web.php
@@ -334,9 +334,14 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         ->name('rpg.char-editor')
         ->middleware('can:access-rpg-char-editor');
 
-    Route::post('/rpg/char-editor/pdf', [RpgCharEditorController::class, 'pdf'])
+    Route::post('/rpg/char-editor/pdf', [RpgCharEditorController::class, 'storePdfExport'])
         ->name('rpg.char-editor.pdf')
         ->middleware('can:access-rpg-char-editor');
+
+    Route::get('/rpg/char-editor/pdf/{token}', [RpgCharEditorController::class, 'showPdf'])
+        ->name('rpg.char-editor.pdf.show')
+        ->middleware('can:access-rpg-char-editor')
+        ->whereUuid('token');
 
     Route::prefix('romantauschboerse')->name('romantausch.')->group(function () {
         Route::livewire('/', RomantauschIndex::class)->name('index');

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
 use Spatie\LaravelPdf\Facades\Pdf;
 use Spatie\LaravelPdf\PdfBuilder;
 use Tests\TestCase;
@@ -16,6 +17,20 @@ use Tests\TestCase;
 class RpgCharEditorPdfTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::store('rpg_pdf_exports')->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::store('rpg_pdf_exports')->flush();
+
+        parent::tearDown();
+    }
 
     private function validPdfPayload(array $overrides = []): array
     {
@@ -126,7 +141,7 @@ class RpgCharEditorPdfTest extends TestCase
         $this->actingAs($member)->get($path)->assertOk();
     }
 
-    public function test_pdf_export_replaces_previous_session_payload_when_new_export_is_created(): void
+    public function test_pdf_export_replaces_previous_cached_payload_when_new_export_is_created(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());
 
@@ -134,24 +149,31 @@ class RpgCharEditorPdfTest extends TestCase
             'character_name' => 'Erster Charakter',
         ]));
         $firstToken = basename(parse_url($firstResponse->headers->get('Location'), PHP_URL_PATH));
-        $firstSessionKey = 'rpg-char-editor-pdf.'.$firstToken;
+        $firstCacheKey = 'rpg-char-editor-pdf:'.$firstToken;
+        $firstSessionPayloadKey = 'rpg-char-editor-pdf.'.$firstToken;
 
         $firstResponse
             ->assertRedirect()
-            ->assertSessionHas($firstSessionKey)
+            ->assertSessionMissing($firstSessionPayloadKey)
             ->assertSessionHas('rpg-char-editor-pdf.active-token', $firstToken);
+
+        $this->assertTrue(Cache::store('rpg_pdf_exports')->has($firstCacheKey));
 
         $secondResponse = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
             'character_name' => 'Zweiter Charakter',
         ]));
         $secondToken = basename(parse_url($secondResponse->headers->get('Location'), PHP_URL_PATH));
-        $secondSessionKey = 'rpg-char-editor-pdf.'.$secondToken;
+        $secondCacheKey = 'rpg-char-editor-pdf:'.$secondToken;
+        $secondSessionPayloadKey = 'rpg-char-editor-pdf.'.$secondToken;
 
         $secondResponse
             ->assertRedirect()
-            ->assertSessionMissing($firstSessionKey)
-            ->assertSessionHas($secondSessionKey)
+            ->assertSessionMissing($firstSessionPayloadKey)
+            ->assertSessionMissing($secondSessionPayloadKey)
             ->assertSessionHas('rpg-char-editor-pdf.active-token', $secondToken);
+
+        $this->assertFalse(Cache::store('rpg_pdf_exports')->has($firstCacheKey));
+        $this->assertTrue(Cache::store('rpg_pdf_exports')->has($secondCacheKey));
 
         Pdf::shouldReceive('view')->never();
 
@@ -166,9 +188,19 @@ class RpgCharEditorPdfTest extends TestCase
         $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload());
         $path = parse_url($response->headers->get('Location'), PHP_URL_PATH);
 
-        Pdf::shouldReceive('view')->never();
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::type('array'))
+            ->andReturnUsing(fn () => new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
 
         $this->actingAs($otherMember)->get($path)->assertNotFound();
+        $this->actingAs($member)->get($path)->assertOk();
     }
 
     public function test_pdf_export_get_route_rejects_unknown_tokens(): void
@@ -189,19 +221,23 @@ class RpgCharEditorPdfTest extends TestCase
 
         Pdf::shouldReceive('view')->never();
 
+        $cacheKey = 'rpg-char-editor-pdf:'.$token;
+
+        Cache::store('rpg_pdf_exports')->put($cacheKey, [
+            'user_id' => (string) $member->getAuthIdentifier(),
+            'expires_at' => now()->subMinute()->getTimestamp(),
+            'data' => $this->validPdfPayload(),
+        ], now()->addMinute());
+
         $this->withSession([
             'rpg-char-editor-pdf.active-token' => $token,
-            'rpg-char-editor-pdf.'.$token => [
-                'user_id' => (string) $member->getAuthIdentifier(),
-                'expires_at' => now()->subMinute()->getTimestamp(),
-                'data' => $this->validPdfPayload(),
-            ],
         ])
             ->actingAs($member)
             ->get('/rpg/char-editor/pdf/'.$token)
             ->assertNotFound()
-            ->assertSessionMissing('rpg-char-editor-pdf.'.$token)
             ->assertSessionMissing('rpg-char-editor-pdf.active-token');
+
+        $this->assertFalse(Cache::store('rpg_pdf_exports')->has($cacheKey));
     }
 
     public function test_pdf_view_receives_normalized_browser_payload_for_disabled_editor_fields(): void

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -89,6 +89,84 @@ class RpgCharEditorPdfTest extends TestCase
         return $user->refresh();
     }
 
+    public function test_pdf_export_post_redirects_to_get_viewer_url(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload());
+
+        $response->assertRedirect();
+
+        $path = parse_url($response->headers->get('Location'), PHP_URL_PATH);
+
+        $this->assertMatchesRegularExpression('#^/rpg/char-editor/pdf/[0-9a-f-]{36}$#', $path);
+    }
+
+    public function test_pdf_export_get_route_can_be_opened_repeatedly_by_pdf_viewers(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload());
+        $path = parse_url($response->headers->get('Location'), PHP_URL_PATH);
+
+        Pdf::shouldReceive('view')
+            ->twice()
+            ->with('rpg.char-sheet', \Mockery::type('array'))
+            ->andReturnUsing(fn () => new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $this->actingAs($member)->get($path)->assertOk();
+        $this->actingAs($member)->get($path)->assertOk();
+    }
+
+    public function test_pdf_export_get_route_is_scoped_to_exporting_user(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+        $otherMember = $this->addAgRollenspielMembership($this->createMember());
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload());
+        $path = parse_url($response->headers->get('Location'), PHP_URL_PATH);
+
+        Pdf::shouldReceive('view')->never();
+
+        $this->actingAs($otherMember)->get($path)->assertNotFound();
+    }
+
+    public function test_pdf_export_get_route_rejects_unknown_tokens(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        $this->actingAs($member)
+            ->get('/rpg/char-editor/pdf/00000000-0000-4000-8000-000000000000')
+            ->assertNotFound();
+    }
+
+    public function test_pdf_export_get_route_rejects_expired_tokens(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+        $token = '00000000-0000-4000-8000-000000000001';
+
+        Pdf::shouldReceive('view')->never();
+
+        $this->withSession([
+            'rpg-char-editor-pdf.'.$token => [
+                'user_id' => (string) $member->getAuthIdentifier(),
+                'expires_at' => now()->subMinute()->getTimestamp(),
+                'data' => $this->validPdfPayload(),
+            ],
+        ])
+            ->actingAs($member)
+            ->get('/rpg/char-editor/pdf/'.$token)
+            ->assertNotFound();
+    }
+
     public function test_pdf_view_receives_normalized_browser_payload_for_disabled_editor_fields(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());
@@ -121,7 +199,7 @@ class RpgCharEditorPdfTest extends TestCase
                 }
             });
 
-        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             '_token' => 'ignored by payload whitelist',
             'player_name' => 'Holger',
             'character_name' => 'Holli',
@@ -179,7 +257,7 @@ class RpgCharEditorPdfTest extends TestCase
                 }
             });
 
-        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Collection Payload',
             'attributes' => [
                 'st' => ' 2 ',
@@ -235,7 +313,7 @@ class RpgCharEditorPdfTest extends TestCase
                 }
             });
 
-        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             'player_name' => ' Holger ',
             'character_name' => ['manipuliert'],
             'race' => 123,
@@ -265,7 +343,7 @@ class RpgCharEditorPdfTest extends TestCase
                 }
             });
 
-        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             ...$this->validPdfPayload(['character_name' => 'Preview Portrait']),
             'portrait_data_url' => $dataUrl,
         ]);
@@ -355,7 +433,7 @@ class RpgCharEditorPdfTest extends TestCase
                 }
             });
 
-        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Foo/Bar',
             'portrait' => UploadedFile::fake()->image('avatar.jpg'),
         ]);
@@ -378,7 +456,7 @@ class RpgCharEditorPdfTest extends TestCase
     {
         $member = $this->addAgRollenspielMembership($this->createMember());
 
-        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload());
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload());
 
         $response->assertOk();
         $response->assertHeader('content-type', 'application/pdf');
@@ -401,7 +479,7 @@ class RpgCharEditorPdfTest extends TestCase
                 }
             });
 
-        $response = $this->actingAs($admin)->post('/rpg/char-editor/pdf', [
+        $response = $this->followingRedirects()->actingAs($admin)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Foo',
         ]);
 
@@ -412,7 +490,7 @@ class RpgCharEditorPdfTest extends TestCase
     {
         $member = $this->addAgRollenspielMembership($this->createMember());
 
-        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             ...$this->validPdfPayload(['character_name' => 'Mit Portrait']),
             'portrait' => UploadedFile::fake()->image('avatar.png', 120, 120),
         ]);
@@ -437,7 +515,7 @@ class RpgCharEditorPdfTest extends TestCase
                 }
             });
 
-        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', [
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Foo',
             'portrait' => UploadedFile::fake()->image('avatar.png'),
         ]);

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -124,6 +124,38 @@ class RpgCharEditorPdfTest extends TestCase
         $this->actingAs($member)->get($path)->assertOk();
     }
 
+    public function test_pdf_export_replaces_previous_session_payload_when_new_export_is_created(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        $firstResponse = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'character_name' => 'Erster Charakter',
+        ]));
+        $firstToken = basename(parse_url($firstResponse->headers->get('Location'), PHP_URL_PATH));
+        $firstSessionKey = 'rpg-char-editor-pdf.'.$firstToken;
+
+        $firstResponse
+            ->assertRedirect()
+            ->assertSessionHas($firstSessionKey)
+            ->assertSessionHas('rpg-char-editor-pdf.active-token', $firstToken);
+
+        $secondResponse = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'character_name' => 'Zweiter Charakter',
+        ]));
+        $secondToken = basename(parse_url($secondResponse->headers->get('Location'), PHP_URL_PATH));
+        $secondSessionKey = 'rpg-char-editor-pdf.'.$secondToken;
+
+        $secondResponse
+            ->assertRedirect()
+            ->assertSessionMissing($firstSessionKey)
+            ->assertSessionHas($secondSessionKey)
+            ->assertSessionHas('rpg-char-editor-pdf.active-token', $secondToken);
+
+        Pdf::shouldReceive('view')->never();
+
+        $this->actingAs($member)->get('/rpg/char-editor/pdf/'.$firstToken)->assertNotFound();
+    }
+
     public function test_pdf_export_get_route_is_scoped_to_exporting_user(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());
@@ -156,6 +188,7 @@ class RpgCharEditorPdfTest extends TestCase
         Pdf::shouldReceive('view')->never();
 
         $this->withSession([
+            'rpg-char-editor-pdf.active-token' => $token,
             'rpg-char-editor-pdf.'.$token => [
                 'user_id' => (string) $member->getAuthIdentifier(),
                 'expires_at' => now()->subMinute()->getTimestamp(),
@@ -164,7 +197,9 @@ class RpgCharEditorPdfTest extends TestCase
         ])
             ->actingAs($member)
             ->get('/rpg/char-editor/pdf/'.$token)
-            ->assertNotFound();
+            ->assertNotFound()
+            ->assertSessionMissing('rpg-char-editor-pdf.'.$token)
+            ->assertSessionMissing('rpg-char-editor-pdf.active-token');
     }
 
     public function test_pdf_view_receives_normalized_browser_payload_for_disabled_editor_fields(): void

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -95,7 +95,9 @@ class RpgCharEditorPdfTest extends TestCase
 
         $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload());
 
-        $response->assertRedirect();
+        $response
+            ->assertStatus(Response::HTTP_SEE_OTHER)
+            ->assertRedirect();
 
         $path = parse_url($response->headers->get('Location'), PHP_URL_PATH);
 

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -103,16 +103,16 @@ test.describe('RPG Charakter-Editor', () => {
             }
         });
 
-        const popupPromise = page.waitForEvent('popup', { timeout: 5000 }).catch(() => null);
-
-        await page.getByTestId('pdf-button').click();
-        const popup = await popupPromise;
+        const [popup] = await Promise.all([
+            page.waitForEvent('popup', { timeout: 5000 }),
+            page.getByTestId('pdf-button').click(),
+        ]);
 
         await expect.poll(() => pdfRequests.some((request) => request.method === 'GET' && pdfViewerPath.test(request.pathname))).toBe(true);
         expect(pdfRequests.filter((request) => request.method === 'POST' && request.pathname === '/rpg/char-editor/pdf')).toHaveLength(1);
         expect(pdfRequests.filter((request) => request.method === 'POST' && request.pathname !== '/rpg/char-editor/pdf')).toHaveLength(0);
 
-        await popup?.close().catch(() => {});
+        await popup.close().catch(() => {});
     });
 
     test('sendet gesperrte Basisdaten und automatisch gewährte Fertigkeiten im Formularpayload', async ({ page }) => {

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -23,6 +23,29 @@ const openAdvancedEditor = async (page, { race = 'Barbar', culture = 'Landbewohn
 };
 
 const checkbox = (page, name, value) => page.locator(`input[type="checkbox"][name="${name}"][value="${value}"]`);
+const completeValidBarbarExport = async (page) => {
+    await page.getByTestId('char-editor-form').evaluate((form) => {
+        const state = window.Alpine?.$data(form);
+
+        if (!state) {
+            throw new Error('Charakter-Editor-State konnte nicht gefunden werden.');
+        }
+
+        state.attributes.st = 2;
+        state.attributes.ge = 1;
+
+        for (const skill of state.skills) {
+            if (!skill.valueDisabled) {
+                skill.value = 4;
+            }
+        }
+
+        state.skills.push({ name: 'Fahren', value: 4, source: null, locked: false, nameDisabled: false, valueDisabled: false, badge: null });
+        state.skills.push({ name: 'Handeln', value: 4, source: null, locked: false, nameDisabled: false, valueDisabled: false, badge: null });
+    });
+
+    await expect(page.getByTestId('pdf-button')).toBeEnabled();
+};
 
 test.describe('RPG Charakter-Editor', () => {
     test('lädt ohne Persist-Fehler und sperrt den Formularfluss initial korrekt', async ({ page }) => {
@@ -63,6 +86,33 @@ test.describe('RPG Charakter-Editor', () => {
 
         expect(pageErrors).toEqual([]);
         expect(consoleErrors.filter((message) => /\$persist|Cannot redefine property: \$persist/i.test(message))).toEqual([]);
+    });
+
+    test('oeffnet den PDF-Export browseruebergreifend ueber eine GET-Viewer-URL', async ({ page }) => {
+        await openAdvancedEditor(page);
+        await completeValidBarbarExport(page);
+
+        const pdfRequests = [];
+        const pdfViewerPath = /^\/rpg\/char-editor\/pdf\/[0-9a-f-]{36}$/;
+
+        page.context().on('request', (request) => {
+            const url = new URL(request.url());
+
+            if (url.pathname.startsWith('/rpg/char-editor/pdf')) {
+                pdfRequests.push({ method: request.method(), pathname: url.pathname });
+            }
+        });
+
+        const popupPromise = page.waitForEvent('popup', { timeout: 5000 }).catch(() => null);
+
+        await page.getByTestId('pdf-button').click();
+        const popup = await popupPromise;
+
+        await expect.poll(() => pdfRequests.some((request) => request.method === 'GET' && pdfViewerPath.test(request.pathname))).toBe(true);
+        expect(pdfRequests.filter((request) => request.method === 'POST' && request.pathname === '/rpg/char-editor/pdf')).toHaveLength(1);
+        expect(pdfRequests.filter((request) => request.method === 'POST' && request.pathname !== '/rpg/char-editor/pdf')).toHaveLength(0);
+
+        await popup?.close().catch(() => {});
     });
 
     test('sendet gesperrte Basisdaten und automatisch gewährte Fertigkeiten im Formularpayload', async ({ page }) => {


### PR DESCRIPTION
This pull request introduces a new, more secure and user-friendly workflow for exporting RPG character sheets as PDFs. Instead of generating the PDF directly on POST, the export is now prepared and cached, and users are redirected to a GET endpoint with a unique token to retrieve the PDF. This approach improves cache management, access control, and allows for repeated downloads by the exporting user. The changes include controller refactoring, new routes, a dedicated cache store, and comprehensive feature tests.

**Controller and Export Workflow Refactor:**

- Refactored `RpgCharEditorController` to separate PDF export preparation (`storePdfExport`) and PDF retrieval (`showPdf`), using a cache-backed token system for improved access control and session management. Added helper methods for cache operations and validation logic. [[1]](diffhunk://#diff-cc4e8a0530fc1f0b8a79eef9d32623f68bfc4dcf332e23360b25f2c63b266c1eR34-R41) [[2]](diffhunk://#diff-cc4e8a0530fc1f0b8a79eef9d32623f68bfc4dcf332e23360b25f2c63b266c1eL40-R107) [[3]](diffhunk://#diff-cc4e8a0530fc1f0b8a79eef9d32623f68bfc4dcf332e23360b25f2c63b266c1eR117-R182)

**Routing and Cache Configuration:**

- Updated routes to use the new POST (prepare) and GET (retrieve) endpoints for PDF exports, including UUID token validation.
- Added a dedicated `rpg_pdf_exports` file cache store in `config/cache.php` for storing export payloads.

**Testing Improvements:**

- Significantly expanded and refactored `RpgCharEditorPdfTest` to cover the new workflow, including tests for token scoping, cache invalidation, repeated access, and expired/unknown tokens. Ensured cache isolation in test setup/teardown. Updated all relevant tests to follow redirects as per the new workflow. [[1]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692R12) [[2]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692R21-R34) [[3]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692R107-R242) [[4]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L124-R275) [[5]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L182-R333) [[6]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L238-R389) [[7]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L268-R419) [[8]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L358-R509) [[9]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L381-R532) [[10]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L404-R555) [[11]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L415-R566) [[12]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692L440-R591)

**End-to-End Test Utility:**

- Added a utility function in the E2E test suite to quickly fill out a valid character export for streamlined scenario testing.