### PR TITLE
Feature: Geschlecht and cultures Nomade und Volk der 13 Inseln

### DIFF
--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -208,9 +208,9 @@ class RpgCharEditorController extends Controller
         $culture = $character['culture'] ?? '';
         $gender = $character['gender'] ?? '';
 
-        if ($gender !== '' && ! in_array($gender, self::GENDER_VALUES, true)) {
+        if (! in_array($gender, self::GENDER_VALUES, true)) {
             throw ValidationException::withMessages([
-                'gender' => 'Das Geschlecht muss einem der erlaubten Werte entsprechen.',
+                'gender' => 'Das Geschlecht muss gewählt werden und einem erlaubten Wert entsprechen.',
             ]);
         }
 

--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -238,12 +238,6 @@ class RpgCharEditorController extends Controller
             ]);
         }
 
-        if ($culture === 'Volk der 13 Inseln' && $gender === '') {
-            throw ValidationException::withMessages([
-                'gender' => 'Für die Kultur Volk der 13 Inseln muss ein gültiges Geschlecht gewählt werden.',
-            ]);
-        }
-
         if ($culture === 'Volk der 13 Inseln'
             && $gender === 'weiblich'
             && ! in_array('Psychische Kraft', $advantages, true)) {

--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -17,6 +17,7 @@ class RpgCharEditorController extends Controller
     private const CHARACTER_KEYS = [
         'player_name',
         'character_name',
+        'gender',
         'race',
         'culture',
         'description',
@@ -93,12 +94,20 @@ class RpgCharEditorController extends Controller
             'portrait_data_url' => 'nullable|string|max:'.self::PORTRAIT_DATA_URL_MAX_CHARS,
         ]);
 
+        $character = $this->characterPayload($request);
+        $attributes = $this->attributesPayload($request->input('attributes', []));
+        $skills = $this->skillsPayload($request->input('skills', []));
+        $advantages = $this->listPayload($request->input('advantages', []));
+        $disadvantages = $this->listPayload($request->input('disadvantages', []));
+
+        $this->validateCharacterRules($character, $advantages);
+
         return [
-            'character' => $this->characterPayload($request),
-            'attributes' => $this->attributesPayload($request->input('attributes', [])),
-            'skills' => $this->skillsPayload($request->input('skills', [])),
-            'advantages' => $this->listPayload($request->input('advantages', [])),
-            'disadvantages' => $this->listPayload($request->input('disadvantages', [])),
+            'character' => $character,
+            'attributes' => $attributes,
+            'skills' => $skills,
+            'advantages' => $advantages,
+            'disadvantages' => $disadvantages,
             'portrait' => $this->portraitPayload($request),
         ];
     }
@@ -188,12 +197,10 @@ class RpgCharEditorController extends Controller
             $character[$key] = $this->stringPayload($request->input($key, ''));
         }
 
-        $this->validateCharacterRules($character);
-
         return $character;
     }
 
-    private function validateCharacterRules(array $character): void
+    private function validateCharacterRules(array $character, array $advantages): void
     {
         $race = $character['race'] ?? '';
         $culture = $character['culture'] ?? '';
@@ -213,6 +220,20 @@ class RpgCharEditorController extends Controller
         if ($culture === 'Bunkermensch' && $race !== 'Techno') {
             throw ValidationException::withMessages([
                 'culture' => 'Die Kultur Bunkermensch ist laut Regelwerk nur für Technos zugelassen.',
+            ]);
+        }
+
+        if ($culture === 'Volk der 13 Inseln' && $race !== 'Barbar') {
+            throw ValidationException::withMessages([
+                'culture' => 'Die Kultur Volk der 13 Inseln ist laut Regelwerk nur fuer Barbaren zugelassen.',
+            ]);
+        }
+
+        if ($culture === 'Volk der 13 Inseln'
+            && ($character['gender'] ?? '') === 'weiblich'
+            && ! in_array('Psychische Kraft', $advantages, true)) {
+            throw ValidationException::withMessages([
+                'advantages' => 'Weibliche Charaktere aus dem Volk der 13 Inseln muessen Psychische Kraft waehlen.',
             ]);
         }
     }

