### PR TITLE
Feature: Ruinen- and Untergrundbewohner cultures

### DIFF
--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -11,6 +11,8 @@ const CULTURE_DESCRIPTIONS = {
     Meeresbewohner: 'Meeresbewohner sind Hydriten aus großen, seit langem verborgenen Unterseestädten. Ihre Gesellschaft ist streng hierarchisch organisiert, technisch und biotechnologisch weit fortgeschritten und meidet den Kontakt zu Oberflächenbewohnern.',
     Bunkermensch: 'Bunkermenschen sind Nachfahren jener Menschen, die die Katastrophe in Bunkern überlebten. Sie verfügen über Technik der alten Welt, leiden aber durch Isolation an einer fatalen Immunschwäche und begegnen der Oberfläche meist nur in Schutzanzügen.',
     Nomade: 'Nomaden folgen den Routen ihrer Nutztiere durch die Jahreszeiten. Sie sind wehrhaft, überleben in unwirtlicher Natur und werden von sesshaften Völkern oft misstrauisch betrachtet.',
+    Ruinenbewohner: 'Ruinenbewohner leben in den Resten der Städte aus der Zeit vor Kristoflus als Banditen, Jäger und Sammler. Ihre Gesellschaften sind primitiv und von Brutalität und Not geprägt.',
+    Untergrundbewohner: 'Untergrundbewohner leben in Höhlen und alten Stollen, um sich vor den Gefahren der Oberfläche zu schützen. Sie arbeiten überwiegend als Bergleute, Jäger und Sammler. Häufig haben sie seltsame Rituale und clanartige Strukturen von großer Starrheit entwickelt.',
     'Volk der 13 Inseln': 'Das Volk der 13 Inseln lebt in Schweden, Dänemark und Finnland. Es besteht vor allem aus Jägern, Bauern und Fischern. Frauen dieser Kultur besitzen die Gabe des Lauschens.'
 };
 
@@ -21,6 +23,7 @@ const TECHNO_SKILL_POOL_POINTS = 12;
 const BUNKERMENSCH_BONUS_SKILLS = ['Feuerwaffen', 'Pilot', 'Wissenschaftler'];
 const NOMADE_COMBAT_SKILLS = ['Nahkampf', 'Fernkampf'];
 const NOMADE_MOVEMENT_SKILLS = ['Reiten', 'Athletik'];
+const RUINENBEWOHNER_BONUS_SKILLS = ['Nahkampf', 'Fernkampf', 'Athletik', 'Kunde'];
 const VOLK_DER_13_INSELN_CULTURE = 'Volk der 13 Inseln';
 const VOLK_DER_13_INSELN_PROFESSION_SKILLS = ['Beruf: Bauer', 'Beruf: Fischer'];
 const VOLK_DER_13_INSELN_REQUIRED_ADVANTAGE = 'Psychische Kraft';
@@ -84,6 +87,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     bunkermenschBonusSkill: null,
     nomadeCombatSkill: null,
     nomadeMovementSkill: null,
+    ruinenbewohnerBonusSkill: null,
     volkDer13InselnProfessionSkill: null,
     technoSkillNames: TECHNO_SKILLS,
     technoSkillPoolPoints: TECHNO_SKILL_POOL_POINTS,
@@ -648,6 +652,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (this.culture === 'Meeresbewohner') this.applyCultureMeeresbewohner();
         if (this.culture === 'Bunkermensch') this.applyCultureBunkermensch();
         if (this.culture === 'Nomade') this.applyCultureNomade();
+        if (this.culture === 'Ruinenbewohner') this.applyCultureRuinenbewohner();
+        if (this.culture === 'Untergrundbewohner') this.applyCultureUntergrundbewohner();
         if (this.culture === VOLK_DER_13_INSELN_CULTURE) this.applyCultureVolkDer13Inseln();
         this.updateDescription();
     },
@@ -680,6 +686,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.bunkermenschBonusSkill = null;
         this.nomadeCombatSkill = null;
         this.nomadeMovementSkill = null;
