### PR TITLE
Feature: Techno race and Bunkermensch culture

### DIFF
--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -195,13 +195,26 @@ class RpgCharEditorController extends Controller
 
     private function validateCharacterRules(array $character): void
     {
-        if (($character['race'] ?? '') !== 'Hydrit' || ($character['culture'] ?? '') === 'Meeresbewohner') {
-            return;
+        $race = $character['race'] ?? '';
+        $culture = $character['culture'] ?? '';
+
+        if ($race === 'Hydrit' && $culture !== 'Meeresbewohner') {
+            throw ValidationException::withMessages([
+                'culture' => 'Hydriten können laut Regelwerk nur die Kultur Meeresbewohner wählen.',
+            ]);
         }
 
-        throw ValidationException::withMessages([
-            'culture' => 'Hydriten können laut Regelwerk nur die Kultur Meeresbewohner wählen.',
-        ]);
+        if ($race === 'Techno' && $culture !== 'Bunkermensch') {
+            throw ValidationException::withMessages([
+                'culture' => 'Technos können laut Regelwerk nur die Kultur Bunkermensch wählen.',
+            ]);
+        }
+
+        if ($culture === 'Bunkermensch' && $race !== 'Techno') {
+            throw ValidationException::withMessages([
+                'culture' => 'Die Kultur Bunkermensch ist laut Regelwerk nur für Technos zugelassen.',
+            ]);
+        }
     }
 
     private function stringPayload(mixed $value): string

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -106,12 +106,11 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     },
 
     getAttributeMin(id) {
-        const modifier = this.attributeModifier(id);
-        return modifier > 0 ? Math.min(modifier, this.attributeMax()) : -1;
+        return Math.max(-1, -1 + this.attributeModifier(id));
     },
 
-    getAttributeMax() {
-        return this.attributeMax();
+    getAttributeMax(id) {
+        return Math.max(this.getAttributeMin(id), this.attributeMax() + this.attributeModifier(id));
     },
 
     apUsed() {
@@ -448,8 +447,9 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
         Object.entries(modifiers).forEach(([id, modifier]) => {
             if (!ATTRIBUTE_IDS.includes(id)) return;
-            const currentValue = this.attributes[id] === 0 ? modifier : this.attributes[id];
-            this.attributes[id] = Math.max(this.getAttributeMin(id), Math.min(currentValue, this.getAttributeMax(id)));
+            const paidValue = Number.isFinite(Number(this.attributes[id])) ? Number(this.attributes[id]) : 0;
+            const modifiedValue = paidValue + modifier;
+            this.attributes[id] = Math.max(this.getAttributeMin(id), Math.min(modifiedValue, this.getAttributeMax(id)));
         });
     },
 
@@ -459,7 +459,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
         Object.entries(previousModifiers).forEach(([id, modifier]) => {
             if (!ATTRIBUTE_IDS.includes(id)) return;
-            const paidValue = Math.max((Number(this.attributes[id]) || 0) - modifier, 0);
+            const modifiedValue = Number.isFinite(Number(this.attributes[id])) ? Number(this.attributes[id]) : modifier;
+            const paidValue = modifiedValue - modifier;
             this.attributes[id] = Math.max(-1, Math.min(paidValue, this.attributeMax()));
         });
     },

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -1,17 +1,22 @@
 const RACE_DESCRIPTIONS = {
     Barbar: 'Im 26. Jahrhundert besteht die Zivilisation zum größten Teil aus Barbaren. Sie leben in unterschiedlichen Kulturen, beispielsweise als Seefahrer (die Disuuslachter), Nomaden (die Wandernden Völker) oder Ruinenbewohner (die Loords von Landán). Die zeichnen sich durch Zähigkeit, Wildheit und Kampflust aus, sind zumeist primitiv und leben in Clans. Ehre und Mut werden hoch geschätzt. Technologisch bewegen sich die meisten Barbaren zwischen der späten Steinzeit und dem frühen Mittelalter.',
     Guul: 'Guule sind bedauernswerte Mutationen des Homo Sapiens. Sie sind dürr, fast zwei Meter groß und völlig unbehaart. Ihre langen knochigen Arme enden in Krallen. Die verhornten Füße laufen an den Fersen in einem fingerdicken Stachel aus. Aus dem Maul tropft weißlicher Schleim, was ihr abstoßendes Äußeres zusätzlich verstärkt. Guule sind meist nur mit einem Lendenschurz bekleidet. Sie ernähren sich von Aas und Gebeinen, die sie u.a. aus Gräbern holen.',
-    Hydrit: 'Hydriten, von den Menschen oft Fischmenschen genannt, sind ein friedliebendes und altes Volk. Sie leben in geheimen Unterseestädten, sind amphibisch, kultiviert und verfügen über fortgeschrittene biogenetische Technologien. Der Genuss von Fleisch verwandelt Hydriten in gefährliche Bestien, weshalb sie sich meist vegetarisch ernähren.'
+    Hydrit: 'Hydriten, von den Menschen oft Fischmenschen genannt, sind ein friedliebendes und altes Volk. Sie leben in geheimen Unterseestädten, sind amphibisch, kultiviert und verfügen über fortgeschrittene biogenetische Technologien. Der Genuss von Fleisch verwandelt Hydriten in gefährliche Bestien, weshalb sie sich meist vegetarisch ernähren.',
+    Techno: 'Technos sind Nachfahren der Menschen, die den Kometeneinschlag in Bunkern überlebt und eine neue Zivilisation aufgebaut haben. Aufgrund ihres technologischen Fortschritts gelten sie vielen Barbaren als Götter oder Dämonen. Sie leiden jedoch an einer tödlichen Immunschwäche und können die Außenwelt nur mit Schutzanzug betreten.'
 };
 
 const CULTURE_DESCRIPTIONS = {
     Landbewohner: 'Landbewohner bewirtschaften den Boden und versuchen als Bauern und Viehzüchter ihren Lebensunterhalt zu verdienen. Die meisten sind einfache Menschen, die Ruhe und Frieden suchen, nicht viel von der Welt wissen und einfache Landgötter anbeten. Aberglauben ist weit verbreitet.',
     Stadtbewohner: 'Stadtbewohner versuchen in der dunklen Zukunft der Erde neues Leben erblühen zu lassen. Dazu haben sie sich in neu erbauten Siedlungen (zuweilen auf Ruinen aus der Zeit vor dem Kometen) angesiedelt und leben als Händler, Handwerker und Bauern. Die Mauern ihrer Siedlungen schützen sie vor den Gefahren der Wildnis. Ihre Siedlungen sind somit Lichter der Hoffnung in der Dunkelheit.',
-    Meeresbewohner: 'Meeresbewohner sind Hydriten aus großen, seit langem verborgenen Unterseestädten. Ihre Gesellschaft ist streng hierarchisch organisiert, technisch und biotechnologisch weit fortgeschritten und meidet den Kontakt zu Oberflächenbewohnern.'
+    Meeresbewohner: 'Meeresbewohner sind Hydriten aus großen, seit langem verborgenen Unterseestädten. Ihre Gesellschaft ist streng hierarchisch organisiert, technisch und biotechnologisch weit fortgeschritten und meidet den Kontakt zu Oberflächenbewohnern.',
+    Bunkermensch: 'Bunkermenschen sind Nachfahren jener Menschen, die die Katastrophe in Bunkern überlebten. Sie verfügen über Technik der alten Welt, leiden aber durch Isolation an einer fatalen Immunschwäche und begegnen der Oberfläche meist nur in Schutzanzügen.'
 };
 
 const CULTURE_NAMES = Object.keys(CULTURE_DESCRIPTIONS);
 const ATTRIBUTE_IDS = ['st', 'ge', 'ro', 'wi', 'wa', 'in', 'au'];
