### PR TITLE
Fix: Enforce Hydrit race to Meeresbewohner culture

### DIFF
--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -188,7 +188,20 @@ class RpgCharEditorController extends Controller
             $character[$key] = $this->stringPayload($request->input($key, ''));
         }
 
+        $this->validateCharacterRules($character);
+
         return $character;
+    }
+
+    private function validateCharacterRules(array $character): void
+    {
+        if (($character['race'] ?? '') !== 'Hydrit' || ($character['culture'] ?? '') === 'Meeresbewohner') {
+            return;
+        }
+
+        throw ValidationException::withMessages([
+            'culture' => 'Hydriten können laut Regelwerk nur die Kultur Meeresbewohner wählen.',
+        ]);
     }
 
     private function stringPayload(mixed $value): string

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -175,8 +175,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (allowedCultures.length !== 1) return false;
 
         const [defaultCulture] = allowedCultures;
+        this.clearCulture();
         this.culture = defaultCulture;
-        this.handleCultureChange();
 
         return true;
     },
@@ -469,7 +469,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     // --- Culture handling ---
     handleCultureChange() {
-        if (!this.isCultureSelectable(this.culture) && this.enforceCultureForRace()) {
+        if (!this.isCultureSelectable(this.culture)) {
+            this.enforceCultureForRace();
             return;
         }
 

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -10,6 +10,7 @@ const CULTURE_DESCRIPTIONS = {
     Meeresbewohner: 'Meeresbewohner sind Hydriten aus großen, seit langem verborgenen Unterseestädten. Ihre Gesellschaft ist streng hierarchisch organisiert, technisch und biotechnologisch weit fortgeschritten und meidet den Kontakt zu Oberflächenbewohnern.'
 };
 
+const CULTURE_NAMES = Object.keys(CULTURE_DESCRIPTIONS);
 const ATTRIBUTE_IDS = ['st', 'ge', 'ro', 'wi', 'wa', 'in', 'au'];
 
 function hydrateExistingCharEditors() {
@@ -156,6 +157,28 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
             if (this.raceGrants['Bildung']) used.add('Intuition');
         }
         return used;
+    },
+
+    allowedCulturesForRace(race = this.race) {
+        if (race === 'Hydrit') return ['Meeresbewohner'];
+
+        return CULTURE_NAMES;
+    },
+
+    isCultureSelectable(culture) {
+        return this.allowedCulturesForRace().includes(culture);
+    },
+
+    enforceCultureForRace() {
+        const allowedCultures = this.allowedCulturesForRace();
+        if (allowedCultures.includes(this.culture)) return false;
+        if (allowedCultures.length !== 1) return false;
+
+        const [defaultCulture] = allowedCultures;
+        this.culture = defaultCulture;
+        this.handleCultureChange();
+
+        return true;
     },
 
     // --- Methods ---
@@ -358,6 +381,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (this.race === 'Guul') this.applyRaceGuul();
         if (this.race === 'Hydrit') this.applyRaceHydrit();
         this.restoreRaceState(this.race);
+        this.enforceCultureForRace();
         this._prevRace = this.race;
         this.updateDescription();
     },