+        this.ruinenbewohnerBonusSkill = null;
         this.volkDer13InselnProfessionSkill = null;
         this.setCultureLockedAdvantages([]);
         previousCultureSkills.forEach(name => this.refreshGrantedSkill(name));
@@ -713,6 +720,18 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.setFreeMin('\u00dcberleben', 1, 'Kultur');
         this.setNomadeCombatSkill('Nahkampf');
         this.setNomadeMovementSkill('Reiten');
+    },
+
+    applyCultureRuinenbewohner() {
+        this.setFreeMin('Diebeskunst', 1, 'Kultur');
+        this.setFreeMin('Heimlichkeit', 1, 'Kultur');
+        this.setRuinenbewohnerBonusSkill('Nahkampf');
+    },
+
+    applyCultureUntergrundbewohner() {
+        this.setFreeMin('Athletik', 1, 'Kultur');
+        this.setFreeMin('Beruf: Bergmann', 1, 'Kultur');
+        this.setFreeMin('\u00dcberleben', 1, 'Kultur');
     },
 
     applyCultureVolkDer13Inseln() {
@@ -786,6 +805,10 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
 
     setNomadeMovementSkill(skillName) {
         this.setCultureChoiceSkill(skillName, NOMADE_MOVEMENT_SKILLS, 'nomadeMovementSkill');
+    },
+
+    setRuinenbewohnerBonusSkill(skillName) {
+        this.setCultureChoiceSkill(skillName, RUINENBEWOHNER_BONUS_SKILLS, 'ruinenbewohnerBonusSkill');
     },
 
     setVolkDer13InselnProfessionSkill(skillName) {

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -97,6 +97,8 @@
                             <option value="Meeresbewohner" :disabled="!isCultureSelectable('Meeresbewohner')">Meeresbewohner</option>
                             <option value="Bunkermensch" :disabled="!isCultureSelectable('Bunkermensch')">Bunkermensch</option>
                             <option value="Nomade" :disabled="!isCultureSelectable('Nomade')">Nomade</option>
+                            <option value="Ruinenbewohner" :disabled="!isCultureSelectable('Ruinenbewohner')">Ruinenbewohner</option>
+                            <option value="Untergrundbewohner" :disabled="!isCultureSelectable('Untergrundbewohner')">Untergrundbewohner</option>
                             <option value="Volk der 13 Inseln" :disabled="!isCultureSelectable('Volk der 13 Inseln')">Volk der 13 Inseln</option>
                         </select>
                     </div>
@@ -202,6 +204,15 @@
                                 </select>
                             </div>
                         </div>
+                        <div x-show="culture === 'Ruinenbewohner'" class="mb-2">
+                            <label for="ruinenbewohner-bonus-select" class="text-sm font-medium text-base-content mb-1">Ruinenbewohner Zusatzbonus</label>
+                            <select id="ruinenbewohner-bonus-select" class="select select-bordered w-full sm:w-auto" x-model="ruinenbewohnerBonusSkill" @change="setRuinenbewohnerBonusSkill(ruinenbewohnerBonusSkill)">
+                                <option value="Nahkampf">Nahkampf (+1)</option>
+                                <option value="Fernkampf">Fernkampf (+1)</option>
+                                <option value="Athletik">Athletik (+1)</option>
+                                <option value="Kunde">Kunde (+1)</option>
+                            </select>
+                        </div>
                         <div x-show="culture === 'Volk der 13 Inseln'" class="mb-2">
                             <label for="volk-13-profession-select" class="text-sm font-medium text-base-content mb-1">Volk der 13 Inseln Beruf-Bonus</label>
                             <select id="volk-13-profession-select" class="select select-bordered w-full sm:w-auto" x-model="volkDer13InselnProfessionSkill" @change="setVolkDer13InselnProfessionSkill(volkDer13InselnProfessionSkill)">
@@ -253,6 +264,7 @@
                             <option value="Athletik"></option>
                             <option value="Beruf"></option>
                             <option value="Beruf: Bauer"></option>
+                            <option value="Beruf: Bergmann"></option>
                             <option value="Beruf: Fischer"></option>
                             <option value="Beruf: Farmer"></option>
                             <option value="Beruf: Künstler"></option>

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -452,7 +452,7 @@ class RpgCharEditorPdfTest extends TestCase
             'skills' => [
                 ['name' => 'Nahkampf', 'value' => 1],
                 ['name' => 'Reiten', 'value' => 1],
-                ['name' => 'Ueberleben', 'value' => 1],
+                ['name' => 'Überleben', 'value' => 1],
             ],
         ]));
 