+const TECHNO_SKILLS = ['Fahren', 'Feuerwaffen', 'Heiler', 'Pilot', 'Techniker', 'Wissenschaftler'];
+const TECHNO_SKILL_POOL_POINTS = 12;
+const BUNKERMENSCH_BONUS_SKILLS = ['Feuerwaffen', 'Pilot', 'Wissenschaftler'];
 
 function hydrateExistingCharEditors() {
     if (!window.Alpine
@@ -67,7 +72,12 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     citySkill: null,
     seaProfessionSkill: null,
     seaKnowledgeOrCombatSkill: null,
+    bunkermenschBonusSkill: null,
+    technoSkillNames: TECHNO_SKILLS,
+    technoSkillPoolPoints: TECHNO_SKILL_POOL_POINTS,
+    technoSkillPoints: Object.fromEntries(TECHNO_SKILLS.map(name => [name, 2])),
     raceCache: {},
+    raceAttributeModifiers: {},
 
     // Dynamic data
     attributes: { st: 0, ge: 0, ro: 0, wi: 0, wa: 0, in: 0, au: 0 },
@@ -87,8 +97,25 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         return this.race === 'Barbar' ? 2 : 1;
     },
 
+    attributeModifier(id) {
+        return this.raceAttributeModifiers[id] || 0;
+    },
+
+    attributeCost(id, value = this.attributes[id]) {
+        return Math.max(value - this.attributeModifier(id), 0);
+    },
+
+    getAttributeMin(id) {
+        const modifier = this.attributeModifier(id);
+        return modifier > 0 ? Math.min(modifier, this.attributeMax()) : -1;
+    },
+
+    getAttributeMax() {
+        return this.attributeMax();
+    },
+
     apUsed() {
-        return ATTRIBUTE_IDS.reduce((sum, id) => sum + Math.max(this.attributes[id], 0), 0);
+        return ATTRIBUTE_IDS.reduce((sum, id) => sum + this.attributeCost(id), 0);
     },
 
     apRemaining() {
@@ -124,6 +151,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     formValid() {
         return this.apRemaining() === 0
             && this.fpRemaining() === 0
+            && this.technoSkillPoolComplete()
             && this.selectedDisadvantages.length >= this.chosenAdvantagesCount();
     },
 
@@ -161,8 +189,9 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     allowedCulturesForRace(race = this.race) {
         if (race === 'Hydrit') return ['Meeresbewohner'];
+        if (race === 'Techno') return ['Bunkermensch'];
 
-        return CULTURE_NAMES;
+        return CULTURE_NAMES.filter(culture => culture !== 'Bunkermensch');
     },
 
     isCultureSelectable(culture) {
@@ -172,9 +201,9 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     enforceCultureForRace() {
         const allowedCultures = this.allowedCulturesForRace();
         if (allowedCultures.includes(this.culture)) return false;
-        if (allowedCultures.length !== 1) return false;
+        if (!this.culture && allowedCultures.length !== 1) return false;
 
-        const [defaultCulture] = allowedCultures;
+        const [defaultCulture = ''] = allowedCultures.length === 1 ? allowedCultures : [''];
         this.clearCulture();
         this.culture = defaultCulture;
 
@@ -190,16 +219,17 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     clampAttribute(id) {
         let val = this.attributes[id];
-        if (typeof val !== 'number' || isNaN(val)) val = 0;
-        val = Math.max(-1, Math.min(val, this.attributeMax()));
+        if (typeof val !== 'number' || isNaN(val)) val = this.attributeModifier(id) || 0;
+        val = Math.max(this.getAttributeMin(id), Math.min(val, this.getAttributeMax(id)));
 
-        // Check AP budget
+        // Check AP budget against paid values after race modifiers.
         const othersUsed = ATTRIBUTE_IDS.reduce((sum, otherId) => {
             if (otherId === id) return sum;
-            return sum + Math.max(this.attributes[otherId], 0);
+            return sum + this.attributeCost(otherId);
         }, 0);
-        const maxForThis = Math.max(-1, Math.min(this.base.AP + this.raceAPBonus - othersUsed, this.attributeMax()));
-        val = Math.min(val, maxForThis);
+        const availableForThis = Math.max(0, this.base.AP + this.raceAPBonus - othersUsed);
+        const maxForThis = Math.min(this.getAttributeMax(id), this.attributeModifier(id) + availableForThis);
+        val = Math.min(val, Math.max(this.getAttributeMin(id), maxForThis));
 
         this.attributes[id] = val;
     },
@@ -369,6 +399,71 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         return this.allUsedSkillNames().has(optionValue);
     },
 
+    resetTechnoSkillPoints(defaultValue = 0) {
+        this.technoSkillPoints = Object.fromEntries(TECHNO_SKILLS.map(name => [name, defaultValue]));
+    },
+
+    technoPoolUsed() {
+        return TECHNO_SKILLS.reduce((sum, name) => sum + (Number(this.technoSkillPoints[name]) || 0), 0);
+    },
+
+    technoSkillPoolComplete() {
+        return this.race !== 'Techno' || this.technoPoolUsed() === this.technoSkillPoolPoints;
+    },
+
+    setTechnoSkillPoints(skillName, value) {
+        if (!TECHNO_SKILLS.includes(skillName)) return;
+
+        const parsedValue = Number.parseInt(value, 10);
+        const normalizedValue = Number.isFinite(parsedValue)
+            ? Math.max(0, Math.min(parsedValue, this.base.maxFW))
+            : 0;
+
+        this.technoSkillPoints[skillName] = normalizedValue;
+        this.applyTechnoSkillGrant(skillName);
+        this.refreshBunkermenschBonusGrant();
+    },
+
+    applyTechnoSkillGrant(skillName) {
+        const value = this.race === 'Techno' ? (Number(this.technoSkillPoints[skillName]) || 0) : 0;
+
+        if (value > 0) {
+            this.raceGrants[skillName] = { type: 'min', value };
+            const skill = this.ensureSkill(skillName);
+            this.applyGrantToSkill(skill);
+            return;
+        }
+
+        delete this.raceGrants[skillName];
+        this.refreshGrantedSkill(skillName);
+    },
+
+    refreshAllTechnoSkillGrants() {
+        TECHNO_SKILLS.forEach(name => this.applyTechnoSkillGrant(name));
+        this.refreshBunkermenschBonusGrant();
+    },
+
+    setRaceAttributeModifiers(modifiers) {
+        this.raceAttributeModifiers = { ...modifiers };
+
+        Object.entries(modifiers).forEach(([id, modifier]) => {
+            if (!ATTRIBUTE_IDS.includes(id)) return;
+            const currentValue = this.attributes[id] === 0 ? modifier : this.attributes[id];
+            this.attributes[id] = Math.max(this.getAttributeMin(id), Math.min(currentValue, this.getAttributeMax(id)));
+        });
+    },
+
+    clearRaceAttributeModifiers() {
+        const previousModifiers = { ...this.raceAttributeModifiers };
+        this.raceAttributeModifiers = {};
+
+        Object.entries(previousModifiers).forEach(([id, modifier]) => {
+            if (!ATTRIBUTE_IDS.includes(id)) return;
+            const paidValue = Math.max((Number(this.attributes[id]) || 0) - modifier, 0);
+            this.attributes[id] = Math.max(-1, Math.min(paidValue, this.attributeMax()));
+        });
+    },
+
     // --- Race handling ---
     handleRaceChange() {
         if (this.raceCache[this._prevRace]) {
@@ -380,6 +475,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (this.race === 'Barbar') this.applyRaceBarbar();
         if (this.race === 'Guul') this.applyRaceGuul();
         if (this.race === 'Hydrit') this.applyRaceHydrit();
+        if (this.race === 'Techno') this.applyRaceTechno();
         this.restoreRaceState(this.race);
         this.enforceCultureForRace();
         this._prevRace = this.race;
@@ -392,6 +488,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
             attributes: { ...this.attributes },
             skills: this.skills.filter(s => this.raceGrants[s.name]).map(s => ({ name: s.name, value: s.value })),
             barbarCombatSkill: this.barbarCombatSkill,
+            technoSkillPoints: { ...this.technoSkillPoints },
         };
     },
 
@@ -400,7 +497,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (!cache) return;
         ATTRIBUTE_IDS.forEach(id => {
             if (cache.attributes[id] !== undefined) {
-                this.attributes[id] = Math.max(-1, Math.min(cache.attributes[id], this.attributeMax()));
+                this.attributes[id] = Math.max(this.getAttributeMin(id), Math.min(cache.attributes[id], this.getAttributeMax(id)));
             }
         });
         cache.skills.forEach(cached => {
@@ -409,6 +506,10 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         });
         if (raceName === 'Barbar' && cache.barbarCombatSkill) {
             this.setBarbarCombatSkill(cache.barbarCombatSkill);
+        }
+        if (raceName === 'Techno' && cache.technoSkillPoints) {
+            this.technoSkillPoints = { ...this.technoSkillPoints, ...cache.technoSkillPoints };
+            this.refreshAllTechnoSkillGrants();
         }
     },
 
@@ -420,6 +521,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.raceAPBonus = 0;
         this.raceGrants = {};
         this.barbarCombatSkill = null;
+        this.resetTechnoSkillPoints(0);
+        this.clearRaceAttributeModifiers();
         previousRaceSkills.forEach(name => this.refreshGrantedSkill(name));
         this.selectedAdvantages = this.selectedAdvantages.filter(value => value === 'Zäh' || !previousLockedAdvantages.includes(value));
         this.selectedDisadvantages = this.selectedDisadvantages.filter(value => !previousLockedDisadvantages.includes(value));
@@ -453,6 +556,16 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.selectedDisadvantages = [...new Set([...this.selectedDisadvantages, 'Anfälligkeit gegen Wahnsinn'])];
     },
 
+    applyRaceTechno() {
+        this.setRaceAttributeModifiers({ st: -1, ro: -1, in: 1 });
+        this.resetTechnoSkillPoints(2);
+        this.refreshAllTechnoSkillGrants();
+        this.raceLocked.advantages = ['High-Tech-Ausrüstung'];
+        this.raceLocked.disadvantages = ['Tödliche Immunschwäche'];
+        this.selectedAdvantages = [...new Set([...this.selectedAdvantages, 'High-Tech-Ausrüstung'])];
+        this.selectedDisadvantages = [...new Set([...this.selectedDisadvantages, 'Tödliche Immunschwäche'])];
+    },
+
     setBarbarCombatSkill(skillName) {
         ['Nahkampf', 'Fernkampf']
             .filter(name => name !== skillName && this.raceGrants[name])
@@ -478,6 +591,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (this.culture === 'Landbewohner') this.applyCultureLandbewohner();
         if (this.culture === 'Stadtbewohner') this.applyCultureStadtbewohner();
         if (this.culture === 'Meeresbewohner') this.applyCultureMeeresbewohner();
+        if (this.culture === 'Bunkermensch') this.applyCultureBunkermensch();
         this.updateDescription();
     },
 
@@ -488,6 +602,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.citySkill = null;
         this.seaProfessionSkill = null;
         this.seaKnowledgeOrCombatSkill = null;
+        this.bunkermenschBonusSkill = null;
         previousCultureSkills.forEach(name => this.refreshGrantedSkill(name));
     },
 