--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -206,6 +206,13 @@ class RpgCharEditorController extends Controller
     {
         $race = $character['race'] ?? '';
         $culture = $character['culture'] ?? '';
+        $gender = $character['gender'] ?? '';
+
+        if ($gender !== '' && ! in_array($gender, self::GENDER_VALUES, true)) {
+            throw ValidationException::withMessages([
+                'gender' => 'Das Geschlecht muss einem der erlaubten Werte entsprechen.',
+            ]);
+        }
 
         if ($race === 'Hydrit' && $culture !== 'Meeresbewohner') {
             throw ValidationException::withMessages([
@@ -231,14 +238,14 @@ class RpgCharEditorController extends Controller
             ]);
         }
 
-        if ($culture === 'Volk der 13 Inseln' && ! in_array($character['gender'] ?? '', self::GENDER_VALUES, true)) {
+        if ($culture === 'Volk der 13 Inseln' && $gender === '') {
             throw ValidationException::withMessages([
                 'gender' => 'Für die Kultur Volk der 13 Inseln muss ein gültiges Geschlecht gewählt werden.',
             ]);
         }
 
         if ($culture === 'Volk der 13 Inseln'
-            && ($character['gender'] ?? '') === 'weiblich'
+            && $gender === 'weiblich'
             && ! in_array('Psychische Kraft', $advantages, true)) {
             throw ValidationException::withMessages([
                 'advantages' => 'Weibliche Charaktere aus dem Volk der 13 Inseln müssen Psychische Kraft wählen.',

--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -24,6 +24,8 @@ class RpgCharEditorController extends Controller
         'equipment',
     ];
 
+    private const GENDER_VALUES = ['weiblich', 'maennlich', 'divers'];
+
     private const PORTRAIT_MAX_BYTES = 2_097_152;
 
     private const PORTRAIT_MAX_BASE64_CHARS = 2_796_204;
@@ -226,6 +228,12 @@ class RpgCharEditorController extends Controller
         if ($culture === 'Volk der 13 Inseln' && $race !== 'Barbar') {
             throw ValidationException::withMessages([
                 'culture' => 'Die Kultur Volk der 13 Inseln ist laut Regelwerk nur für Barbaren zugelassen.',
+            ]);
+        }
+
+        if ($culture === 'Volk der 13 Inseln' && ! in_array($character['gender'] ?? '', self::GENDER_VALUES, true)) {
+            throw ValidationException::withMessages([
+                'gender' => 'Für die Kultur Volk der 13 Inseln muss ein gültiges Geschlecht gewählt werden.',
             ]);
         }
 

--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -225,7 +225,7 @@ class RpgCharEditorController extends Controller
 
         if ($culture === 'Volk der 13 Inseln' && $race !== 'Barbar') {
             throw ValidationException::withMessages([
-                'culture' => 'Die Kultur Volk der 13 Inseln ist laut Regelwerk nur fuer Barbaren zugelassen.',
+                'culture' => 'Die Kultur Volk der 13 Inseln ist laut Regelwerk nur für Barbaren zugelassen.',
             ]);
         }
 
@@ -233,7 +233,7 @@ class RpgCharEditorController extends Controller
             && ($character['gender'] ?? '') === 'weiblich'
             && ! in_array('Psychische Kraft', $advantages, true)) {
             throw ValidationException::withMessages([
-                'advantages' => 'Weibliche Charaktere aus dem Volk der 13 Inseln muessen Psychische Kraft waehlen.',
+                'advantages' => 'Weibliche Charaktere aus dem Volk der 13 Inseln müssen Psychische Kraft wählen.',
             ]);
         }
     }

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -10,8 +10,8 @@ const CULTURE_DESCRIPTIONS = {
     Stadtbewohner: 'Stadtbewohner versuchen in der dunklen Zukunft der Erde neues Leben erblühen zu lassen. Dazu haben sie sich in neu erbauten Siedlungen (zuweilen auf Ruinen aus der Zeit vor dem Kometen) angesiedelt und leben als Händler, Handwerker und Bauern. Die Mauern ihrer Siedlungen schützen sie vor den Gefahren der Wildnis. Ihre Siedlungen sind somit Lichter der Hoffnung in der Dunkelheit.',
     Meeresbewohner: 'Meeresbewohner sind Hydriten aus großen, seit langem verborgenen Unterseestädten. Ihre Gesellschaft ist streng hierarchisch organisiert, technisch und biotechnologisch weit fortgeschritten und meidet den Kontakt zu Oberflächenbewohnern.',
     Bunkermensch: 'Bunkermenschen sind Nachfahren jener Menschen, die die Katastrophe in Bunkern überlebten. Sie verfügen über Technik der alten Welt, leiden aber durch Isolation an einer fatalen Immunschwäche und begegnen der Oberfläche meist nur in Schutzanzügen.',
-    Nomade: 'Nomaden folgen den Routen ihrer Nutztiere durch die Jahreszeiten. Sie sind wehrhaft, ueberleben in unwirtlicher Natur und werden von sesshaften Voelkern oft misstrauisch betrachtet.',
-    'Volk der 13 Inseln': 'Das Volk der 13 Inseln lebt in Schweden, Daenemark und Finnland. Es besteht vor allem aus Jaegern, Bauern und Fischern. Frauen dieser Kultur besitzen die Gabe des Lauschens.'
+    Nomade: 'Nomaden folgen den Routen ihrer Nutztiere durch die Jahreszeiten. Sie sind wehrhaft, überleben in unwirtlicher Natur und werden von sesshaften Völkern oft misstrauisch betrachtet.',
+    'Volk der 13 Inseln': 'Das Volk der 13 Inseln lebt in Schweden, Dänemark und Finnland. Es besteht vor allem aus Jägern, Bauern und Fischern. Frauen dieser Kultur besitzen die Gabe des Lauschens.'
 };
 
 const CULTURE_NAMES = Object.keys(CULTURE_DESCRIPTIONS);

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -9,7 +9,9 @@ const CULTURE_DESCRIPTIONS = {
     Landbewohner: 'Landbewohner bewirtschaften den Boden und versuchen als Bauern und Viehzüchter ihren Lebensunterhalt zu verdienen. Die meisten sind einfache Menschen, die Ruhe und Frieden suchen, nicht viel von der Welt wissen und einfache Landgötter anbeten. Aberglauben ist weit verbreitet.',
     Stadtbewohner: 'Stadtbewohner versuchen in der dunklen Zukunft der Erde neues Leben erblühen zu lassen. Dazu haben sie sich in neu erbauten Siedlungen (zuweilen auf Ruinen aus der Zeit vor dem Kometen) angesiedelt und leben als Händler, Handwerker und Bauern. Die Mauern ihrer Siedlungen schützen sie vor den Gefahren der Wildnis. Ihre Siedlungen sind somit Lichter der Hoffnung in der Dunkelheit.',
     Meeresbewohner: 'Meeresbewohner sind Hydriten aus großen, seit langem verborgenen Unterseestädten. Ihre Gesellschaft ist streng hierarchisch organisiert, technisch und biotechnologisch weit fortgeschritten und meidet den Kontakt zu Oberflächenbewohnern.',
-    Bunkermensch: 'Bunkermenschen sind Nachfahren jener Menschen, die die Katastrophe in Bunkern überlebten. Sie verfügen über Technik der alten Welt, leiden aber durch Isolation an einer fatalen Immunschwäche und begegnen der Oberfläche meist nur in Schutzanzügen.'
+    Bunkermensch: 'Bunkermenschen sind Nachfahren jener Menschen, die die Katastrophe in Bunkern überlebten. Sie verfügen über Technik der alten Welt, leiden aber durch Isolation an einer fatalen Immunschwäche und begegnen der Oberfläche meist nur in Schutzanzügen.',
+    Nomade: 'Nomaden folgen den Routen ihrer Nutztiere durch die Jahreszeiten. Sie sind wehrhaft, ueberleben in unwirtlicher Natur und werden von sesshaften Voelkern oft misstrauisch betrachtet.',
+    'Volk der 13 Inseln': 'Das Volk der 13 Inseln lebt in Schweden, Daenemark und Finnland. Es besteht vor allem aus Jaegern, Bauern und Fischern. Frauen dieser Kultur besitzen die Gabe des Lauschens.'
 };
 
 const CULTURE_NAMES = Object.keys(CULTURE_DESCRIPTIONS);
@@ -17,6 +19,12 @@ const ATTRIBUTE_IDS = ['st', 'ge', 'ro', 'wi', 'wa', 'in', 'au'];
 const TECHNO_SKILLS = ['Fahren', 'Feuerwaffen', 'Heiler', 'Pilot', 'Techniker', 'Wissenschaftler'];
 const TECHNO_SKILL_POOL_POINTS = 12;
 const BUNKERMENSCH_BONUS_SKILLS = ['Feuerwaffen', 'Pilot', 'Wissenschaftler'];
+const NOMADE_COMBAT_SKILLS = ['Nahkampf', 'Fernkampf'];
+const NOMADE_MOVEMENT_SKILLS = ['Reiten', 'Athletik'];
+const VOLK_DER_13_INSELN_CULTURE = 'Volk der 13 Inseln';
+const VOLK_DER_13_INSELN_PROFESSION_SKILLS = ['Beruf: Bauer', 'Beruf: Fischer'];
+const VOLK_DER_13_INSELN_REQUIRED_ADVANTAGE = 'Psychische Kraft';
+const FEMALE_GENDER = 'weiblich';
 
 function hydrateExistingCharEditors() {
     if (!window.Alpine
@@ -54,6 +62,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     // Basic info
     playerName: '',
     characterName: '',
+    gender: '',
     race: '',
     culture: '',
     description: '',
@@ -73,6 +82,9 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     seaProfessionSkill: null,
     seaKnowledgeOrCombatSkill: null,
     bunkermenschBonusSkill: null,
+    nomadeCombatSkill: null,
+    nomadeMovementSkill: null,
+    volkDer13InselnProfessionSkill: null,
     technoSkillNames: TECHNO_SKILLS,
     technoSkillPoolPoints: TECHNO_SKILL_POOL_POINTS,
     technoSkillPoints: Object.fromEntries(TECHNO_SKILLS.map(name => [name, 2])),
@@ -85,12 +97,14 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     selectedAdvantages: ['Zäh'],
     selectedDisadvantages: [],
     raceLocked: { advantages: [], disadvantages: [] },
+    cultureLocked: { advantages: [], disadvantages: [] },
+    cultureAutoSelectedAdvantages: [],
 
     // UI state
     advancedUnlocked: false,
 
     basicsFilled() {
-        return this.playerName.trim() && this.characterName.trim() && this.race && this.culture;
+        return this.playerName.trim() && this.characterName.trim() && this.gender && this.race && this.culture;
     },
 
     attributeMax() {
@@ -135,8 +149,14 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         return this.base.FP - this.fpUsed();
     },
 
+    lockedAdvantages() {
+        return [...new Set([...this.raceLocked.advantages, ...this.cultureLocked.advantages])];
+    },
+
     chosenAdvantagesCount() {
-        return this.selectedAdvantages.filter(a => a !== 'Zäh' && !this.raceLocked.advantages.includes(a)).length;
+        const lockedAdvantages = this.lockedAdvantages();
+
+        return this.selectedAdvantages.filter(a => a !== 'Zäh' && !lockedAdvantages.includes(a)).length;
     },
 
     freeAdvantagePoints() {
@@ -190,7 +210,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (race === 'Hydrit') return ['Meeresbewohner'];
         if (race === 'Techno') return ['Bunkermensch'];
 
-        return CULTURE_NAMES.filter(culture => culture !== 'Bunkermensch');
+        return CULTURE_NAMES.filter(culture => culture !== 'Bunkermensch'
+            && (race === 'Barbar' || culture !== VOLK_DER_13_INSELN_CULTURE));
     },
 
     isCultureSelectable(culture) {
@@ -213,6 +234,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     init() {
         this.$watch('race', () => this.handleRaceChange());
         this.$watch('culture', () => this.handleCultureChange());
+        this.$watch('gender', () => this.handleGenderChange());
         this.$watch('selectedAdvantages', () => this.enforceAdvantageLimit());
     },
 
@@ -246,6 +268,10 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     unlockAdvanced() {
         this.advancedUnlocked = true;
+    },
+
+    handleGenderChange() {
+        this.refreshCultureLockedAdvantages();
     },
 
     updateDescription() {
@@ -593,6 +619,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (this.culture === 'Stadtbewohner') this.applyCultureStadtbewohner();
         if (this.culture === 'Meeresbewohner') this.applyCultureMeeresbewohner();
         if (this.culture === 'Bunkermensch') this.applyCultureBunkermensch();
+        if (this.culture === 'Nomade') this.applyCultureNomade();
+        if (this.culture === VOLK_DER_13_INSELN_CULTURE) this.applyCultureVolkDer13Inseln();
         this.updateDescription();
     },
 
@@ -604,6 +632,10 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.seaProfessionSkill = null;
         this.seaKnowledgeOrCombatSkill = null;
         this.bunkermenschBonusSkill = null;
+        this.nomadeCombatSkill = null;
+        this.nomadeMovementSkill = null;
+        this.volkDer13InselnProfessionSkill = null;
+        this.setCultureLockedAdvantages([]);
         previousCultureSkills.forEach(name => this.refreshGrantedSkill(name));
     },
 
@@ -629,6 +661,19 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.setFreeMin('Bildung', 1, 'Kultur');
         this.setFreeMin('Nahkampf', 1, 'Kultur');
         this.setBunkermenschBonusSkill('Feuerwaffen');
+    },
+
+    applyCultureNomade() {
+        this.setFreeMin('\u00dcberleben', 1, 'Kultur');
+        this.setNomadeCombatSkill('Nahkampf');
+        this.setNomadeMovementSkill('Reiten');
+    },
+
+    applyCultureVolkDer13Inseln() {
+        this.setFreeMin('Athletik', 1, 'Kultur');
+        this.setFreeMin('\u00dcberleben', 1, 'Kultur');
+        this.setVolkDer13InselnProfessionSkill('Beruf: Bauer');
+        this.refreshCultureLockedAdvantages();
     },
 
     setCitySkill(skillName) {
@@ -673,6 +718,34 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.applyGrantToSkill(skill);
     },
 
+    setCultureChoiceSkill(skillName, optionNames, stateProperty, value = 1) {
+        if (!optionNames.includes(skillName)) return;
+
+        optionNames
+            .filter(name => name !== skillName && this.cultureGrants[name])
+            .forEach(name => {
+                delete this.cultureGrants[name];
+                this.refreshGrantedSkill(name);
+            });
+
+        this[stateProperty] = skillName;
+        this.cultureGrants[skillName] = { type: 'min', value };
+        const skill = this.ensureSkill(skillName);
+        this.applyGrantToSkill(skill);
+    },
+
+    setNomadeCombatSkill(skillName) {
+        this.setCultureChoiceSkill(skillName, NOMADE_COMBAT_SKILLS, 'nomadeCombatSkill');
+    },
+
+    setNomadeMovementSkill(skillName) {
+        this.setCultureChoiceSkill(skillName, NOMADE_MOVEMENT_SKILLS, 'nomadeMovementSkill');
+    },
+
+    setVolkDer13InselnProfessionSkill(skillName) {
+        this.setCultureChoiceSkill(skillName, VOLK_DER_13_INSELN_PROFESSION_SKILLS, 'volkDer13InselnProfessionSkill');
+    },
+
     setBunkermenschBonusSkill(skillName) {
         if (!BUNKERMENSCH_BONUS_SKILLS.includes(skillName)) return;
 
@@ -702,11 +775,37 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.applyGrantToSkill(skill);
     },
 
+    setCultureLockedAdvantages(advantages) {
+        const nextAdvantages = [...new Set(advantages)];
+        const previousAutoSelected = [...this.cultureAutoSelectedAdvantages];
+        const autoSelectedToRemove = previousAutoSelected.filter(value => !nextAdvantages.includes(value));
+
+        this.selectedAdvantages = this.selectedAdvantages.filter(value => !autoSelectedToRemove.includes(value));
+
+        const newlyAutoSelected = nextAdvantages.filter(value => !this.selectedAdvantages.includes(value));
+        this.selectedAdvantages = [...new Set([...this.selectedAdvantages, ...newlyAutoSelected])];
+        this.cultureLocked.advantages = nextAdvantages;
+        this.cultureAutoSelectedAdvantages = [
+            ...previousAutoSelected.filter(value => nextAdvantages.includes(value) && this.selectedAdvantages.includes(value)),
+            ...newlyAutoSelected,
+        ];
+        this.enforceAdvantageLimit();
+    },
+
+    refreshCultureLockedAdvantages() {
+        const advantages = this.culture === VOLK_DER_13_INSELN_CULTURE && this.gender === FEMALE_GENDER
+            ? [VOLK_DER_13_INSELN_REQUIRED_ADVANTAGE]
+            : [];
+
+        this.setCultureLockedAdvantages(advantages);
+    },
+
     // --- Advantages ---
     enforceAdvantageLimit() {
         const max = this.base.freeAdvantages;
-        const locked = this.selectedAdvantages.filter(a => this.raceLocked.advantages.includes(a));
-        const chosen = this.selectedAdvantages.filter(a => a !== 'Zäh' && !this.raceLocked.advantages.includes(a));
+        const lockedAdvantages = this.lockedAdvantages();
+        const locked = this.selectedAdvantages.filter(a => lockedAdvantages.includes(a));
+        const chosen = this.selectedAdvantages.filter(a => a !== 'Zäh' && !lockedAdvantages.includes(a));
 
         if (chosen.length > max) {
             this.selectedAdvantages = [...new Set(['Zäh', ...locked, ...chosen.slice(0, max)])];
@@ -726,7 +825,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     isAdvantageDisabled(value) {
         if (value === 'Zäh') return true;
-        if (this.raceLocked.advantages.includes(value)) return true;
+        if (this.lockedAdvantages().includes(value)) return true;
         return !this.selectedAdvantages.includes(value) && this.chosenAdvantagesCount() >= this.base.freeAdvantages;
     },
 

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -72,7 +72,7 @@
                         <select name="gender" id="gender" class="select select-bordered w-full" x-model="gender" :disabled="advancedUnlocked">
                             <option value="" disabled>Geschlecht wählen</option>
                             <option value="weiblich">Weiblich</option>
-                            <option value="maennlich">Maennlich</option>
+                            <option value="maennlich">Männlich</option>
                             <option value="divers">Divers / keine Angabe</option>
                         </select>
                     </div>

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -70,7 +70,7 @@
                     <div :class="{ 'opacity-50': advancedUnlocked }">
                         <label for="gender" class="block text-sm font-medium text-base-content mb-1">Geschlecht</label>
                         <select name="gender" id="gender" class="select select-bordered w-full" x-model="gender" :disabled="advancedUnlocked">
-                            <option value="" disabled>Geschlecht waehlen</option>
+                            <option value="" disabled>Geschlecht wählen</option>
                             <option value="weiblich">Weiblich</option>
                             <option value="maennlich">Maennlich</option>
                             <option value="divers">Divers / keine Angabe</option>

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -50,6 +50,7 @@
 
                 <input type="hidden" name="player_name" :value="playerName" :disabled="!shouldMirrorBaseFields()">
                 <input type="hidden" name="character_name" :value="characterName" :disabled="!shouldMirrorBaseFields()">
+                <input type="hidden" name="gender" :value="gender" :disabled="!shouldMirrorBaseFields()">
                 <input type="hidden" name="race" :value="race" :disabled="!shouldMirrorBaseFields()">
                 <input type="hidden" name="culture" :value="culture" :disabled="!shouldMirrorBaseFields()">
                 <input type="hidden" name="portrait_data_url" :value="portraitPreview || ''" :disabled="!shouldSubmitPortraitPreview()">
@@ -64,6 +65,16 @@
 
                     <div :class="{ 'opacity-50': advancedUnlocked }">
                         <x-input label="Charaktername" name="character_name" x-model="characterName" x-bind:disabled="advancedUnlocked" />
+                    </div>
+
+                    <div :class="{ 'opacity-50': advancedUnlocked }">
+                        <label for="gender" class="block text-sm font-medium text-base-content mb-1">Geschlecht</label>
+                        <select name="gender" id="gender" class="select select-bordered w-full" x-model="gender" :disabled="advancedUnlocked">
+                            <option value="" disabled>Geschlecht waehlen</option>
+                            <option value="weiblich">Weiblich</option>
+                            <option value="maennlich">Maennlich</option>
+                            <option value="divers">Divers / keine Angabe</option>
+                        </select>
                     </div>
 
                     <div :class="{ 'opacity-50': advancedUnlocked }">
@@ -85,6 +96,8 @@
                             <option value="Stadtbewohner" :disabled="!isCultureSelectable('Stadtbewohner')">Stadtbewohner</option>
                             <option value="Meeresbewohner" :disabled="!isCultureSelectable('Meeresbewohner')">Meeresbewohner</option>
                             <option value="Bunkermensch" :disabled="!isCultureSelectable('Bunkermensch')">Bunkermensch</option>
+                            <option value="Nomade" :disabled="!isCultureSelectable('Nomade')">Nomade</option>
+                            <option value="Volk der 13 Inseln" :disabled="!isCultureSelectable('Volk der 13 Inseln')">Volk der 13 Inseln</option>
                         </select>
                     </div>
 
@@ -173,6 +186,29 @@
                                 <option value="Wissenschaftler">Wissenschaftler (+1)</option>
                             </select>
                         </div>
+                        <div x-show="culture === 'Nomade'" class="mb-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                            <div>
+                                <label for="nomade-combat-select" class="text-sm font-medium text-base-content mb-1">Nomade Kampfbonus</label>
+                                <select id="nomade-combat-select" class="select select-bordered w-full" x-model="nomadeCombatSkill" @change="setNomadeCombatSkill(nomadeCombatSkill)">
+                                    <option value="Nahkampf">Nahkampf (+1)</option>
+                                    <option value="Fernkampf">Fernkampf (+1)</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label for="nomade-movement-select" class="text-sm font-medium text-base-content mb-1">Nomade Bewegungsbonus</label>
+                                <select id="nomade-movement-select" class="select select-bordered w-full" x-model="nomadeMovementSkill" @change="setNomadeMovementSkill(nomadeMovementSkill)">
+                                    <option value="Reiten">Reiten (+1)</option>
+                                    <option value="Athletik">Athletik (+1)</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div x-show="culture === 'Volk der 13 Inseln'" class="mb-2">
+                            <label for="volk-13-profession-select" class="text-sm font-medium text-base-content mb-1">Volk der 13 Inseln Beruf-Bonus</label>
+                            <select id="volk-13-profession-select" class="select select-bordered w-full sm:w-auto" x-model="volkDer13InselnProfessionSkill" @change="setVolkDer13InselnProfessionSkill(volkDer13InselnProfessionSkill)">
+                                <option value="Beruf: Bauer">Beruf: Bauer (+1)</option>
+                                <option value="Beruf: Fischer">Beruf: Fischer (+1)</option>
+                            </select>
+                        </div>
                         <div class="space-y-2">
                             <template x-for="(skill, index) in skills" :key="index">
                                 <div class="grid grid-cols-1 sm:grid-cols-4 gap-2 items-center">
@@ -216,6 +252,8 @@
                         <datalist id="skills-list">
                             <option value="Athletik"></option>
                             <option value="Beruf"></option>
+                            <option value="Beruf: Bauer"></option>
+                            <option value="Beruf: Fischer"></option>
                             <option value="Beruf: Farmer"></option>
                             <option value="Beruf: Künstler"></option>
                             <option value="Bildung"></option>

--- a/resources/views/rpg/char-sheet.blade.php
+++ b/resources/views/rpg/char-sheet.blade.php
@@ -20,6 +20,7 @@
     <div class="section">
         <strong>Spieler:</strong> {{ $character['player_name'] ?? '' }}<br>
         <strong>Charakter:</strong> {{ $character['character_name'] ?? '' }}<br>
+        <strong>Geschlecht:</strong> {{ $character['gender'] ?? '' }}<br>
         <strong>Rasse:</strong> {{ $character['race'] ?? '' }}<br>
         <strong>Kultur:</strong> {{ $character['culture'] ?? '' }}
     </div>

--- a/resources/views/rpg/char-sheet.blade.php
+++ b/resources/views/rpg/char-sheet.blade.php
@@ -12,6 +12,15 @@
     </style>
 </head>
 <body>
+    @php
+        $genderLabels = [
+            'weiblich' => 'Weiblich',
+            'maennlich' => 'Männlich',
+            'divers' => 'Divers / keine Angabe',
+        ];
+        $gender = $character['gender'] ?? '';
+    @endphp
+
     <h1>Charakterbogen</h1>
     @if($portrait)
         <img class="portrait" src="{{ $portrait }}" alt="Portrait">
@@ -20,7 +29,7 @@
     <div class="section">
         <strong>Spieler:</strong> {{ $character['player_name'] ?? '' }}<br>
         <strong>Charakter:</strong> {{ $character['character_name'] ?? '' }}<br>
-        <strong>Geschlecht:</strong> {{ $character['gender'] ?? '' }}<br>
+        <strong>Geschlecht:</strong> {{ $genderLabels[$gender] ?? '' }}<br>
         <strong>Rasse:</strong> {{ $character['race'] ?? '' }}<br>
         <strong>Kultur:</strong> {{ $character['culture'] ?? '' }}
     </div>

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -325,6 +325,44 @@ class RpgCharEditorPdfTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_pdf_export_rejects_invalid_gender_for_all_cultures(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'gender' => 'unbekannt',
+            'culture' => 'Landbewohner',
+        ]));
+
+        $response->assertSessionHasErrors('gender');
+    }
+
+    public function test_pdf_export_allows_empty_gender_for_other_cultures(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(fn ($data) => $data['character']['gender'] === ''
+                && $data['character']['culture'] === 'Landbewohner'))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'gender' => '',
+            'culture' => 'Landbewohner',
+        ]));
+
+        $response->assertOk();
+    }
+
     public function test_pdf_export_accepts_hydrit_with_meeresbewohner_culture(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -105,6 +105,29 @@ class RpgCharEditorPdfTest extends TestCase
         return $user->refresh();
     }
 