@@ -445,6 +469,10 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     // --- Culture handling ---
     handleCultureChange() {
+        if (!this.isCultureSelectable(this.culture) && this.enforceCultureForRace()) {
+            return;
+        }
+
         this.clearCulture();
         if (this.culture === 'Landbewohner') this.applyCultureLandbewohner();
         if (this.culture === 'Stadtbewohner') this.applyCultureStadtbewohner();

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -79,9 +79,9 @@
                         <label for="culture" class="block text-sm font-medium text-base-content mb-1">Kultur</label>
                         <select name="culture" id="culture" class="select select-bordered w-full" x-model="culture" :disabled="advancedUnlocked">
                             <option value="" disabled>Kultur wählen</option>
-                            <option value="Landbewohner">Landbewohner</option>
-                            <option value="Stadtbewohner">Stadtbewohner</option>
-                            <option value="Meeresbewohner">Meeresbewohner</option>
+                            <option value="Landbewohner" :disabled="!isCultureSelectable('Landbewohner')">Landbewohner</option>
+                            <option value="Stadtbewohner" :disabled="!isCultureSelectable('Stadtbewohner')">Stadtbewohner</option>
+                            <option value="Meeresbewohner" :disabled="!isCultureSelectable('Meeresbewohner')">Meeresbewohner</option>
                         </select>
                     </div>
 

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -299,6 +299,44 @@ class RpgCharEditorPdfTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_pdf_export_accepts_hydrit_with_meeresbewohner_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(fn ($data) => $data['character']['race'] === 'Hydrit'
+                && $data['character']['culture'] === 'Meeresbewohner'))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Hydrit',
+            'culture' => 'Meeresbewohner',
+        ]));
+
+        $response->assertOk();
+    }
+
+    public function test_pdf_export_rejects_hydrit_with_other_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Hydrit',
+            'culture' => 'Landbewohner',
+        ]));
+
+        $response->assertSessionHasErrors('culture');
+    }
+
     public function test_pdf_normalizes_collection_payloads_to_trimmed_scalar_strings(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -315,6 +315,19 @@ describe('charEditor – Kultur-Logik', () => {
         expect(barbar.culture).toBe('');
     });
 
+    it('erzwingt Hydrit-Kultur ohne direkten Kultur-Handler-Durchlauf', () => {
+        const e = createEditor({ race: 'Hydrit', culture: 'Landbewohner' });
+        e.applyCultureLandbewohner();
+        const handleCultureChange = vi.spyOn(e, 'handleCultureChange');
+
+        expect(e.enforceCultureForRace()).toBe(true);
+
+        expect(e.culture).toBe('Meeresbewohner');
+        expect(handleCultureChange).not.toHaveBeenCalled();
+        expect(e.cultureGrants).toEqual({});
+        expect(e.skills.find(s => s.name === 'Beruf: Landwirt')).toBeUndefined();
+    });
+
     it('Rassenwechsel zu Hydrit setzt Kultur auf Meeresbewohner und ersetzt alte Kultur-Grants', () => {
         const e = createEditor({ race: 'Hydrit', culture: 'Landbewohner' });
         e.applyCultureLandbewohner();
@@ -325,9 +338,13 @@ describe('charEditor – Kultur-Logik', () => {
 
         expect(e.culture).toBe('Meeresbewohner');
         expect(e.cultureGrants['Beruf: Landwirt']).toBeUndefined();
+        expect(e.cultureGrants['Beruf: Farmer']).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Beruf: Landwirt')).toBeUndefined();
+
+        e.handleCultureChange();
+
         expect(e.cultureGrants['Beruf: Farmer']).toEqual({ type: 'min', value: 1 });
         expect(e.cultureGrants.Wissenschaftler).toEqual({ type: 'min', value: 1 });
-        expect(e.skills.find(s => s.name === 'Beruf: Landwirt')).toBeUndefined();
         expect(e.skills.find(s => s.name === 'Athletik')).toMatchObject({ value: 2, badge: 'Rasse/Kultur' });
     });
 
@@ -338,6 +355,10 @@ describe('charEditor – Kultur-Logik', () => {
         e.handleCultureChange();
 
         expect(e.culture).toBe('Meeresbewohner');
+        expect(e.cultureGrants).toEqual({});
+
+        e.handleCultureChange();
+
         expect(e.cultureGrants.Athletik).toEqual({ type: 'min', value: 1 });
         expect(e.skills.find(s => s.name === 'Athletik')).toMatchObject({ value: 2, badge: 'Rasse/Kultur' });
     });

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -295,6 +295,53 @@ describe('charEditor – Rassen-Logik', () => {
 });
 
 describe('charEditor – Kultur-Logik', () => {
+    it('Hydrit erlaubt nur Meeresbewohner als Kultur', () => {
+        const e = createEditor({ race: 'Hydrit' });
+
+        expect(e.allowedCulturesForRace()).toEqual(['Meeresbewohner']);
+        expect(e.isCultureSelectable('Meeresbewohner')).toBe(true);
+        expect(e.isCultureSelectable('Landbewohner')).toBe(false);
+        expect(e.isCultureSelectable('Stadtbewohner')).toBe(false);
+
+        e.race = 'Barbar';
+
+        expect(e.isCultureSelectable('Landbewohner')).toBe(true);
+        expect(e.isCultureSelectable('Stadtbewohner')).toBe(true);
+        expect(e.isCultureSelectable('Meeresbewohner')).toBe(true);
+
+        const barbar = createEditor({ race: 'Barbar', culture: '' });
+        barbar.handleRaceChange();
+
+        expect(barbar.culture).toBe('');
+    });
+
+    it('Rassenwechsel zu Hydrit setzt Kultur auf Meeresbewohner und ersetzt alte Kultur-Grants', () => {
+        const e = createEditor({ race: 'Hydrit', culture: 'Landbewohner' });
+        e.applyCultureLandbewohner();
+
+        expect(e.cultureGrants['Beruf: Landwirt']).toEqual({ type: 'exact', value: 2 });
+
+        e.handleRaceChange();
+
+        expect(e.culture).toBe('Meeresbewohner');
+        expect(e.cultureGrants['Beruf: Landwirt']).toBeUndefined();
+        expect(e.cultureGrants['Beruf: Farmer']).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Wissenschaftler).toEqual({ type: 'min', value: 1 });
+        expect(e.skills.find(s => s.name === 'Beruf: Landwirt')).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Athletik')).toMatchObject({ value: 2, badge: 'Rasse/Kultur' });
+    });
+
+    it('direkter Kulturwechsel verhindert ungueltige Hydrit-Kultur', () => {
+        const e = createEditor({ race: 'Hydrit', culture: 'Landbewohner' });
+        e.applyRaceHydrit();
+
+        e.handleCultureChange();
+
+        expect(e.culture).toBe('Meeresbewohner');
+        expect(e.cultureGrants.Athletik).toEqual({ type: 'min', value: 1 });
+        expect(e.skills.find(s => s.name === 'Athletik')).toMatchObject({ value: 2, badge: 'Rasse/Kultur' });
+    });
+
     it('Landbewohner erhält Viehzüchter und Landwirt als Exact-Grants', () => {
         const e = createEditor();
         e.applyCultureLandbewohner();

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -209,6 +209,46 @@ test.describe('RPG Charakter-Editor', () => {
         expect(payload).toContain('Gejagt');
     });
 
+    test('erzwingt Meeresbewohner als einzige Kultur fuer Hydrit', async ({ page }) => {
+        await login(page, 'info@maddraxikon.com');
+        await page.goto('/rpg/char-editor');
+
+        await page.getByLabel('Spielername').fill('Playwright Spieler');
+        await page.getByLabel('Charaktername').fill('Wudan');
+        await page.locator('#culture').selectOption('Landbewohner');
+        await expect(page.locator('#culture')).toHaveValue('Landbewohner');
+
+        await page.locator('#race').selectOption('Hydrit');
+
+        await expect(page.locator('#culture')).toHaveValue('Meeresbewohner');
+
+        const cultureOptions = await page.locator('#culture').evaluate((select) => Object.fromEntries(
+            Array.from(select.options).map((option) => [option.value || 'placeholder', option.disabled]),
+        ));
+
+        expect(cultureOptions).toMatchObject({
+            Landbewohner: true,
+            Stadtbewohner: true,
+            Meeresbewohner: false,
+        });
+
+        await page.getByTestId('char-editor-continue-button').click();
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+            };
+        });
+
+        expect(payload).toEqual({
+            race: 'Hydrit',
+            culture: 'Meeresbewohner',
+        });
+    });
+
     test('setzt Hydrit- und Meeresbewohner-Regeln inklusive Wahlboni im Formularpayload um', async ({ page }) => {
         await openAdvancedEditor(page, { race: 'Hydrit', culture: 'Meeresbewohner' });
 


### PR DESCRIPTION
This pull request enforces a ruleset where the "Hydrit" race can only select the "Meeresbewohner" culture in the RPG character editor. The restriction is implemented consistently across backend validation, frontend UI logic, and is thoroughly tested with unit, feature, and end-to-end tests.

**Backend validation:**

* Added a validation rule in `RpgCharEditorController.php` to throw a validation error if a character of race "Hydrit" selects any culture other than "Meeresbewohner".

**Frontend logic and UI:**

* Updated `char-editor.js` to:
  * Dynamically determine allowed cultures for the selected race, restricting "Hydrit" to "Meeresbewohner". [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R13) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R162-R183)
  * Automatically enforce and correct the culture selection when the race changes to "Hydrit". [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R384) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R472-R476)
  * Disable invalid culture options in the culture `<select>` dropdown in the Blade template.

**Testing:**

* Added backend feature tests to verify that "Hydrit" with "Meeresbewohner" is accepted and other cultures are rejected.
* Added frontend unit tests to ensure the logic for allowed/auto-corrected cultures works as intended.
* Added end-to-end tests to check that the UI enforces the restriction and submits the correct values.