### PR TITLE
Fix: Enforce Techno race for Bunkermensch culture

### DIFF
--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -90,6 +90,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     technoSkillPoints: Object.fromEntries(TECHNO_SKILLS.map(name => [name, 2])),
     raceCache: {},
     raceAttributeModifiers: {},
+    raceLockedByBunkermenschCulture: false,
 
     // Dynamic data
     attributes: { st: 0, ge: 0, ro: 0, wi: 0, wa: 0, in: 0, au: 0 },
@@ -215,7 +216,17 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     },
 
     isCultureSelectable(culture) {
+        if (culture === 'Bunkermensch') return true;
+
+        if (this.race === 'Techno' && this.raceLockedByBunkermenschCulture) {
+            return this.allowedCulturesForRace('').includes(culture);
+        }
+
         return this.allowedCulturesForRace().includes(culture);
+    },
+
+    isRaceSelectable(race) {
+        return this.culture !== 'Bunkermensch' || race === 'Techno';
     },
 
     enforceCultureForRace() {
@@ -493,6 +504,12 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     // --- Race handling ---
     handleRaceChange() {
+        if (!this.isRaceSelectable(this.race)) {
+            this.race = 'Techno';
+        } else if (this.culture !== 'Bunkermensch' || this.race !== 'Techno') {
+            this.raceLockedByBunkermenschCulture = false;
+        }
+
         if (this.raceCache[this._prevRace]) {
             // Already cached by cacheRaceState below
         } else if (this._prevRace) {
@@ -614,6 +631,12 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
             return;
         }
 
+        if (this.culture === 'Bunkermensch') {
+            this.ensureTechnoRaceForBunkermenschCulture();
+        } else {
+            this.releaseBunkermenschRaceLock();
+        }
+
         this.clearCulture();
         if (this.culture === 'Landbewohner') this.applyCultureLandbewohner();
         if (this.culture === 'Stadtbewohner') this.applyCultureStadtbewohner();
@@ -622,6 +645,24 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (this.culture === 'Nomade') this.applyCultureNomade();
         if (this.culture === VOLK_DER_13_INSELN_CULTURE) this.applyCultureVolkDer13Inseln();
         this.updateDescription();
+    },
+
+    ensureTechnoRaceForBunkermenschCulture() {
+        if (this.race === 'Techno') return;
+
+        this.raceLockedByBunkermenschCulture = true;
+        this.race = 'Techno';
+        this.handleRaceChange();
+    },
+
+    releaseBunkermenschRaceLock() {
+        if (!this.raceLockedByBunkermenschCulture) return;
+
+        this.raceLockedByBunkermenschCulture = false;
+        if (this.race !== 'Techno') return;
+
+        this.race = '';
+        this.handleRaceChange();
     },
 
     clearCulture() {

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -504,11 +504,16 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     // --- Race handling ---
     handleRaceChange() {
+        const previousRace = this._prevRace || '';
+        if (this.race === previousRace) return;
+
         if (!this.isRaceSelectable(this.race)) {
             this.race = 'Techno';
         } else if (this.culture !== 'Bunkermensch' || this.race !== 'Techno') {
             this.raceLockedByBunkermenschCulture = false;
         }
+
+        if (this.race === previousRace) return;
 
         if (this.raceCache[this._prevRace]) {
             // Already cached by cacheRaceState below

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -226,7 +226,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     },
 
     isRaceSelectable(race) {
-        return this.culture !== 'Bunkermensch' || race === 'Techno';
+        return this.culture !== 'Bunkermensch' || !this.raceLockedByBunkermenschCulture || race === 'Techno';
     },
 
     enforceCultureForRace() {

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -81,10 +81,10 @@
                         <label for="race" class="block text-sm font-medium text-base-content mb-1">Rasse</label>
                         <select name="race" id="race" class="select select-bordered w-full" x-model="race" :disabled="advancedUnlocked">
                             <option value="" disabled>Rasse wählen</option>
-                            <option value="Barbar">Barbar</option>
-                            <option value="Guul">Guul</option>
-                            <option value="Hydrit">Hydrit</option>
-                            <option value="Techno">Techno</option>
+                            <option value="Barbar" :disabled="!isRaceSelectable('Barbar')">Barbar</option>
+                            <option value="Guul" :disabled="!isRaceSelectable('Guul')">Guul</option>
+                            <option value="Hydrit" :disabled="!isRaceSelectable('Hydrit')">Hydrit</option>
+                            <option value="Techno" :disabled="!isRaceSelectable('Techno')">Techno</option>
                         </select>
                     </div>
 

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -533,14 +533,31 @@ describe('charEditor – Kultur-Logik', () => {
         e.applyRaceTechno();
         e.applyCultureBunkermensch();
         e._prevRace = 'Techno';
+        const clearRace = vi.spyOn(e, 'clearRace');
 
         e.race = 'Barbar';
         e.handleRaceChange();
 
         expect(e.race).toBe('Techno');
+        expect(clearRace).not.toHaveBeenCalled();
         expect(e.raceGrants.Fahren).toEqual({ type: 'min', value: 2 });
         expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 1 });
         expect(e.isRaceSelectable('Barbar')).toBe(false);
+    });
+
+    it('ignoriert doppelten Rassen-Handler-Lauf bei unveraenderter Rasse', () => {
+        const e = createEditor({ race: 'Techno', culture: 'Bunkermensch' });
+        e.applyRaceTechno();
+        e.applyCultureBunkermensch();
+        e._prevRace = 'Techno';
+        const clearRace = vi.spyOn(e, 'clearRace');
+
+        e.handleRaceChange();
+
+        expect(clearRace).not.toHaveBeenCalled();
+        expect(e.race).toBe('Techno');
+        expect(e.raceGrants.Fahren).toEqual({ type: 'min', value: 2 });
+        expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 1 });
     });
 
     it('Bunkermensch erhält Bildung, Nahkampf und den wählbaren Zusatzbonus', () => {

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -438,7 +438,7 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.skills.find(s => s.name === 'Athletik')).toMatchObject({ value: 2, badge: 'Rasse/Kultur' });
     });
 