+    public function test_char_sheet_formats_gender_values_for_pdf_view(): void
+    {
+        $html = view('rpg.char-sheet', [
+            'character' => [
+                'player_name' => 'Spieler Eins',
+                'character_name' => 'Foo Bar',
+                'gender' => 'maennlich',
+                'race' => 'Barbar',
+                'culture' => 'Landbewohner',
+                'description' => '',
+                'equipment' => '',
+            ],
+            'attributes' => [],
+            'skills' => [],
+            'advantages' => [],
+            'disadvantages' => [],
+            'portrait' => null,
+        ])->render();
+
+        $this->assertStringContainsString('Geschlecht:</strong> Männlich', $html);
+        $this->assertStringNotContainsString('maennlich', $html);
+    }
+
     public function test_pdf_export_post_redirects_to_get_viewer_url(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());
@@ -444,6 +467,49 @@ class RpgCharEditorPdfTest extends TestCase
         ]));
 
         $response->assertOk();
+    }
+
+    public function test_pdf_export_accepts_male_volk_der_13_inseln_without_required_advantage(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(fn ($data) => $data['character']['gender'] === 'maennlich'
+                && $data['character']['culture'] === 'Volk der 13 Inseln'
+                && ! in_array('Psychische Kraft', $data['advantages'], true)))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'gender' => 'maennlich',
+            'culture' => 'Volk der 13 Inseln',
+            'advantages' => ['Zaeh'],
+        ]));
+
+        $response->assertOk();
+    }
+
+    public function test_pdf_export_rejects_volk_der_13_inseln_without_valid_gender(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        foreach (['', 'unbekannt'] as $gender) {
+            $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+                'gender' => $gender,
+                'culture' => 'Volk der 13 Inseln',
+                'advantages' => ['Zaeh'],
+            ]));
+
+            $response->assertSessionHasErrors('gender');
+        }
     }
 
     public function test_pdf_export_rejects_volk_der_13_inseln_for_non_barbar(): void

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -325,42 +325,20 @@ class RpgCharEditorPdfTest extends TestCase
         $response->assertOk();
     }
 