@@ -509,7 +509,7 @@ class RpgCharEditorPdfTest extends TestCase
                     && $data['character']['culture'] === 'Untergrundbewohner'
                     && $skills->has('Athletik')
                     && $skills->has('Beruf: Bergmann')
-                    && $skills->has('Ueberleben');
+                    && $skills->has('Überleben');
             }))
             ->andReturn(new class extends PdfBuilder
             {
@@ -525,7 +525,7 @@ class RpgCharEditorPdfTest extends TestCase
                 ['name' => 'Nahkampf', 'value' => 1],
                 ['name' => 'Athletik', 'value' => 1],
                 ['name' => 'Beruf: Bergmann', 'value' => 1],
-                ['name' => 'Ueberleben', 'value' => 1],
+                ['name' => 'Überleben', 'value' => 1],
             ],
         ]));
 

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -459,6 +459,79 @@ class RpgCharEditorPdfTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_pdf_export_accepts_ruinenbewohner_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(function ($data) {
+                $skills = collect($data['skills'])->keyBy('name');
+
+                return $data['character']['race'] === 'Barbar'
+                    && $data['character']['culture'] === 'Ruinenbewohner'
+                    && $skills->has('Diebeskunst')
+                    && $skills->has('Heimlichkeit')
+                    && $skills->has('Fernkampf')
+                    && ! $skills->has('Fernwaffen');
+            }))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'culture' => 'Ruinenbewohner',
+            'skills' => [
+                ['name' => 'Nahkampf', 'value' => 1],
+                ['name' => 'Diebeskunst', 'value' => 1],
+                ['name' => 'Heimlichkeit', 'value' => 1],
+                ['name' => 'Fernkampf', 'value' => 1],
+            ],
+        ]));
+
+        $response->assertOk();
+    }
+
+    public function test_pdf_export_accepts_untergrundbewohner_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(function ($data) {
+                $skills = collect($data['skills'])->keyBy('name');
+
+                return $data['character']['race'] === 'Barbar'
+                    && $data['character']['culture'] === 'Untergrundbewohner'
+                    && $skills->has('Athletik')
+                    && $skills->has('Beruf: Bergmann')
+                    && $skills->has('Ueberleben');
+            }))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'culture' => 'Untergrundbewohner',
+            'skills' => [
+                ['name' => 'Nahkampf', 'value' => 1],
+                ['name' => 'Athletik', 'value' => 1],
+                ['name' => 'Beruf: Bergmann', 'value' => 1],
+                ['name' => 'Ueberleben', 'value' => 1],
+            ],
+        ]));
+
+        $response->assertOk();
+    }
+
     public function test_pdf_export_accepts_volk_der_13_inseln_for_barbar_with_required_advantage(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -382,6 +382,8 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.isCultureSelectable('Stadtbewohner')).toBe(true);
         expect(e.isCultureSelectable('Meeresbewohner')).toBe(true);
         expect(e.isCultureSelectable('Nomade')).toBe(true);
+        expect(e.isCultureSelectable('Ruinenbewohner')).toBe(true);
+        expect(e.isCultureSelectable('Untergrundbewohner')).toBe(true);
         expect(e.isCultureSelectable('Volk der 13 Inseln')).toBe(true);
 
         const barbar = createEditor({ race: 'Barbar', culture: '' });