-    it('Techno erlaubt nur Bunkermensch und andere Rassen dürfen Bunkermensch nicht wählen', () => {
+    it('Techno erzwingt Bunkermensch und Bunkermensch sperrt Rassen auf Techno', () => {
         const techno = createEditor({ race: 'Techno' });
 
         expect(techno.allowedCulturesForRace()).toEqual(['Bunkermensch']);
@@ -453,7 +453,16 @@ describe('charEditor – Kultur-Logik', () => {
         expect(barbar.isCultureSelectable('Meeresbewohner')).toBe(true);
         expect(barbar.isCultureSelectable('Nomade')).toBe(true);
         expect(barbar.isCultureSelectable('Volk der 13 Inseln')).toBe(true);
-        expect(barbar.isCultureSelectable('Bunkermensch')).toBe(false);
+        expect(barbar.isCultureSelectable('Bunkermensch')).toBe(true);
+
+        const bunker = createEditor({ race: 'Techno', culture: 'Bunkermensch', raceLockedByBunkermenschCulture: true });
+
+        expect(bunker.isRaceSelectable('Barbar')).toBe(false);
+        expect(bunker.isRaceSelectable('Guul')).toBe(false);
+        expect(bunker.isRaceSelectable('Hydrit')).toBe(false);
+        expect(bunker.isRaceSelectable('Techno')).toBe(true);
+        expect(bunker.isCultureSelectable('Landbewohner')).toBe(true);
+        expect(bunker.isCultureSelectable('Volk der 13 Inseln')).toBe(false);
     });
 
     it('Rassenwechsel zu Techno setzt Kultur auf Bunkermensch und ersetzt alte Kultur-Grants', () => {
@@ -465,6 +474,7 @@ describe('charEditor – Kultur-Logik', () => {
         e.handleRaceChange();
 
         expect(e.culture).toBe('Bunkermensch');
+        expect(e.raceLockedByBunkermenschCulture).toBe(false);
         expect(e.cultureGrants['Beruf: Landwirt']).toBeUndefined();
         expect(e.skills.find(s => s.name === 'Beruf: Landwirt')).toBeUndefined();
 
@@ -475,15 +485,62 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.cultureGrants.Feuerwaffen).toEqual({ type: 'min', value: 3 });
     });
 
-    it('direkter Kulturwechsel verhindert Bunkermensch für Nicht-Technos', () => {
+    it('Kulturwechsel auf Bunkermensch setzt Techno automatisch und ersetzt alte Rassen-Grants', () => {
         const e = createEditor({ race: 'Barbar', culture: 'Bunkermensch' });
-        e.applyCultureBunkermensch();
+        e.applyRaceBarbar();
+
+        expect(e.raceGrants['\u00dcberleben']).toEqual({ type: 'min', value: 1 });
 
         e.handleCultureChange();
 
-        expect(e.culture).toBe('');
-        expect(e.cultureGrants).toEqual({});
-        expect(e.skills.find(s => s.name === 'Bildung')).toBeUndefined();
+        expect(e.race).toBe('Techno');
+        expect(e.raceLockedByBunkermenschCulture).toBe(true);
+        expect(e.raceGrants['\u00dcberleben']).toBeUndefined();
+        expect(e.raceGrants.Fahren).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Feuerwaffen).toEqual({ type: 'min', value: 2 });
+        expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Feuerwaffen).toEqual({ type: 'min', value: 3 });
+        expect(e.isRaceSelectable('Barbar')).toBe(false);
+        expect(e.isRaceSelectable('Techno')).toBe(true);
+    });
+
+    it('Kulturwechsel weg von automatisch gesetztem Bunkermensch leert Techno und gibt Rassen frei', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Bunkermensch' });
+        e.applyRaceBarbar();
+        e.handleCultureChange();
+
+        expect(e.race).toBe('Techno');
+        expect(e.raceLockedByBunkermenschCulture).toBe(true);
+
+        e.culture = 'Landbewohner';
+        e.handleCultureChange();
+
+        expect(e.race).toBe('');
+        expect(e.raceLockedByBunkermenschCulture).toBe(false);
+        expect(e.raceGrants).toEqual({});
+        expect(e.cultureGrants['Beruf: Landwirt']).toEqual({ type: 'exact', value: 2 });
+        expect(e.cultureGrants.Feuerwaffen).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Feuerwaffen')).toBeUndefined();
+        expect(e.isRaceSelectable('Barbar')).toBe(true);
+        expect(e.isRaceSelectable('Guul')).toBe(true);
+        expect(e.isRaceSelectable('Hydrit')).toBe(true);
+        expect(e.isRaceSelectable('Techno')).toBe(true);
+    });
+
+    it('direkter Rassenwechsel bleibt bei Bunkermensch auf Techno beschraenkt', () => {
+        const e = createEditor({ race: 'Techno', culture: 'Bunkermensch' });
+        e.applyRaceTechno();
+        e.applyCultureBunkermensch();
+        e._prevRace = 'Techno';
+
+        e.race = 'Barbar';
+        e.handleRaceChange();
+
+        expect(e.race).toBe('Techno');
+        expect(e.raceGrants.Fahren).toEqual({ type: 'min', value: 2 });
+        expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 1 });
+        expect(e.isRaceSelectable('Barbar')).toBe(false);
     });
 
     it('Bunkermensch erhält Bildung, Nahkampf und den wählbaren Zusatzbonus', () => {

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -438,7 +438,7 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.skills.find(s => s.name === 'Athletik')).toMatchObject({ value: 2, badge: 'Rasse/Kultur' });
     });
 
-    it('Techno erzwingt Bunkermensch und Bunkermensch sperrt Rassen auf Techno', () => {
+    it('Techno erzwingt Bunkermensch und nur der Auto-Lock sperrt Rassen auf Techno', () => {
         const techno = createEditor({ race: 'Techno' });
 
         expect(techno.allowedCulturesForRace()).toEqual(['Bunkermensch']);
@@ -463,6 +463,14 @@ describe('charEditor – Kultur-Logik', () => {
         expect(bunker.isRaceSelectable('Techno')).toBe(true);
         expect(bunker.isCultureSelectable('Landbewohner')).toBe(true);
         expect(bunker.isCultureSelectable('Volk der 13 Inseln')).toBe(false);
+
+        const manualTechno = createEditor({ race: 'Techno', culture: 'Bunkermensch' });
+
+        expect(manualTechno.isRaceSelectable('Barbar')).toBe(true);
+        expect(manualTechno.isRaceSelectable('Guul')).toBe(true);
+        expect(manualTechno.isRaceSelectable('Hydrit')).toBe(true);
+        expect(manualTechno.isRaceSelectable('Techno')).toBe(true);
+        expect(manualTechno.isCultureSelectable('Landbewohner')).toBe(false);
     });
 
     it('Rassenwechsel zu Techno setzt Kultur auf Bunkermensch und ersetzt alte Kultur-Grants', () => {
@@ -528,8 +536,8 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.isRaceSelectable('Techno')).toBe(true);
     });
 
-    it('direkter Rassenwechsel bleibt bei Bunkermensch auf Techno beschraenkt', () => {
-        const e = createEditor({ race: 'Techno', culture: 'Bunkermensch' });
+    it('direkter Rassenwechsel bleibt bei aktivem Bunkermensch-Auto-Lock auf Techno beschraenkt', () => {
+        const e = createEditor({ race: 'Techno', culture: 'Bunkermensch', raceLockedByBunkermenschCulture: true });
         e.applyRaceTechno();
         e.applyCultureBunkermensch();
         e._prevRace = 'Techno';
@@ -543,6 +551,24 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.raceGrants.Fahren).toEqual({ type: 'min', value: 2 });
         expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 1 });
         expect(e.isRaceSelectable('Barbar')).toBe(false);
+    });
+
+    it('manuell gewaehlter Techno kann per Rassenwechsel aus Bunkermensch herauswechseln', () => {
+        const e = createEditor({ race: 'Techno', culture: 'Bunkermensch' });
+        e.applyRaceTechno();
+        e.applyCultureBunkermensch();
+        e._prevRace = 'Techno';
+
+        e.race = 'Barbar';
+        e.handleRaceChange();
+
+        expect(e.race).toBe('Barbar');
+        expect(e.culture).toBe('');
+        expect(e.raceLockedByBunkermenschCulture).toBe(false);
+        expect(e.raceGrants['\u00dcberleben']).toEqual({ type: 'min', value: 1 });
+        expect(e.raceGrants.Fahren).toBeUndefined();
+        expect(e.cultureGrants).toEqual({});
+        expect(e.isRaceSelectable('Barbar')).toBe(true);
     });
 
     it('ignoriert doppelten Rassen-Handler-Lauf bei unveraenderter Rasse', () => {

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -417,11 +417,83 @@ test.describe('RPG Charakter-Editor', () => {
         ]));
     });
 
-    test('erzwingt Bunkermensch als einzige Kultur fuer Techno', async ({ page }) => {
+    test('setzt Techno automatisch wenn Bunkermensch zuerst gewaehlt wird', async ({ page }) => {
         await login(page, 'info@maddraxikon.com');
         await page.goto('/rpg/char-editor');
 
-        await expect(page.locator('#culture option[value="Bunkermensch"]')).toBeDisabled();
+        await expect(page.locator('#culture option[value="Bunkermensch"]')).not.toBeDisabled();
+
+        await page.getByLabel('Spielername').fill('Playwright Spieler');
+        await page.getByLabel('Charaktername').fill('Wudan');
+        await page.locator('#gender').selectOption('maennlich');
+        await page.locator('#culture').selectOption('Bunkermensch');
+
+        await expect(page.locator('#race')).toHaveValue('Techno');
+        await expect(page.locator('#culture')).toHaveValue('Bunkermensch');
+
+        const lockedRaceOptions = await page.locator('#race').evaluate((select) => Object.fromEntries(
+            Array.from(select.options).map((option) => [option.value || 'placeholder', option.disabled]),
+        ));
+
+        expect(lockedRaceOptions).toMatchObject({
+            Barbar: true,
+            Guul: true,
+            Hydrit: true,
+            Techno: false,
+        });
+
+        const unlockedCultureOptions = await page.locator('#culture').evaluate((select) => Object.fromEntries(
+            Array.from(select.options).map((option) => [option.value || 'placeholder', option.disabled]),
+        ));
+
+        expect(unlockedCultureOptions).toMatchObject({
+            Landbewohner: false,
+            Stadtbewohner: false,
+            Meeresbewohner: false,
+            Bunkermensch: false,
+            Nomade: false,
+            'Volk der 13 Inseln': true,
+        });
+
+        await page.locator('#culture').selectOption('Landbewohner');
+
+        await expect(page.locator('#culture')).toHaveValue('Landbewohner');
+        await expect(page.locator('#race')).toHaveValue('');
+
+        const releasedRaceOptions = await page.locator('#race').evaluate((select) => Object.fromEntries(
+            Array.from(select.options).map((option) => [option.value || 'placeholder', option.disabled]),
+        ));
+
+        expect(releasedRaceOptions).toMatchObject({
+            Barbar: false,
+            Guul: false,
+            Hydrit: false,
+            Techno: false,
+        });
+
+        await page.locator('#race').selectOption('Barbar');
+        await page.getByTestId('char-editor-continue-button').click();
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+            };
+        });
+
+        expect(payload).toEqual({
+            race: 'Barbar',
+            culture: 'Landbewohner',
+        });
+    });
+
+    test('erzwingt Bunkermensch als einzige Kultur fuer manuell gewaehlt Techno', async ({ page }) => {
+        await login(page, 'info@maddraxikon.com');
+        await page.goto('/rpg/char-editor');
+
+        await expect(page.locator('#culture option[value="Bunkermensch"]')).not.toBeDisabled();
 
         await page.getByLabel('Spielername').fill('Playwright Spieler');
         await page.getByLabel('Charaktername').fill('Wudan');
@@ -444,6 +516,17 @@ test.describe('RPG Charakter-Editor', () => {
             Bunkermensch: false,
             Nomade: true,
             'Volk der 13 Inseln': true,
+        });
+
+        const raceOptions = await page.locator('#race').evaluate((select) => Object.fromEntries(
+            Array.from(select.options).map((option) => [option.value || 'placeholder', option.disabled]),
+        ));
+
+        expect(raceOptions).toMatchObject({
+            Barbar: true,
+            Guul: true,
+            Hydrit: true,
+            Techno: false,
         });
 
         await page.getByTestId('char-editor-continue-button').click();

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -523,9 +523,9 @@ test.describe('RPG Charakter-Editor', () => {
         ));
 
         expect(raceOptions).toMatchObject({
-            Barbar: true,
-            Guul: true,
-            Hydrit: true,
+            Barbar: false,
+            Guul: false,
+            Hydrit: false,
             Techno: false,
         });
 


### PR DESCRIPTION
This pull request refines the logic for selecting the "Bunkermensch" culture and "Techno" race in the character editor, making the relationship between these two options more intuitive and robust. Now, selecting "Bunkermensch" as a culture automatically sets the race to "Techno" and locks other races, while switching away from "Bunkermensch" releases this lock and allows all races again. The changes are thoroughly tested with updated unit and end-to-end tests.

**Character editor logic improvements:**

* Added a new state variable `raceLockedByBunkermenschCulture` in `char-editor.js` to track when the "Techno" race is locked due to selecting the "Bunkermensch" culture.
* Implemented `isRaceSelectable` and updated `isCultureSelectable` to enforce that only "Techno" can be selected when "Bunkermensch" is chosen, and vice versa.
* Updated `handleRaceChange` to prevent changing away from "Techno" when the lock is active, and to release the lock when appropriate.
* Modified `handleCultureChange` to automatically set and lock the race to "Techno" when "Bunkermensch" is chosen, and to release the lock and clear the race when switching away. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R639-R644) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R655-R672)

**UI enhancements:**

* Updated the race dropdown in `char-editor.blade.php` to disable non-selectable races dynamically based on the new logic.

**Testing updates:**

* Expanded unit tests to cover all new behaviors, including automatic race locking/unlocking, proper grant application/removal, and edge cases like manual Techno selection or redundant handler calls. [[1]](diffhunk://#diff-fb18f83cf98be37a88d19828a9e35f53c1e003d762ea98aab19f3e4e301b364bL441-R441) [[2]](diffhunk://#diff-fb18f83cf98be37a88d19828a9e35f53c1e003d762ea98aab19f3e4e301b364bL456-R473) [[3]](diffhunk://#diff-fb18f83cf98be37a88d19828a9e35f53c1e003d762ea98aab19f3e4e301b364bR485) [[4]](diffhunk://#diff-fb18f83cf98be37a88d19828a9e35f53c1e003d762ea98aab19f3e4e301b364bL478-R586)
* Enhanced end-to-end tests to verify the new locking logic, UI state, and payloads for both automatic and manual Techno/Bunkermensch selection flows. [[1]](diffhunk://#diff-48d2a15af217532067f591c00c0e82f39584112f276cd4b2ff9c4e0ad80910c6L420-R496) [[2]](diffhunk://#diff-48d2a15af217532067f591c00c0e82f39584112f276cd4b2ff9c4e0ad80910c6R521-R531)