-    public function test_pdf_export_rejects_invalid_gender_for_all_cultures(): void
+    public function test_pdf_export_rejects_missing_or_invalid_gender_for_all_cultures(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());
 
         Pdf::shouldReceive('view')->never();
 
-        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
-            'gender' => 'unbekannt',
-            'culture' => 'Landbewohner',
-        ]));
+        $payloadWithoutGender = $this->validPdfPayload();
+        unset($payloadWithoutGender['gender']);
 
-        $response->assertSessionHasErrors('gender');
-    }
+        foreach ([$payloadWithoutGender, $this->validPdfPayload(['gender' => '']), $this->validPdfPayload(['gender' => 'unbekannt'])] as $payload) {
+            $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $payload);
 
-    public function test_pdf_export_allows_empty_gender_for_other_cultures(): void
-    {
-        $member = $this->addAgRollenspielMembership($this->createMember());
-
-        Pdf::shouldReceive('view')
-            ->once()
-            ->with('rpg.char-sheet', \Mockery::on(fn ($data) => $data['character']['gender'] === ''
-                && $data['character']['culture'] === 'Landbewohner'))
-            ->andReturn(new class extends PdfBuilder
-            {
-                public function toResponse($request): Response
-                {
-                    return response('PDF', 200, $this->responseHeaders);
-                }
-            });
-
-        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
-            'gender' => '',
-            'culture' => 'Landbewohner',
-        ]));
-
-        $response->assertOk();
+            $response->assertSessionHasErrors('gender');
+        }
     }
 
     public function test_pdf_export_accepts_hydrit_with_meeresbewohner_culture(): void