@@ -452,6 +454,8 @@ describe('charEditor – Kultur-Logik', () => {
         expect(barbar.isCultureSelectable('Stadtbewohner')).toBe(true);
         expect(barbar.isCultureSelectable('Meeresbewohner')).toBe(true);
         expect(barbar.isCultureSelectable('Nomade')).toBe(true);
+        expect(barbar.isCultureSelectable('Ruinenbewohner')).toBe(true);
+        expect(barbar.isCultureSelectable('Untergrundbewohner')).toBe(true);
         expect(barbar.isCultureSelectable('Volk der 13 Inseln')).toBe(true);
         expect(barbar.isCultureSelectable('Bunkermensch')).toBe(true);
 
@@ -462,6 +466,8 @@ describe('charEditor – Kultur-Logik', () => {
         expect(bunker.isRaceSelectable('Hydrit')).toBe(false);
         expect(bunker.isRaceSelectable('Techno')).toBe(true);
         expect(bunker.isCultureSelectable('Landbewohner')).toBe(true);
+        expect(bunker.isCultureSelectable('Ruinenbewohner')).toBe(true);
+        expect(bunker.isCultureSelectable('Untergrundbewohner')).toBe(true);
         expect(bunker.isCultureSelectable('Volk der 13 Inseln')).toBe(false);
 
         const manualTechno = createEditor({ race: 'Techno', culture: 'Bunkermensch' });
@@ -751,6 +757,57 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.skills.find(s => s.name === 'Nahkampf')).toMatchObject({ value: 1, badge: 'Rasse' });
     });
 
+    it('Ruinenbewohner setzt Diebeskunst, Heimlichkeit und den Standard-Wahlbonus', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Ruinenbewohner' });
+        e.applyRaceBarbar();
+        e.applyCultureRuinenbewohner();
+
+        expect(e.cultureGrants.Diebeskunst).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Heimlichkeit).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.ruinenbewohnerBonusSkill).toBe('Nahkampf');
+        expect(e.skills.find(s => s.name === 'Nahkampf')).toMatchObject({ value: 1, badge: 'Rasse/Kultur' });
+        expect(e.skills.find(s => s.name === 'Fernwaffen')).toBeUndefined();
+    });
+
+    it('Ruinenbewohner-Wahlbonus ersetzt alte Optionen ohne Rassen-Grants zu entfernen', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Ruinenbewohner' });
+        e.applyRaceBarbar();
+        e.applyCultureRuinenbewohner();
+
+        e.setRuinenbewohnerBonusSkill('Fernkampf');
+
+        expect(e.cultureGrants.Nahkampf).toBeUndefined();
+        expect(e.raceGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.skills.find(s => s.name === 'Nahkampf')).toMatchObject({ value: 1, badge: 'Rasse' });
+        expect(e.cultureGrants.Fernkampf).toEqual({ type: 'min', value: 1 });
+
+        e.setRuinenbewohnerBonusSkill('Athletik');
+
+        expect(e.cultureGrants.Fernkampf).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Fernkampf')).toBeUndefined();
+        expect(e.cultureGrants.Athletik).toEqual({ type: 'min', value: 1 });
+
+        e.setRuinenbewohnerBonusSkill('Kunde');
+
+        expect(e.cultureGrants.Athletik).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Athletik')).toBeUndefined();
+        expect(e.cultureGrants.Kunde).toEqual({ type: 'min', value: 1 });
+        expect(e.ruinenbewohnerBonusSkill).toBe('Kunde');
+    });
+
+    it('Untergrundbewohner setzt Athletik, Bergmann und Ueberleben', () => {
+        const e = createEditor({ race: 'Barbar', culture: 'Untergrundbewohner' });
+        e.applyRaceBarbar();
+        e.applyCultureUntergrundbewohner();
+
+        expect(e.cultureGrants.Athletik).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants['Beruf: Bergmann']).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants['\u00dcberleben']).toEqual({ type: 'min', value: 1 });
+        expect(e.skills.find(s => s.name === '\u00dcberleben')).toMatchObject({ value: 1, badge: 'Rasse/Kultur' });
+        expect(e.skills.find(s => s.name === 'Beruf: Bergmann')).toMatchObject({ value: 1, badge: 'Kultur' });
+    });
+
     it('Volk der 13 Inseln ist nur fuer Barbaren auswaehlbar', () => {
         const barbar = createEditor({ race: 'Barbar' });
         const guul = createEditor({ race: 'Guul' });
@@ -758,6 +815,8 @@ describe('charEditor – Kultur-Logik', () => {
         expect(barbar.isCultureSelectable('Volk der 13 Inseln')).toBe(true);
         expect(guul.isCultureSelectable('Volk der 13 Inseln')).toBe(false);
         expect(guul.isCultureSelectable('Nomade')).toBe(true);
+        expect(guul.isCultureSelectable('Ruinenbewohner')).toBe(true);
+        expect(guul.isCultureSelectable('Untergrundbewohner')).toBe(true);
 
         const invalid = createEditor({ race: 'Guul', culture: 'Volk der 13 Inseln', gender: 'weiblich' });
         invalid.applyCultureVolkDer13Inseln();

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -236,6 +236,8 @@ test.describe('RPG Charakter-Editor', () => {
             Stadtbewohner: true,
             Meeresbewohner: false,
             Nomade: true,
+            Ruinenbewohner: true,
+            Untergrundbewohner: true,
             'Volk der 13 Inseln': true,
         });
 
@@ -417,6 +419,86 @@ test.describe('RPG Charakter-Editor', () => {
         ]));
     });
 
+    test('setzt Ruinenbewohner-Regeln inklusive Fernkampf-Mapping im Formularpayload um', async ({ page }) => {
+        await openAdvancedEditor(page, { race: 'Barbar', culture: 'Ruinenbewohner' });
+
+        await page.locator('#ruinenbewohner-bonus-select').selectOption('Fernkampf');
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+            const skillsByIndex = {};
+
+            for (const [key, value] of data.entries()) {
+                const match = key.match(/^skills\[(\d+)]\[(name|value)]$/);
+
+                if (!match) {
+                    continue;
+                }
+
+                const [, index, field] = match;
+                skillsByIndex[index] ??= {};
+                skillsByIndex[index][field] = value;
+            }
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+                skills: Object.values(skillsByIndex),
+            };
+        });
+
+        expect(payload.race).toBe('Barbar');
+        expect(payload.culture).toBe('Ruinenbewohner');
+        expect(payload.skills).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Nahkampf', value: '1' }),
+            expect.objectContaining({ name: 'Diebeskunst', value: '1' }),
+            expect.objectContaining({ name: 'Heimlichkeit', value: '1' }),
+            expect.objectContaining({ name: 'Fernkampf', value: '1' }),
+        ]));
+        expect(payload.skills).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Fernwaffen' }),
+            expect.objectContaining({ name: 'Athletik' }),
+            expect.objectContaining({ name: 'Kunde' }),
+        ]));
+    });
+
+    test('setzt Untergrundbewohner-Regeln im Formularpayload um', async ({ page }) => {
+        await openAdvancedEditor(page, { race: 'Barbar', culture: 'Untergrundbewohner' });
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+            const skillsByIndex = {};
+
+            for (const [key, value] of data.entries()) {
+                const match = key.match(/^skills\[(\d+)]\[(name|value)]$/);
+
+                if (!match) {
+                    continue;
+                }
+
+                const [, index, field] = match;
+                skillsByIndex[index] ??= {};
+                skillsByIndex[index][field] = value;
+            }
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+                skills: Object.values(skillsByIndex),
+            };
+        });
+
+        expect(payload.race).toBe('Barbar');
+        expect(payload.culture).toBe('Untergrundbewohner');
+        expect(payload.skills).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Nahkampf', value: '1' }),
+            expect.objectContaining({ name: 'Athletik', value: '1' }),
+            expect.objectContaining({ name: 'Beruf: Bergmann', value: '1' }),
+            expect.objectContaining({ name: '\u00dcberleben', value: '1' }),
+        ]));
+        expect(payload.skills.filter((skill) => skill.name === '\u00dcberleben')).toHaveLength(1);
+    });
+
     test('setzt Techno automatisch wenn Bunkermensch zuerst gewaehlt wird', async ({ page }) => {
         await login(page, 'info@maddraxikon.com');
         await page.goto('/rpg/char-editor');
@@ -452,6 +534,8 @@ test.describe('RPG Charakter-Editor', () => {
             Meeresbewohner: false,
             Bunkermensch: false,
             Nomade: false,
+            Ruinenbewohner: false,
+            Untergrundbewohner: false,
             'Volk der 13 Inseln': true,
         });
 
@@ -515,6 +599,8 @@ test.describe('RPG Charakter-Editor', () => {
             Meeresbewohner: true,
             Bunkermensch: false,
             Nomade: true,
+            Ruinenbewohner: true,
+            Untergrundbewohner: true,
             'Volk der 13 Inseln': true,
         });
 


### PR DESCRIPTION
This pull request adds two new cultures, "Ruinenbewohner" and "Untergrundbewohner", to the RPG character editor. It includes full support for these cultures in the frontend, backend, and automated tests. The changes ensure that users can select these cultures, apply their unique skill rules, and export character sheets with the correct data.

Key changes include:

**Frontend: Culture Selection & UI**
- Added "Ruinenbewohner" and "Untergrundbewohner" as selectable options in the character editor dropdown and provided their descriptions. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R14-R15) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R100-R101)
- Implemented a new bonus skill selection UI for "Ruinenbewohner" and ensured the correct skills are available for selection. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R26) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R207-R215)