@@ -507,6 +622,12 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.setFreeMin('Athletik', 1, 'Kultur');
         this.setSeaProfessionSkill('Beruf: Farmer');
         this.setSeaKnowledgeOrCombatSkill('Wissenschaftler');
+    },
+
+    applyCultureBunkermensch() {
+        this.setFreeMin('Bildung', 1, 'Kultur');
+        this.setFreeMin('Nahkampf', 1, 'Kultur');
+        this.setBunkermenschBonusSkill('Feuerwaffen');
     },
 
     setCitySkill(skillName) {
@@ -548,6 +669,35 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.seaKnowledgeOrCombatSkill = skillName;
         this.cultureGrants[skillName] = { type: 'min', value: 1 };
         const skill = this.ensureSkill(skillName);
+        this.applyGrantToSkill(skill);
+    },
+
+    setBunkermenschBonusSkill(skillName) {
+        if (!BUNKERMENSCH_BONUS_SKILLS.includes(skillName)) return;
+
+        BUNKERMENSCH_BONUS_SKILLS
+            .filter(name => name !== skillName && this.cultureGrants[name])
+            .forEach(name => {
+                delete this.cultureGrants[name];
+                const grant = this.getGrant(name);
+                const skill = this.skills.find(s => s.name === name);
+                if (skill && grant && skill.value > grant.value) {
+                    skill.value = grant.value;
+                }
+                this.refreshGrantedSkill(name);
+            });
+
+        this.bunkermenschBonusSkill = skillName;
+        this.refreshBunkermenschBonusGrant();
+    },
+
+    refreshBunkermenschBonusGrant() {
+        if (this.culture !== 'Bunkermensch' || !this.bunkermenschBonusSkill) return;
+
+        const raceValue = Number(this.technoSkillPoints[this.bunkermenschBonusSkill]) || 0;
+        const value = Math.min(this.base.maxFW, raceValue + 1);
+        this.cultureGrants[this.bunkermenschBonusSkill] = { type: 'min', value };
+        const skill = this.ensureSkill(this.bunkermenschBonusSkill);
         this.applyGrantToSkill(skill);
     },
 

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -32,6 +32,7 @@
         'Feind',
         'Primitiv',
         'Gejagt',