@@ -612,6 +590,7 @@ class RpgCharEditorPdfTest extends TestCase
 
         $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Collection Payload',
+            'gender' => 'maennlich',
             'attributes' => [
                 'st' => ' 2 ',
                 'ge' => ['manipuliert'],
@@ -790,6 +769,7 @@ class RpgCharEditorPdfTest extends TestCase
 
         $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Foo/Bar',
+            'gender' => 'maennlich',
             'portrait' => UploadedFile::fake()->image('avatar.jpg'),
         ]);
 
@@ -836,6 +816,7 @@ class RpgCharEditorPdfTest extends TestCase
 
         $response = $this->followingRedirects()->actingAs($admin)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Foo',
+            'gender' => 'maennlich',
         ]);
 
         $response->assertOk();
@@ -872,6 +853,7 @@ class RpgCharEditorPdfTest extends TestCase
 
         $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             'character_name' => 'Foo',
+            'gender' => 'maennlich',
             'portrait' => UploadedFile::fake()->image('avatar.png'),
         ]);
 

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -37,6 +37,7 @@ class RpgCharEditorPdfTest extends TestCase
         return array_replace_recursive([
             'player_name' => 'Spieler Eins',
             'character_name' => 'Foo Bar',
+            'gender' => 'maennlich',
             'race' => 'Barbar',
             'culture' => 'Landbewohner',
             'description' => 'Ein erfahrener Charakter aus Wudan.',
@@ -250,6 +251,7 @@ class RpgCharEditorPdfTest extends TestCase
                 return $data['character'] === [
                     'player_name' => 'Holger',
                     'character_name' => 'Holli',
+                    'gender' => 'weiblich',
                     'race' => 'Barbar',
                     'culture' => 'Landbewohner',
                     'description' => 'Beschreibung aus dem Editor',
@@ -276,6 +278,7 @@ class RpgCharEditorPdfTest extends TestCase
             '_token' => 'ignored by payload whitelist',
             'player_name' => 'Holger',
             'character_name' => 'Holli',
+            'gender' => 'weiblich',
             'race' => 'Barbar',
             'culture' => 'Landbewohner',
             'description' => 'Beschreibung aus dem Editor',
@@ -389,6 +392,89 @@ class RpgCharEditorPdfTest extends TestCase
         $response->assertSessionHasErrors('culture');
     }
 
+    public function test_pdf_export_accepts_nomade_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(fn ($data) => $data['character']['race'] === 'Barbar'
+                && $data['character']['culture'] === 'Nomade'))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'culture' => 'Nomade',
+            'skills' => [
+                ['name' => 'Nahkampf', 'value' => 1],
+                ['name' => 'Reiten', 'value' => 1],
+                ['name' => 'Ueberleben', 'value' => 1],
+            ],
+        ]));
+
+        $response->assertOk();
+    }
+
+    public function test_pdf_export_accepts_volk_der_13_inseln_for_barbar_with_required_advantage(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(fn ($data) => $data['character']['race'] === 'Barbar'
+                && $data['character']['culture'] === 'Volk der 13 Inseln'
+                && in_array('Psychische Kraft', $data['advantages'], true)))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'gender' => 'weiblich',
+            'culture' => 'Volk der 13 Inseln',
+            'advantages' => ['Zaeh', 'Psychische Kraft'],
+        ]));
+
+        $response->assertOk();
+    }
+
+    public function test_pdf_export_rejects_volk_der_13_inseln_for_non_barbar(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Guul',
+            'culture' => 'Volk der 13 Inseln',
+        ]));
+
+        $response->assertSessionHasErrors('culture');
+    }
+
+    public function test_pdf_export_rejects_female_volk_der_13_inseln_without_psychische_kraft(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'gender' => 'weiblich',
+            'culture' => 'Volk der 13 Inseln',
+            'advantages' => ['Zaeh'],
+        ]));
+
+        $response->assertSessionHasErrors('advantages');
+    }
+
     public function test_pdf_normalizes_collection_payloads_to_trimmed_scalar_strings(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());