**Skill Logic & Application**
- Defined and applied unique skill grants for both new cultures:
  - "Ruinenbewohner" grants minimum levels in "Diebeskunst" and "Heimlichkeit" and allows a choice among several bonus skills.
  - "Untergrundbewohner" grants minimum levels in "Athletik", "Beruf: Bergmann", and "Überleben". [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R725-R736) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R810-R813)
- Updated the logic to reset and apply these culture-specific skill grants when changing cultures. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R655-R656) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R689)
- Added "Beruf: Bergmann" to the available skill list for character creation.

**Testing**
- Added comprehensive unit tests and end-to-end tests to verify that both new cultures are selectable, apply the correct skill logic, and are handled correctly in form submissions and PDF exports. [[1]](diffhunk://#diff-fb18f83cf98be37a88d19828a9e35f53c1e003d762ea98aab19f3e4e301b364bR385-R386) [[2]](diffhunk://#diff-fb18f83cf98be37a88d19828a9e35f53c1e003d762ea98aab19f3e4e301b364bR457-R458) [[3]](diffhunk://#diff-fb18f83cf98be37a88d19828a9e35f53c1e003d762ea98aab19f3e4e301b364bR469-R470) [[4]](diffhunk://#diff-fb18f83cf98be37a88d19828a9e35f53c1e003d762ea98aab19f3e4e301b364bR760-R819) [[5]](diffhunk://#diff-48d2a15af217532067f591c00c0e82f39584112f276cd4b2ff9c4e0ad80910c6R239-R240) [[6]](diffhunk://#diff-48d2a15af217532067f591c00c0e82f39584112f276cd4b2ff9c4e0ad80910c6R422-R501) [[7]](diffhunk://#diff-48d2a15af217532067f591c00c0e82f39584112f276cd4b2ff9c4e0ad80910c6R537-R538) [[8]](diffhunk://#diff-7ea08d80eacd6f929c14ae7b12371e82f955d0d4dbf539fbf7b2763ca2621692R462-R534)

These changes ensure a consistent and bug-free experience for users selecting and using the new cultures in the character editor.