+        'Tödliche Immunschwäche',
     ];
 @endphp
 <x-app-layout>
@@ -72,6 +73,7 @@
                             <option value="Barbar">Barbar</option>
                             <option value="Guul">Guul</option>
                             <option value="Hydrit">Hydrit</option>
+                            <option value="Techno">Techno</option>
                         </select>
                     </div>
 
@@ -82,6 +84,7 @@
                             <option value="Landbewohner" :disabled="!isCultureSelectable('Landbewohner')">Landbewohner</option>
                             <option value="Stadtbewohner" :disabled="!isCultureSelectable('Stadtbewohner')">Stadtbewohner</option>
                             <option value="Meeresbewohner" :disabled="!isCultureSelectable('Meeresbewohner')">Meeresbewohner</option>
+                            <option value="Bunkermensch" :disabled="!isCultureSelectable('Bunkermensch')">Bunkermensch</option>
                         </select>
                     </div>
 
@@ -108,7 +111,7 @@
                         <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
                             @foreach(['st' => 'Stärke (ST)', 'ge' => 'Geschicklichkeit (GE)', 'ro' => 'Robustheit (RO)', 'wi' => 'Willenskraft (WI)', 'wa' => 'Wahrnehmung (WA)', 'in' => 'Intelligenz (IN)', 'au' => 'Auftreten (AU)'] as $attrId => $label)
                             <div>