@@ -463,6 +549,7 @@ class RpgCharEditorPdfTest extends TestCase
             ->with('rpg.char-sheet', \Mockery::on(fn ($data) => $data['character'] === [
                 'player_name' => 'Holger',
                 'character_name' => '',
+                'gender' => 'weiblich',
                 'race' => '123',
                 'culture' => '',
                 'description' => '',
@@ -479,6 +566,7 @@ class RpgCharEditorPdfTest extends TestCase
         $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', [
             'player_name' => ' Holger ',
             'character_name' => ['manipuliert'],
+            'gender' => ' weiblich ',
             'race' => 123,
             'culture' => false,
             'description' => ['manipuliert'],

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -381,6 +381,8 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.isCultureSelectable('Landbewohner')).toBe(true);
         expect(e.isCultureSelectable('Stadtbewohner')).toBe(true);
         expect(e.isCultureSelectable('Meeresbewohner')).toBe(true);
+        expect(e.isCultureSelectable('Nomade')).toBe(true);
+        expect(e.isCultureSelectable('Volk der 13 Inseln')).toBe(true);
 
         const barbar = createEditor({ race: 'Barbar', culture: '' });
         barbar.handleRaceChange();
@@ -449,6 +451,8 @@ describe('charEditor – Kultur-Logik', () => {
         expect(barbar.isCultureSelectable('Landbewohner')).toBe(true);
         expect(barbar.isCultureSelectable('Stadtbewohner')).toBe(true);
         expect(barbar.isCultureSelectable('Meeresbewohner')).toBe(true);
+        expect(barbar.isCultureSelectable('Nomade')).toBe(true);
+        expect(barbar.isCultureSelectable('Volk der 13 Inseln')).toBe(true);
         expect(barbar.isCultureSelectable('Bunkermensch')).toBe(false);
     });
 
@@ -616,6 +620,101 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.skills.find(s => s.name === 'Beruf: Farmer')).toBeUndefined();
         expect(e.skills.find(s => s.name === 'Wissenschaftler')).toBeUndefined();
     });
+
+    it('Nomade setzt Ueberleben und die Standard-Wahlboni', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Nomade' });
+        e.applyRaceBarbar();
+        e.applyCultureNomade();
+
+        expect(e.cultureGrants['\u00dcberleben']).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Reiten).toEqual({ type: 'min', value: 1 });
+        expect(e.nomadeCombatSkill).toBe('Nahkampf');
+        expect(e.nomadeMovementSkill).toBe('Reiten');
+        expect(e.skills.find(s => s.name === '\u00dcberleben')).toMatchObject({ value: 1, badge: 'Rasse/Kultur' });
+    });
+
+    it('Nomade-Wahlboni ersetzen alte Optionen ohne Rassen-Grants zu entfernen', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Nomade' });
+        e.applyRaceBarbar();
+        e.applyCultureNomade();
+
+        e.setNomadeCombatSkill('Fernkampf');
+        e.setNomadeMovementSkill('Athletik');
+
+        expect(e.cultureGrants.Nahkampf).toBeUndefined();
+        expect(e.raceGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Fernkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Reiten).toBeUndefined();
+        expect(e.cultureGrants.Athletik).toEqual({ type: 'min', value: 1 });
+        expect(e.skills.find(s => s.name === 'Reiten')).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Nahkampf')).toMatchObject({ value: 1, badge: 'Rasse' });
+    });
+
+    it('Volk der 13 Inseln ist nur fuer Barbaren auswaehlbar', () => {
+        const barbar = createEditor({ race: 'Barbar' });
+        const guul = createEditor({ race: 'Guul' });
+
+        expect(barbar.isCultureSelectable('Volk der 13 Inseln')).toBe(true);
+        expect(guul.isCultureSelectable('Volk der 13 Inseln')).toBe(false);
+        expect(guul.isCultureSelectable('Nomade')).toBe(true);
+
+        const invalid = createEditor({ race: 'Guul', culture: 'Volk der 13 Inseln', gender: 'weiblich' });
+        invalid.applyCultureVolkDer13Inseln();
+        invalid.handleRaceChange();
+
+        expect(invalid.culture).toBe('');
+        expect(invalid.cultureGrants).toEqual({});
+        expect(invalid.selectedAdvantages).not.toContain('Psychische Kraft');
+    });
+
+    it('Volk der 13 Inseln setzt Athletik, Ueberleben und Beruf-Wahlbonus', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Volk der 13 Inseln', gender: 'maennlich' });
+        e.applyRaceBarbar();
+        e.applyCultureVolkDer13Inseln();
+
+        expect(e.cultureGrants.Athletik).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants['\u00dcberleben']).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants['Beruf: Bauer']).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureLocked.advantages).toEqual([]);
+        expect(e.skills.find(s => s.name === '\u00dcberleben')).toMatchObject({ value: 1, badge: 'Rasse/Kultur' });
+
+        e.setVolkDer13InselnProfessionSkill('Beruf: Fischer');
+
+        expect(e.cultureGrants['Beruf: Bauer']).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Beruf: Bauer')).toBeUndefined();
+        expect(e.cultureGrants['Beruf: Fischer']).toEqual({ type: 'min', value: 1 });
+    });
+
+    it('weibliches Volk der 13 Inseln erzwingt Psychische Kraft ohne freie Vorteile zu verbrauchen', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Volk der 13 Inseln', gender: 'weiblich' });
+        e.applyCultureVolkDer13Inseln();
+
+        expect(e.cultureLocked.advantages).toEqual(['Psychische Kraft']);
+        expect(e.selectedAdvantages).toContain('Psychische Kraft');
+        expect(e.chosenAdvantagesCount()).toBe(0);
+        expect(e.freeAdvantagePoints()).toBe(2);
+        expect(e.selectedDisabledAdvantages()).toEqual(['Z\u00e4h', 'Psychische Kraft']);
+
+        e.gender = 'maennlich';
+        e.handleGenderChange();
+
+        expect(e.cultureLocked.advantages).toEqual([]);
+        expect(e.selectedAdvantages).not.toContain('Psychische Kraft');
+    });
+
+    it('Kultur-Pflichtvorteil erhaelt bereits frei gewaehlte Psychische Kraft', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Volk der 13 Inseln', gender: 'weiblich' });
+        e.selectedAdvantages = ['Z\u00e4h', 'Psychische Kraft'];
+        e.applyCultureVolkDer13Inseln();
+
+        e.gender = 'maennlich';
+        e.handleGenderChange();
+
+        expect(e.selectedAdvantages).toContain('Psychische Kraft');
+        expect(e.chosenAdvantagesCount()).toBe(1);
+        expect(e.freeAdvantagePoints()).toBe(1);
+    });
 });
 
 describe('charEditor – Vorteile/Nachteile', () => {
@@ -717,6 +816,7 @@ describe('charEditor – Computed Properties', () => {
         const e = createEditor({
             playerName: 'Test',
             characterName: 'Held',
+            gender: 'weiblich',
             race: 'Barbar',
             culture: 'Landbewohner',
         });
@@ -727,6 +827,17 @@ describe('charEditor – Computed Properties', () => {
         const e = createEditor({
             playerName: 'Test',
             characterName: '',
+            gender: 'weiblich',
+            race: 'Barbar',
+            culture: 'Landbewohner',
+        });
+        expect(e.basicsFilled()).toBeFalsy();
+    });
+
+    it('basicsFilled false ohne Geschlecht', () => {
+        const e = createEditor({
+            playerName: 'Test',
+            characterName: 'Held',
             race: 'Barbar',
             culture: 'Landbewohner',
         });

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -8,12 +8,13 @@ const login = async (page, email, password = 'password') => {
     await page.waitForURL((url) => !url.pathname.endsWith('/login'));
 };
 
-const openAdvancedEditor = async (page, { race = 'Barbar', culture = 'Landbewohner' } = {}) => {
+const openAdvancedEditor = async (page, { race = 'Barbar', culture = 'Landbewohner', gender = 'maennlich' } = {}) => {
     await login(page, 'info@maddraxikon.com');
     await page.goto('/rpg/char-editor');
 
     await page.getByLabel('Spielername').fill('Playwright Spieler');
     await page.getByLabel('Charaktername').fill('Wudan');
+    await page.locator('#gender').selectOption(gender);
     await page.locator('#race').selectOption(race);
     await page.locator('#culture').selectOption(culture);
     await page.getByTestId('char-editor-continue-button').click();
@@ -77,6 +78,7 @@ test.describe('RPG Charakter-Editor', () => {
 
         await page.getByLabel('Spielername').fill('Playwright Spieler');
         await page.getByLabel('Charaktername').fill('Wudan');
+        await page.locator('#gender').selectOption('maennlich');
         await page.locator('#race').selectOption('Barbar');
         await page.locator('#culture').selectOption('Landbewohner');
 
@@ -137,6 +139,7 @@ test.describe('RPG Charakter-Editor', () => {
             return {
                 playerName: data.get('player_name'),
                 characterName: data.get('character_name'),
+                gender: data.get('gender'),
                 race: data.get('race'),
                 culture: data.get('culture'),
                 skills: Object.values(skillsByIndex),
@@ -145,6 +148,7 @@ test.describe('RPG Charakter-Editor', () => {
 
         expect(payload.playerName).toBe('Playwright Spieler');
         expect(payload.characterName).toBe('Wudan');
+        expect(payload.gender).toBe('maennlich');
         expect(payload.race).toBe('Barbar');
         expect(payload.culture).toBe('Landbewohner');
         expect(payload.skills).toEqual(expect.arrayContaining([
@@ -215,6 +219,7 @@ test.describe('RPG Charakter-Editor', () => {
 
         await page.getByLabel('Spielername').fill('Playwright Spieler');
         await page.getByLabel('Charaktername').fill('Wudan');
+        await page.locator('#gender').selectOption('maennlich');
         await page.locator('#culture').selectOption('Landbewohner');
         await expect(page.locator('#culture')).toHaveValue('Landbewohner');
 
@@ -230,6 +235,8 @@ test.describe('RPG Charakter-Editor', () => {
             Landbewohner: true,
             Stadtbewohner: true,
             Meeresbewohner: false,
+            Nomade: true,
+            'Volk der 13 Inseln': true,
         });
 
         await page.getByTestId('char-editor-continue-button').click();
@@ -308,6 +315,108 @@ test.describe('RPG Charakter-Editor', () => {
         ]));
     });
 
+
+    test('erlaubt Volk der 13 Inseln nur fuer Barbaren und erzwingt Psychische Kraft fuer weiblich', async ({ page }) => {
+        await login(page, 'info@maddraxikon.com');
+        await page.goto('/rpg/char-editor');
+
+        await page.getByLabel('Spielername').fill('Playwright Spieler');
+        await page.getByLabel('Charaktername').fill('Wudan');
+        await page.locator('#gender').selectOption('weiblich');
+
+        await expect(page.locator('#culture option[value="Volk der 13 Inseln"]')).toBeDisabled();
+
+        await page.locator('#race').selectOption('Guul');
+        await expect(page.locator('#culture option[value="Volk der 13 Inseln"]')).toBeDisabled();
+
+        await page.locator('#race').selectOption('Barbar');
+        await expect(page.locator('#culture option[value="Volk der 13 Inseln"]')).not.toBeDisabled();
+        await page.locator('#culture').selectOption('Volk der 13 Inseln');
+        await page.getByTestId('char-editor-continue-button').click();
+
+        await expect(checkbox(page, 'advantages[]', 'Psychische Kraft')).toBeChecked();
+        await expect(checkbox(page, 'advantages[]', 'Psychische Kraft')).toBeDisabled();
+        await expect(page.getByText('Freie Vorteile: 2')).toBeVisible();
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+            const skillsByIndex = {};
+
+            for (const [key, value] of data.entries()) {
+                const match = key.match(/^skills\[(\d+)]\[(name|value)]$/);
+
+                if (!match) {
+                    continue;
+                }
+
+                const [, index, field] = match;
+                skillsByIndex[index] ??= {};
+                skillsByIndex[index][field] = value;
+            }
+
+            return {
+                gender: data.get('gender'),
+                race: data.get('race'),
+                culture: data.get('culture'),
+                advantages: data.getAll('advantages[]'),
+                skills: Object.values(skillsByIndex),
+            };
+        });
+
+        expect(payload.gender).toBe('weiblich');
+        expect(payload.race).toBe('Barbar');
+        expect(payload.culture).toBe('Volk der 13 Inseln');
+        expect(payload.advantages).toEqual(expect.arrayContaining(['Z\u00e4h', 'Psychische Kraft']));
+        expect(payload.skills).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Athletik', value: '1' }),
+            expect.objectContaining({ name: '\u00dcberleben', value: '1' }),
+            expect.objectContaining({ name: 'Beruf: Bauer', value: '1' }),
+        ]));
+    });
+
+    test('setzt Nomade-Regeln inklusive Fernkampf-Mapping im Formularpayload um', async ({ page }) => {
+        await openAdvancedEditor(page, { race: 'Barbar', culture: 'Nomade' });
+
+        await page.locator('#nomade-combat-select').selectOption('Fernkampf');
+        await page.locator('#nomade-movement-select').selectOption('Athletik');
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+            const skillsByIndex = {};
+
+            for (const [key, value] of data.entries()) {
+                const match = key.match(/^skills\[(\d+)]\[(name|value)]$/);
+
+                if (!match) {
+                    continue;
+                }
+
+                const [, index, field] = match;
+                skillsByIndex[index] ??= {};
+                skillsByIndex[index][field] = value;
+            }
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+                skills: Object.values(skillsByIndex),
+            };
+        });
+
+        expect(payload.race).toBe('Barbar');
+        expect(payload.culture).toBe('Nomade');
+        expect(payload.skills).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Nahkampf', value: '1' }),
+            expect.objectContaining({ name: 'Fernkampf', value: '1' }),
+            expect.objectContaining({ name: 'Athletik', value: '1' }),
+            expect.objectContaining({ name: '\u00dcberleben', value: '1' }),
+        ]));
+        expect(payload.skills).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Fernwaffen' }),
+            expect.objectContaining({ name: 'Reiten' }),
+        ]));
+    });
+
     test('erzwingt Bunkermensch als einzige Kultur fuer Techno', async ({ page }) => {
         await login(page, 'info@maddraxikon.com');
         await page.goto('/rpg/char-editor');
@@ -316,6 +425,7 @@ test.describe('RPG Charakter-Editor', () => {
 
         await page.getByLabel('Spielername').fill('Playwright Spieler');
         await page.getByLabel('Charaktername').fill('Wudan');
+        await page.locator('#gender').selectOption('maennlich');
         await page.locator('#culture').selectOption('Landbewohner');
         await expect(page.locator('#culture')).toHaveValue('Landbewohner');
 
@@ -332,6 +442,8 @@ test.describe('RPG Charakter-Editor', () => {
             Stadtbewohner: true,
             Meeresbewohner: true,
             Bunkermensch: false,
+            Nomade: true,
+            'Volk der 13 Inseln': true,
         });
 
         await page.getByTestId('char-editor-continue-button').click();


### PR DESCRIPTION
This pull request introduces major enhancements to the RPG character editor, focusing on supporting new cultures ("Nomade" and "Volk der 13 Inseln"), enforcing stricter character validation rules, and improving the handling of gender-specific and culture-specific requirements. The changes span backend validation, frontend logic, and user interface updates to ensure consistency and compliance with game rules.

**Backend validation and logic enhancements:**

* Added `gender` as a required character attribute, with validation restricting values to "weiblich", "maennlich", or "divers". [[1]](diffhunk://#diff-cc4e8a0530fc1f0b8a79eef9d32623f68bfc4dcf332e23360b25f2c63b266c1eR20-R28) [[2]](diffhunk://#diff-cc4e8a0530fc1f0b8a79eef9d32623f68bfc4dcf332e23360b25f2c63b266c1eL191-R215)
* Implemented new validation rules:
  - Only "Barbar" race can select the "Volk der 13 Inseln" culture.
  - Female characters from "Volk der 13 Inseln" must have the "Psychische Kraft" advantage.
* Updated the payload and validation flow to pass advantages and character data together, ensuring all rules are checked before generating PDFs. [[1]](diffhunk://#diff-cc4e8a0530fc1f0b8a79eef9d32623f68bfc4dcf332e23360b25f2c63b266c1eR99-R112) [[2]](diffhunk://#diff-cc4e8a0530fc1f0b8a79eef9d32623f68bfc4dcf332e23360b25f2c63b266c1eL191-R215)

**Frontend logic and data model updates:**

* Added support for the "Nomade" and "Volk der 13 Inseln" cultures, including their descriptions and specific skill/advantage handling. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L12-R27) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L193-R214) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R622-R623) [[4]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R666-R678)
* Introduced `gender` as a required field in the frontend state and ensured it is included in form submissions. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R65) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R53) [[3]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R70-R79)
* Implemented dynamic enforcement of culture-locked advantages, especially for "Volk der 13 Inseln" females, and unified logic for locked advantages across race and culture. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R100-R107) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R152-R159) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R778-R808)
* Added new skill selection logic for the new cultures, including automatic and selectable skills based on culture and gender. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R85-R87) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R635-R638) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R721-R748)

**User interface improvements:**

* Added a gender selection dropdown to the character creation form, with three options and proper disabling when advanced mode is locked.
* Updated the culture selection dropdown to include "Nomade" and "Volk der 13 Inseln", with dynamic enabling/disabling based on character race.

These changes ensure that character creation strictly follows the RPG's official rules, especially regarding culture and gender restrictions, and provide a more robust and user-friendly character editor experience.