-                                <x-input type="number" label="{{ $label }}" name="attributes[{{ $attrId }}]" id="{{ $attrId }}" min="-1" x-bind:max="attributeMax()" step="1" x-model.number="attributes.{{ $attrId }}" @change="clampAttribute('{{ $attrId }}')" />
+                                <x-input type="number" label="{{ $label }}" name="attributes[{{ $attrId }}]" id="{{ $attrId }}" x-bind:min="getAttributeMin('{{ $attrId }}')" x-bind:max="getAttributeMax('{{ $attrId }}')" step="1" x-model.number="attributes.{{ $attrId }}" @change="clampAttribute('{{ $attrId }}')" />
                             </div>
                             @endforeach
                         </div>
@@ -123,6 +126,20 @@
                                 <option value="Nahkampf">Nahkampf (+1)</option>
                                 <option value="Fernkampf">Fernkampf (+1)</option>
                             </select>
+                        </div>
+                        <div x-show="race === 'Techno'" class="mb-3 rounded-md border border-base-300 bg-base-200/40 p-3">
+                            <div class="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+                                <h3 class="text-sm font-medium text-base-content">Techno-Rassenpunkte</h3>
+                                <p class="text-xs text-base-content/70" aria-live="polite" x-text="'Verteilt: ' + technoPoolUsed() + ' / ' + technoSkillPoolPoints"></p>
+                            </div>
+                            <div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                                <template x-for="skillName in technoSkillNames" :key="'techno-skill-' + skillName">
+                                    <label class="flex min-h-12 items-center justify-between gap-3 rounded-md border border-base-300 bg-base-100 px-3 py-2 text-sm">
+                                        <span class="min-w-0 flex-1" x-text="skillName"></span>
+                                        <input type="number" min="0" x-bind:max="base.maxFW" step="1" class="input input-bordered input-sm w-20" x-model.number="technoSkillPoints[skillName]" @input="setTechnoSkillPoints(skillName, technoSkillPoints[skillName])" @change="setTechnoSkillPoints(skillName, technoSkillPoints[skillName])" data-testid="techno-skill-points-input">
+                                    </label>
+                                </template>
+                            </div>
                         </div>
                         <div x-show="culture === 'Stadtbewohner'" class="mb-2">
                             <label for="city-skill-select" class="text-sm font-medium text-base-content mb-1">Stadtbewohner Bonus</label>
@@ -147,6 +164,14 @@
                                     <option value="Nahkampf">Nahkampf (+1)</option>
                                 </select>
                             </div>
+                        </div>
+                        <div x-show="culture === 'Bunkermensch'" class="mb-2">
+                            <label for="bunkermensch-bonus-select" class="text-sm font-medium text-base-content mb-1">Bunkermensch Zusatzbonus</label>
+                            <select id="bunkermensch-bonus-select" class="select select-bordered w-full sm:w-auto" x-model="bunkermenschBonusSkill" @change="setBunkermenschBonusSkill(bunkermenschBonusSkill)">
+                                <option value="Feuerwaffen">Feuerwaffen (+1)</option>
+                                <option value="Pilot">Pilot (+1)</option>
+                                <option value="Wissenschaftler">Wissenschaftler (+1)</option>
+                            </select>
                         </div>
                         <div class="space-y-2">
                             <template x-for="(skill, index) in skills" :key="index">

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -337,6 +337,58 @@ class RpgCharEditorPdfTest extends TestCase
         $response->assertSessionHasErrors('culture');
     }
 
+    public function test_pdf_export_accepts_techno_with_bunkermensch_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(fn ($data) => $data['character']['race'] === 'Techno'
+                && $data['character']['culture'] === 'Bunkermensch'))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Techno',
+            'culture' => 'Bunkermensch',
+        ]));
+
+        $response->assertOk();
+    }
+
+    public function test_pdf_export_rejects_techno_with_other_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Techno',
+            'culture' => 'Stadtbewohner',
+        ]));
+
+        $response->assertSessionHasErrors('culture');
+    }
+
+    public function test_pdf_export_rejects_bunkermensch_for_non_techno(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Barbar',
+            'culture' => 'Bunkermensch',
+        ]));
+
+        $response->assertSessionHasErrors('culture');
+    }
+
     public function test_pdf_normalizes_collection_payloads_to_trimmed_scalar_strings(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -292,6 +292,47 @@ describe('charEditor – Rassen-Logik', () => {
         expect(e.selectedDisadvantages).not.toContain('Anfälligkeit gegen Wahnsinn');
         expect(e.skills.find(s => s.name === 'Athletik')).toBeUndefined();
     });
+
+    it('Techno erhält kostenlose Attributsmodifikatoren, Pflichtmerkmale und 12 Rassen-Fertigkeitspunkte', () => {
+        const e = createEditor({ race: 'Techno' });
+        e.applyRaceTechno();
+
+        expect(e.attributes).toMatchObject({ st: -1, ro: -1, in: 1 });
+        expect(e.apUsed()).toBe(0);
+        expect(e.apRemaining()).toBe(2);
+        expect(e.getAttributeMin('in')).toBe(1);
+        expect(e.technoPoolUsed()).toBe(12);
+        expect(e.technoSkillPoolComplete()).toBe(true);
+        expect(e.raceGrants.Fahren).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Feuerwaffen).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Heiler).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Pilot).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Techniker).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Wissenschaftler).toEqual({ type: 'min', value: 2 });
+        expect(e.raceLocked.advantages).toEqual(['High-Tech-Ausrüstung']);
+        expect(e.raceLocked.disadvantages).toEqual(['Tödliche Immunschwäche']);
+        expect(e.selectedAdvantages).toEqual(expect.arrayContaining(['Zäh', 'High-Tech-Ausrüstung']));
+        expect(e.selectedDisadvantages).toContain('Tödliche Immunschwäche');
+    });
+
+    it('Techno-Pool begrenzt Einzelwerte und verlangt exakt 12 verteilte Punkte', () => {
+        const e = createEditor({ race: 'Techno' });
+        e.applyRaceTechno();
+
+        e.setTechnoSkillPoints('Fahren', 9);
+
+        expect(e.technoSkillPoints.Fahren).toBe(4);
+        expect(e.raceGrants.Fahren).toEqual({ type: 'min', value: 4 });
+        expect(e.technoPoolUsed()).toBe(14);
+        expect(e.technoSkillPoolComplete()).toBe(false);
+
+        e.setTechnoSkillPoints('Heiler', 0);
+
+        expect(e.technoPoolUsed()).toBe(12);
+        expect(e.technoSkillPoolComplete()).toBe(true);
+        expect(e.raceGrants.Heiler).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Heiler')).toBeUndefined();
+    });
 });
 
 describe('charEditor – Kultur-Logik', () => {
@@ -361,6 +402,95 @@ describe('charEditor – Kultur-Logik', () => {
 
         expect(e.cultureGrants.Athletik).toEqual({ type: 'min', value: 1 });
         expect(e.skills.find(s => s.name === 'Athletik')).toMatchObject({ value: 2, badge: 'Rasse/Kultur' });
+    });
+
+    it('Techno erlaubt nur Bunkermensch und andere Rassen dürfen Bunkermensch nicht wählen', () => {
+        const techno = createEditor({ race: 'Techno' });
+
+        expect(techno.allowedCulturesForRace()).toEqual(['Bunkermensch']);
+        expect(techno.isCultureSelectable('Bunkermensch')).toBe(true);
+        expect(techno.isCultureSelectable('Landbewohner')).toBe(false);
+        expect(techno.isCultureSelectable('Meeresbewohner')).toBe(false);
+
+        const barbar = createEditor({ race: 'Barbar' });
+
+        expect(barbar.isCultureSelectable('Landbewohner')).toBe(true);
+        expect(barbar.isCultureSelectable('Stadtbewohner')).toBe(true);
+        expect(barbar.isCultureSelectable('Meeresbewohner')).toBe(true);
+        expect(barbar.isCultureSelectable('Bunkermensch')).toBe(false);
+    });
+
+    it('Rassenwechsel zu Techno setzt Kultur auf Bunkermensch und ersetzt alte Kultur-Grants', () => {
+        const e = createEditor({ race: 'Techno', culture: 'Landbewohner' });
+        e.applyCultureLandbewohner();
+
+        expect(e.cultureGrants['Beruf: Landwirt']).toEqual({ type: 'exact', value: 2 });
+
+        e.handleRaceChange();
+
+        expect(e.culture).toBe('Bunkermensch');
+        expect(e.cultureGrants['Beruf: Landwirt']).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Beruf: Landwirt')).toBeUndefined();
+
+        e.handleCultureChange();
+
+        expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Feuerwaffen).toEqual({ type: 'min', value: 3 });
+    });
+
+    it('direkter Kulturwechsel verhindert Bunkermensch für Nicht-Technos', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Bunkermensch' });
+        e.applyCultureBunkermensch();
+
+        e.handleCultureChange();
+
+        expect(e.culture).toBe('');
+        expect(e.cultureGrants).toEqual({});
+        expect(e.skills.find(s => s.name === 'Bildung')).toBeUndefined();
+    });
+
+    it('Bunkermensch erhält Bildung, Nahkampf und den wählbaren Zusatzbonus', () => {
+        const e = createEditor({ race: 'Techno', culture: 'Bunkermensch' });
+        e.applyRaceTechno();
+        e.applyCultureBunkermensch();
+
+        expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Feuerwaffen).toEqual({ type: 'min', value: 3 });
+        expect(e.bunkermenschBonusSkill).toBe('Feuerwaffen');
+        expect(e.skills.find(s => s.name === 'Feuerwaffen')).toMatchObject({ value: 3, badge: 'Rasse/Kultur' });
+    });
+
+    it('Bunkermensch-Zusatzbonus senkt den alten Bonus wieder auf den Techno-Rassenwert', () => {
+        const e = createEditor({ race: 'Techno', culture: 'Bunkermensch' });
+        e.applyRaceTechno();
+        e.applyCultureBunkermensch();
+
+        expect(e.skills.find(s => s.name === 'Feuerwaffen')).toMatchObject({ value: 3, badge: 'Rasse/Kultur' });
+
+        e.setBunkermenschBonusSkill('Pilot');
+
+        expect(e.cultureGrants.Feuerwaffen).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Feuerwaffen')).toMatchObject({ value: 2, badge: 'Rasse' });
+    });
+
+    it('Bunkermensch-Zusatzbonus ersetzt alte Optionen und addiert auf Techno-Poolpunkte bis zum Maximum', () => {
+        const e = createEditor({ race: 'Techno', culture: 'Bunkermensch' });
+        e.applyRaceTechno();
+        e.applyCultureBunkermensch();
+
+        e.setTechnoSkillPoints('Feuerwaffen', 4);
+
+        expect(e.cultureGrants.Feuerwaffen).toEqual({ type: 'min', value: 4 });
+        expect(e.getGrant('Feuerwaffen')).toEqual({ type: 'min', value: 4 });
+
+        e.setBunkermenschBonusSkill('Pilot');
+
+        expect(e.cultureGrants.Feuerwaffen).toBeUndefined();
+        expect(e.raceGrants.Feuerwaffen).toEqual({ type: 'min', value: 4 });
+        expect(e.cultureGrants.Pilot).toEqual({ type: 'min', value: 3 });
+        expect(e.skills.find(s => s.name === 'Pilot')).toMatchObject({ value: 3, badge: 'Rasse/Kultur' });
     });
 
     it('Landbewohner erhält Viehzüchter und Landwirt als Exact-Grants', () => {

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -300,7 +300,8 @@ describe('charEditor – Rassen-Logik', () => {
         expect(e.attributes).toMatchObject({ st: -1, ro: -1, in: 1 });
         expect(e.apUsed()).toBe(0);
         expect(e.apRemaining()).toBe(2);
-        expect(e.getAttributeMin('in')).toBe(1);
+        expect(e.getAttributeMin('in')).toBe(0);
+        expect(e.getAttributeMax('in')).toBe(2);
         expect(e.technoPoolUsed()).toBe(12);
         expect(e.technoSkillPoolComplete()).toBe(true);
         expect(e.raceGrants.Fahren).toEqual({ type: 'min', value: 2 });
@@ -313,6 +314,37 @@ describe('charEditor – Rassen-Logik', () => {
         expect(e.raceLocked.disadvantages).toEqual(['Tödliche Immunschwäche']);
         expect(e.selectedAdvantages).toEqual(expect.arrayContaining(['Zäh', 'High-Tech-Ausrüstung']));
         expect(e.selectedDisadvantages).toContain('Tödliche Immunschwäche');
+    });
+
+    it('Techno rechnet bereits bezahlte Attribute beim Rassenwechsel in modifizierte Endwerte um', () => {
+        const e = createEditor({ race: 'Techno' });
+        e.attributes.st = 1;
+        e.attributes.ro = 0;
+        e.attributes.in = 1;
+
+        e.applyRaceTechno();
+
+        expect(e.attributes.st).toBe(0);
+        expect(e.attributes.ro).toBe(-1);
+        expect(e.attributes.in).toBe(2);
+        expect(e.apUsed()).toBe(2);
+        expect(e.apRemaining()).toBe(0);
+        expect(e.getAttributeMax('st')).toBe(0);
+    });
+
+    it('Rassenwechsel weg von Techno rechnet modifizierte Attribute auf bezahlte Basiswerte zurück', () => {
+        const e = createEditor({ race: 'Techno' });
+        e.applyRaceTechno();
+        e.attributes.st = 0;
+        e.attributes.ro = -1;
+        e.attributes.in = 2;
+
+        e.clearRace();
+
+        expect(e.attributes.st).toBe(1);
+        expect(e.attributes.ro).toBe(0);
+        expect(e.attributes.in).toBe(1);
+        expect(e.apUsed()).toBe(2);
     });
 
     it('Techno-Pool begrenzt Einzelwerte und verlangt exakt 12 verteilte Punkte', () => {

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -307,4 +307,106 @@ test.describe('RPG Charakter-Editor', () => {
             expect.objectContaining({ name: 'Wissenschaftler' }),
         ]));
     });
+
+    test('erzwingt Bunkermensch als einzige Kultur fuer Techno', async ({ page }) => {
+        await login(page, 'info@maddraxikon.com');
+        await page.goto('/rpg/char-editor');
+
+        await expect(page.locator('#culture option[value="Bunkermensch"]')).toBeDisabled();
+
+        await page.getByLabel('Spielername').fill('Playwright Spieler');
+        await page.getByLabel('Charaktername').fill('Wudan');
+        await page.locator('#culture').selectOption('Landbewohner');
+        await expect(page.locator('#culture')).toHaveValue('Landbewohner');
+
+        await page.locator('#race').selectOption('Techno');
+
+        await expect(page.locator('#culture')).toHaveValue('Bunkermensch');
+
+        const cultureOptions = await page.locator('#culture').evaluate((select) => Object.fromEntries(
+            Array.from(select.options).map((option) => [option.value || 'placeholder', option.disabled]),
+        ));
+
+        expect(cultureOptions).toMatchObject({
+            Landbewohner: true,
+            Stadtbewohner: true,
+            Meeresbewohner: true,
+            Bunkermensch: false,
+        });
+
+        await page.getByTestId('char-editor-continue-button').click();
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+            };
+        });
+
+        expect(payload).toEqual({
+            race: 'Techno',
+            culture: 'Bunkermensch',
+        });
+    });
+
+    test('setzt Techno- und Bunkermensch-Regeln inklusive Pool im Formularpayload um', async ({ page }) => {
+        await openAdvancedEditor(page, { race: 'Techno', culture: 'Bunkermensch' });
+
+        await expect(page.locator('#st')).toHaveValue('-1');
+        await expect(page.locator('#ro')).toHaveValue('-1');
+        await expect(page.locator('#in')).toHaveValue('1');
+        await expect(checkbox(page, 'advantages[]', 'High-Tech-Ausrüstung')).toBeChecked();
+        await expect(checkbox(page, 'advantages[]', 'High-Tech-Ausrüstung')).toBeDisabled();
+        await expect(checkbox(page, 'disadvantages[]', 'Tödliche Immunschwäche')).toBeChecked();
+        await expect(checkbox(page, 'disadvantages[]', 'Tödliche Immunschwäche')).toBeDisabled();
+        await expect(page.getByText('Verteilt: 12 / 12')).toBeVisible();
+
+        await page.getByTestId('techno-skill-points-input').first().fill('4');
+        await page.getByTestId('techno-skill-points-input').nth(2).fill('0');
+        await page.locator('#bunkermensch-bonus-select').selectOption('Pilot');
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+            const skillsByIndex = {};
+
+            for (const [key, value] of data.entries()) {
+                const match = key.match(/^skills\[(\d+)]\[(name|value)]$/);
+
+                if (!match) {
+                    continue;
+                }
+
+                const [, index, field] = match;
+                skillsByIndex[index] ??= {};
+                skillsByIndex[index][field] = value;
+            }
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+                advantages: data.getAll('advantages[]'),
+                disadvantages: data.getAll('disadvantages[]'),
+                skills: Object.values(skillsByIndex),
+            };
+        });
+
+        expect(payload.race).toBe('Techno');
+        expect(payload.culture).toBe('Bunkermensch');
+        expect(payload.advantages).toEqual(expect.arrayContaining(['Zäh', 'High-Tech-Ausrüstung']));
+        expect(payload.disadvantages).toContain('Tödliche Immunschwäche');
+        expect(payload.skills).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Fahren', value: '4' }),
+            expect.objectContaining({ name: 'Feuerwaffen', value: '2' }),
+            expect.objectContaining({ name: 'Pilot', value: '3' }),
+            expect.objectContaining({ name: 'Techniker', value: '2' }),
+            expect.objectContaining({ name: 'Wissenschaftler', value: '2' }),
+            expect.objectContaining({ name: 'Bildung', value: '1' }),
+            expect.objectContaining({ name: 'Nahkampf', value: '1' }),
+        ]));
+        expect(payload.skills).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Heiler' }),
+        ]));
+    });
 });


### PR DESCRIPTION
This pull request introduces the new "Techno" race and "Bunkermensch" culture to the character editor, along with their unique attribute modifiers, skill systems, and validation logic. It also refines the handling of race/culture restrictions and updates the UI and backend logic to support these additions.

**Major features and changes:**

*Support for new race "Techno" and culture "Bunkermensch":*
- Added "Techno" as a selectable race and "Bunkermensch" as a culture, with appropriate descriptions and UI options (`char-editor.js`, `char-editor.blade.php`). [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L4-R19) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R76)
- Implemented validation to ensure only "Techno" can select "Bunkermensch" as culture and vice versa, with clear error messages (`RpgCharEditorController.php`).

*Techno-specific attribute and skill logic:*
- Introduced attribute modifiers for "Techno" (e.g., -1 to "st" and "ro", +1 to "in") and adjusted the attribute point calculation and clamping logic to account for these modifiers (`char-editor.js`). [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R75-R80) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R100-R117) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L193-R231)
- Added a unique skill pool system for "Techno" characters, requiring allocation of a fixed number of points across specific skills, with UI and validation (`char-editor.js`). [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R75-R80) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R401-R467) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R153)

*Bunkermensch culture skill bonus:*
- Implemented a system where "Bunkermensch" culture grants a bonus to certain skills, which depends on the Techno's skill allocation, and ensures only valid bonus skills are selectable (`char-editor.js`). [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R676-R704) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R628-R633)

*Race/culture restrictions and state management:*
- Refined logic for allowed and enforced culture selection based on race, ensuring UI and state remain consistent and valid (`char-editor.js`). [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R191-R193) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L175-R205)
- Updated state caching, restoration, and clearing to handle the new race and culture cleanly (`char-editor.js`). [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R492) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L403-R501) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R511-R514) [[4]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R525-R526)

*UI and validation updates:*
- Added "Tödliche Immunschwäche" to the list of disadvantages for Techno characters in the UI (`char-editor.blade.php`).

These changes ensure the new race and culture are fully integrated into character creation, with correct validation, attribute/skill handling, and user experience.

**References:**  
[[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L4-R19) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R76) [[3]](diffhunk://#diff-cc4e8a0530fc1f0b8a79eef9d32623f68bfc4dcf332e23360b25f2c63b266c1eL198-R219) [[4]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R75-R80) [[5]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R100-R117) [[6]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L193-R231) [[7]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R401-R467) [[8]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R153) [[9]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R676-R704) [[10]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R628-R633) [[11]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R191-R193) [[12]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L175-R205) [[13]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R492) [[14]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L403-R501) [[15]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R511-R514) [[16]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R525-R526) [[17]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R35)