### PR TITLE
Feature: Präkristofluu race and Mensch-21 culture

### DIFF
--- a/app/Http/Controllers/RpgCharEditorController.php
+++ b/app/Http/Controllers/RpgCharEditorController.php
@@ -226,9 +226,21 @@ class RpgCharEditorController extends Controller
             ]);
         }
 
+        if ($race === 'Präkristofluu' && $culture !== 'Mensch des 21. Jahrhunderts') {
+            throw ValidationException::withMessages([
+                'culture' => 'Präkristofluu können laut Regelwerk nur die Kultur Mensch des 21. Jahrhunderts wählen.',
+            ]);
+        }
+
         if ($culture === 'Bunkermensch' && $race !== 'Techno') {
             throw ValidationException::withMessages([
                 'culture' => 'Die Kultur Bunkermensch ist laut Regelwerk nur für Technos zugelassen.',
+            ]);
+        }
+
+        if ($culture === 'Mensch des 21. Jahrhunderts' && $race !== 'Präkristofluu') {
+            throw ValidationException::withMessages([
+                'culture' => 'Die Kultur Mensch des 21. Jahrhunderts ist laut Regelwerk nur für Präkristofluu zugelassen.',
             ]);
         }
 

--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -2,7 +2,8 @@ const RACE_DESCRIPTIONS = {
     Barbar: 'Im 26. Jahrhundert besteht die Zivilisation zum größten Teil aus Barbaren. Sie leben in unterschiedlichen Kulturen, beispielsweise als Seefahrer (die Disuuslachter), Nomaden (die Wandernden Völker) oder Ruinenbewohner (die Loords von Landán). Die zeichnen sich durch Zähigkeit, Wildheit und Kampflust aus, sind zumeist primitiv und leben in Clans. Ehre und Mut werden hoch geschätzt. Technologisch bewegen sich die meisten Barbaren zwischen der späten Steinzeit und dem frühen Mittelalter.',
     Guul: 'Guule sind bedauernswerte Mutationen des Homo Sapiens. Sie sind dürr, fast zwei Meter groß und völlig unbehaart. Ihre langen knochigen Arme enden in Krallen. Die verhornten Füße laufen an den Fersen in einem fingerdicken Stachel aus. Aus dem Maul tropft weißlicher Schleim, was ihr abstoßendes Äußeres zusätzlich verstärkt. Guule sind meist nur mit einem Lendenschurz bekleidet. Sie ernähren sich von Aas und Gebeinen, die sie u.a. aus Gräbern holen.',
     Hydrit: 'Hydriten, von den Menschen oft Fischmenschen genannt, sind ein friedliebendes und altes Volk. Sie leben in geheimen Unterseestädten, sind amphibisch, kultiviert und verfügen über fortgeschrittene biogenetische Technologien. Der Genuss von Fleisch verwandelt Hydriten in gefährliche Bestien, weshalb sie sich meist vegetarisch ernähren.',
-    Techno: 'Technos sind Nachfahren der Menschen, die den Kometeneinschlag in Bunkern überlebt und eine neue Zivilisation aufgebaut haben. Aufgrund ihres technologischen Fortschritts gelten sie vielen Barbaren als Götter oder Dämonen. Sie leiden jedoch an einer tödlichen Immunschwäche und können die Außenwelt nur mit Schutzanzug betreten.'
+    Techno: 'Technos sind Nachfahren der Menschen, die den Kometeneinschlag in Bunkern überlebt und eine neue Zivilisation aufgebaut haben. Aufgrund ihres technologischen Fortschritts gelten sie vielen Barbaren als Götter oder Dämonen. Sie leiden jedoch an einer tödlichen Immunschwäche und können die Außenwelt nur mit Schutzanzug betreten.',
+    Präkristofluu: 'Präkristofluu sind Menschen aus dem 21. Jahrhundert, die durch Gefrierkammern oder mysteriöse Zeitphänomene in das 26. Jahrhundert gelangt sind. Ihr technisches Wissen und ihre Kenntnisse der Vergangenheit gleichen ihre geringe Anpassungsfähigkeit aus.'
 };
 
 const CULTURE_DESCRIPTIONS = {
@@ -10,6 +11,7 @@ const CULTURE_DESCRIPTIONS = {
     Stadtbewohner: 'Stadtbewohner versuchen in der dunklen Zukunft der Erde neues Leben erblühen zu lassen. Dazu haben sie sich in neu erbauten Siedlungen (zuweilen auf Ruinen aus der Zeit vor dem Kometen) angesiedelt und leben als Händler, Handwerker und Bauern. Die Mauern ihrer Siedlungen schützen sie vor den Gefahren der Wildnis. Ihre Siedlungen sind somit Lichter der Hoffnung in der Dunkelheit.',
     Meeresbewohner: 'Meeresbewohner sind Hydriten aus großen, seit langem verborgenen Unterseestädten. Ihre Gesellschaft ist streng hierarchisch organisiert, technisch und biotechnologisch weit fortgeschritten und meidet den Kontakt zu Oberflächenbewohnern.',
     Bunkermensch: 'Bunkermenschen sind Nachfahren jener Menschen, die die Katastrophe in Bunkern überlebten. Sie verfügen über Technik der alten Welt, leiden aber durch Isolation an einer fatalen Immunschwäche und begegnen der Oberfläche meist nur in Schutzanzügen.',
+    'Mensch des 21. Jahrhunderts': 'Diese Kultur muss von allen Präkristofluu ausgewählt werden. Menschen des 21. Jahrhunderts sind auf verworrenen Pfaden in das 26. Jahrhundert gelangt; ihre Bandbreite ist nahezu unerschöpflich.',
     Nomade: 'Nomaden folgen den Routen ihrer Nutztiere durch die Jahreszeiten. Sie sind wehrhaft, überleben in unwirtlicher Natur und werden von sesshaften Völkern oft misstrauisch betrachtet.',
     Ruinenbewohner: 'Ruinenbewohner leben in den Resten der Städte aus der Zeit vor Kristoflus als Banditen, Jäger und Sammler. Ihre Gesellschaften sind primitiv und von Brutalität und Not geprägt.',
     Untergrundbewohner: 'Untergrundbewohner leben in Höhlen und alten Stollen, um sich vor den Gefahren der Oberfläche zu schützen. Sie arbeiten überwiegend als Bergleute, Jäger und Sammler. Häufig haben sie seltsame Rituale und clanartige Strukturen von großer Starrheit entwickelt.',
@@ -18,9 +20,14 @@ const CULTURE_DESCRIPTIONS = {
 
 const CULTURE_NAMES = Object.keys(CULTURE_DESCRIPTIONS);
 const ATTRIBUTE_IDS = ['st', 'ge', 'ro', 'wi', 'wa', 'in', 'au'];
+const PRAEKRISTOFLUU_RACE = 'Präkristofluu';
+const MENSCH_21_CULTURE = 'Mensch des 21. Jahrhunderts';
 const TECHNO_SKILLS = ['Fahren', 'Feuerwaffen', 'Heiler', 'Pilot', 'Techniker', 'Wissenschaftler'];
 const TECHNO_SKILL_POOL_POINTS = 12;
 const BUNKERMENSCH_BONUS_SKILLS = ['Feuerwaffen', 'Pilot', 'Wissenschaftler'];
+const PRAEKRISTOFLUU_SKILLS = ['Bildung', 'Fahren', 'Feuerwaffen', 'Pilot', 'Techniker', 'Wissenschaftler'];
+const PRAEKRISTOFLUU_SKILL_POOL_POINTS = 12;
+const MENSCH_21_BONUS_SKILLS = ['Bildung', 'Pilot', 'Techniker', 'Wissenschaftler'];
 const NOMADE_COMBAT_SKILLS = ['Nahkampf', 'Fernkampf'];
 const NOMADE_MOVEMENT_SKILLS = ['Reiten', 'Athletik'];
 const RUINENBEWOHNER_BONUS_SKILLS = ['Nahkampf', 'Fernkampf', 'Athletik', 'Kunde'];
@@ -85,6 +92,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     seaProfessionSkill: null,
     seaKnowledgeOrCombatSkill: null,
     bunkermenschBonusSkill: null,
+    mensch21FirstBonusSkill: null,
+    mensch21SecondBonusSkill: null,
     nomadeCombatSkill: null,
     nomadeMovementSkill: null,
     ruinenbewohnerBonusSkill: null,
@@ -92,6 +101,9 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     technoSkillNames: TECHNO_SKILLS,
     technoSkillPoolPoints: TECHNO_SKILL_POOL_POINTS,
     technoSkillPoints: Object.fromEntries(TECHNO_SKILLS.map(name => [name, 2])),
+    praekristofluuSkillNames: PRAEKRISTOFLUU_SKILLS,
+    praekristofluuSkillPoolPoints: PRAEKRISTOFLUU_SKILL_POOL_POINTS,
+    praekristofluuSkillPoints: Object.fromEntries(PRAEKRISTOFLUU_SKILLS.map(name => [name, 2])),
     raceCache: {},
     raceAttributeModifiers: {},
     raceLockedByBunkermenschCulture: false,
@@ -176,6 +188,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         return this.apRemaining() === 0
             && this.fpRemaining() === 0
             && this.technoSkillPoolComplete()
+            && this.praekristofluuSkillPoolComplete()
             && this.selectedDisadvantages.length >= this.chosenAdvantagesCount();
     },
 
@@ -214,13 +227,17 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
     allowedCulturesForRace(race = this.race) {
         if (race === 'Hydrit') return ['Meeresbewohner'];
         if (race === 'Techno') return ['Bunkermensch'];
+        if (race === PRAEKRISTOFLUU_RACE) return [MENSCH_21_CULTURE];
 
         return CULTURE_NAMES.filter(culture => culture !== 'Bunkermensch'
+            && culture !== MENSCH_21_CULTURE
             && (race === 'Barbar' || culture !== VOLK_DER_13_INSELN_CULTURE));
     },
 
     isCultureSelectable(culture) {
-        if (culture === 'Bunkermensch') return true;
+        if (culture === 'Bunkermensch') {
+            return this.race !== 'Hydrit' && this.race !== PRAEKRISTOFLUU_RACE;
+        }
 
         if (this.race === 'Techno' && this.raceLockedByBunkermenschCulture) {
             return this.allowedCulturesForRace('').includes(culture);
@@ -483,6 +500,50 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.refreshBunkermenschBonusGrant();
     },
 
+    resetPraekristofluuSkillPoints(defaultValue = 0) {
+        this.praekristofluuSkillPoints = Object.fromEntries(PRAEKRISTOFLUU_SKILLS.map(name => [name, defaultValue]));
+    },
+
+    praekristofluuPoolUsed() {
+        return PRAEKRISTOFLUU_SKILLS.reduce((sum, name) => sum + (Number(this.praekristofluuSkillPoints[name]) || 0), 0);
+    },
+
+    praekristofluuSkillPoolComplete() {
+        return this.race !== PRAEKRISTOFLUU_RACE || this.praekristofluuPoolUsed() === this.praekristofluuSkillPoolPoints;
+    },
+
+    setPraekristofluuSkillPoints(skillName, value) {
+        if (!PRAEKRISTOFLUU_SKILLS.includes(skillName)) return;
+
+        const parsedValue = Number.parseInt(value, 10);
+        const normalizedValue = Number.isFinite(parsedValue)
+            ? Math.max(0, Math.min(parsedValue, this.base.maxFW))
+            : 0;
+
+        this.praekristofluuSkillPoints[skillName] = normalizedValue;
+        this.applyPraekristofluuSkillGrant(skillName);
+        this.refreshAllMensch21BonusGrants();
+    },
+
+    applyPraekristofluuSkillGrant(skillName) {
+        const value = this.race === PRAEKRISTOFLUU_RACE ? (Number(this.praekristofluuSkillPoints[skillName]) || 0) : 0;
+
+        if (value > 0) {
+            this.raceGrants[skillName] = { type: 'min', value };
+            const skill = this.ensureSkill(skillName);
+            this.applyGrantToSkill(skill);
+            return;
+        }
+
+        delete this.raceGrants[skillName];
+        this.refreshGrantedSkill(skillName);
+    },
+
+    refreshAllPraekristofluuSkillGrants() {
+        PRAEKRISTOFLUU_SKILLS.forEach(name => this.applyPraekristofluuSkillGrant(name));
+        this.refreshAllMensch21BonusGrants();
+    },
+
     setRaceAttributeModifiers(modifiers) {
         this.raceAttributeModifiers = { ...modifiers };
 
@@ -529,6 +590,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (this.race === 'Guul') this.applyRaceGuul();
         if (this.race === 'Hydrit') this.applyRaceHydrit();
         if (this.race === 'Techno') this.applyRaceTechno();
+        if (this.race === PRAEKRISTOFLUU_RACE) this.applyRacePraekristofluu();
         this.restoreRaceState(this.race);
         this.enforceCultureForRace();
         this._prevRace = this.race;
@@ -542,6 +604,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
             skills: this.skills.filter(s => this.raceGrants[s.name]).map(s => ({ name: s.name, value: s.value })),
             barbarCombatSkill: this.barbarCombatSkill,
             technoSkillPoints: { ...this.technoSkillPoints },
+            praekristofluuSkillPoints: { ...this.praekristofluuSkillPoints },
         };
     },
 
@@ -564,6 +627,10 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
             this.technoSkillPoints = { ...this.technoSkillPoints, ...cache.technoSkillPoints };
             this.refreshAllTechnoSkillGrants();
         }
+        if (raceName === PRAEKRISTOFLUU_RACE && cache.praekristofluuSkillPoints) {
+            this.praekristofluuSkillPoints = { ...this.praekristofluuSkillPoints, ...cache.praekristofluuSkillPoints };
+            this.refreshAllPraekristofluuSkillGrants();
+        }
     },
 
     clearRace() {
@@ -575,6 +642,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.raceGrants = {};
         this.barbarCombatSkill = null;
         this.resetTechnoSkillPoints(0);
+        this.resetPraekristofluuSkillPoints(0);
         this.clearRaceAttributeModifiers();
         previousRaceSkills.forEach(name => this.refreshGrantedSkill(name));
         this.selectedAdvantages = this.selectedAdvantages.filter(value => value === 'Zäh' || !previousLockedAdvantages.includes(value));
@@ -619,6 +687,14 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.selectedDisadvantages = [...new Set([...this.selectedDisadvantages, 'Tödliche Immunschwäche'])];
     },
 
+    applyRacePraekristofluu() {
+        this.setFreeMin('Beruf', 3, 'Rasse');
+        this.resetPraekristofluuSkillPoints(2);
+        this.refreshAllPraekristofluuSkillGrants();
+        this.raceLocked.advantages = ['High-Tech-Ausrüstung'];
+        this.selectedAdvantages = [...new Set([...this.selectedAdvantages, 'High-Tech-Ausrüstung'])];
+    },
+
     setBarbarCombatSkill(skillName) {
         ['Nahkampf', 'Fernkampf']
             .filter(name => name !== skillName && this.raceGrants[name])
@@ -651,6 +727,7 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (this.culture === 'Stadtbewohner') this.applyCultureStadtbewohner();
         if (this.culture === 'Meeresbewohner') this.applyCultureMeeresbewohner();
         if (this.culture === 'Bunkermensch') this.applyCultureBunkermensch();
+        if (this.culture === MENSCH_21_CULTURE) this.applyCultureMensch21();
         if (this.culture === 'Nomade') this.applyCultureNomade();
         if (this.culture === 'Ruinenbewohner') this.applyCultureRuinenbewohner();
         if (this.culture === 'Untergrundbewohner') this.applyCultureUntergrundbewohner();
@@ -684,6 +761,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.seaProfessionSkill = null;
         this.seaKnowledgeOrCombatSkill = null;
         this.bunkermenschBonusSkill = null;
+        this.mensch21FirstBonusSkill = null;
+        this.mensch21SecondBonusSkill = null;
         this.nomadeCombatSkill = null;
         this.nomadeMovementSkill = null;
         this.ruinenbewohnerBonusSkill = null;
@@ -714,6 +793,11 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.setFreeMin('Bildung', 1, 'Kultur');
         this.setFreeMin('Nahkampf', 1, 'Kultur');
         this.setBunkermenschBonusSkill('Feuerwaffen');
+    },
+
+    applyCultureMensch21() {
+        this.setFreeMin('Beruf', 1, 'Kultur');
+        this.setMensch21BonusSkills('Bildung', 'Pilot');
     },
 
     applyCultureNomade() {
@@ -841,6 +925,63 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         const value = Math.min(this.base.maxFW, raceValue + 1);
         this.cultureGrants[this.bunkermenschBonusSkill] = { type: 'min', value };
         const skill = this.ensureSkill(this.bunkermenschBonusSkill);
+        this.applyGrantToSkill(skill);
+    },
+
+    setMensch21FirstBonusSkill(skillName) {
+        this.setMensch21BonusSkills(skillName, this.mensch21SecondBonusSkill);
+    },
+
+    setMensch21SecondBonusSkill(skillName) {
+        this.setMensch21BonusSkills(this.mensch21FirstBonusSkill, skillName);
+    },
+
+    setMensch21BonusSkills(firstSkill, secondSkill) {
+        const first = MENSCH_21_BONUS_SKILLS.includes(firstSkill)
+            ? firstSkill
+            : MENSCH_21_BONUS_SKILLS[0];
+        let second = MENSCH_21_BONUS_SKILLS.includes(secondSkill)
+            ? secondSkill
+            : MENSCH_21_BONUS_SKILLS.find(name => name !== first);
+
+        if (second === first) {
+            second = MENSCH_21_BONUS_SKILLS.find(name => name !== first);
+        }
+
+        const nextSkills = new Set([first, second].filter(Boolean));
+        MENSCH_21_BONUS_SKILLS
+            .filter(name => !nextSkills.has(name) && this.cultureGrants[name])
+            .forEach(name => {
+                delete this.cultureGrants[name];
+                const grant = this.getGrant(name);
+                const skill = this.skills.find(s => s.name === name);
+                if (skill && grant && skill.value > grant.value) {
+                    skill.value = grant.value;
+                }
+                this.refreshGrantedSkill(name);
+            });
+
+        this.mensch21FirstBonusSkill = first;
+        this.mensch21SecondBonusSkill = second;
+        this.refreshAllMensch21BonusGrants();
+    },
+
+    refreshAllMensch21BonusGrants() {
+        if (this.culture !== MENSCH_21_CULTURE) return;
+
+        [...new Set([this.mensch21FirstBonusSkill, this.mensch21SecondBonusSkill].filter(Boolean))]
+            .forEach(name => this.refreshMensch21BonusGrant(name));
+    },
+
+    refreshMensch21BonusGrant(skillName) {
+        if (this.culture !== MENSCH_21_CULTURE || !MENSCH_21_BONUS_SKILLS.includes(skillName)) return;
+
+        const raceValue = this.race === PRAEKRISTOFLUU_RACE
+            ? (Number(this.praekristofluuSkillPoints[skillName]) || 0)
+            : 0;
+        const value = Math.min(this.base.maxFW, raceValue + 1);
+        this.cultureGrants[skillName] = { type: 'min', value };
+        const skill = this.ensureSkill(skillName);
         this.applyGrantToSkill(skill);
     },
 

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -85,6 +85,7 @@
                             <option value="Guul" :disabled="!isRaceSelectable('Guul')">Guul</option>
                             <option value="Hydrit" :disabled="!isRaceSelectable('Hydrit')">Hydrit</option>
                             <option value="Techno" :disabled="!isRaceSelectable('Techno')">Techno</option>
+                            <option value="Präkristofluu" :disabled="!isRaceSelectable('Präkristofluu')">Präkristofluu</option>
                         </select>
                     </div>
 
@@ -96,6 +97,7 @@
                             <option value="Stadtbewohner" :disabled="!isCultureSelectable('Stadtbewohner')">Stadtbewohner</option>
                             <option value="Meeresbewohner" :disabled="!isCultureSelectable('Meeresbewohner')">Meeresbewohner</option>
                             <option value="Bunkermensch" :disabled="!isCultureSelectable('Bunkermensch')">Bunkermensch</option>
+                            <option value="Mensch des 21. Jahrhunderts" :disabled="!isCultureSelectable('Mensch des 21. Jahrhunderts')">Mensch des 21. Jahrhunderts</option>
                             <option value="Nomade" :disabled="!isCultureSelectable('Nomade')">Nomade</option>
                             <option value="Ruinenbewohner" :disabled="!isCultureSelectable('Ruinenbewohner')">Ruinenbewohner</option>
                             <option value="Untergrundbewohner" :disabled="!isCultureSelectable('Untergrundbewohner')">Untergrundbewohner</option>
@@ -156,6 +158,20 @@
                                 </template>
                             </div>
                         </div>
+                        <div x-show="race === 'Präkristofluu'" class="mb-3 rounded-md border border-base-300 bg-base-200/40 p-3">
+                            <div class="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+                                <h3 class="text-sm font-medium text-base-content">Präkristofluu-Rassenpunkte</h3>
+                                <p class="text-xs text-base-content/70" aria-live="polite" x-text="'Verteilt: ' + praekristofluuPoolUsed() + ' / ' + praekristofluuSkillPoolPoints"></p>
+                            </div>
+                            <div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                                <template x-for="skillName in praekristofluuSkillNames" :key="'praekristofluu-skill-' + skillName">
+                                    <label class="flex min-h-12 items-center justify-between gap-3 rounded-md border border-base-300 bg-base-100 px-3 py-2 text-sm">
+                                        <span class="min-w-0 flex-1" x-text="skillName"></span>
+                                        <input type="number" min="0" x-bind:max="base.maxFW" step="1" class="input input-bordered input-sm w-20" x-model.number="praekristofluuSkillPoints[skillName]" @input="setPraekristofluuSkillPoints(skillName, praekristofluuSkillPoints[skillName])" @change="setPraekristofluuSkillPoints(skillName, praekristofluuSkillPoints[skillName])" data-testid="praekristofluu-skill-points-input">
+                                    </label>
+                                </template>
+                            </div>
+                        </div>
                         <div x-show="culture === 'Stadtbewohner'" class="mb-2">
                             <label for="city-skill-select" class="text-sm font-medium text-base-content mb-1">Stadtbewohner Bonus</label>
                             <select id="city-skill-select" class="select select-bordered w-full sm:w-auto" x-model="citySkill" @change="setCitySkill(citySkill)">
@@ -187,6 +203,26 @@
                                 <option value="Pilot">Pilot (+1)</option>
                                 <option value="Wissenschaftler">Wissenschaftler (+1)</option>
                             </select>
+                        </div>
+                        <div x-show="culture === 'Mensch des 21. Jahrhunderts'" class="mb-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                            <div>
+                                <label for="mensch-21-first-bonus-select" class="text-sm font-medium text-base-content mb-1">21. Jahrhundert Bonus 1</label>
+                                <select id="mensch-21-first-bonus-select" class="select select-bordered w-full" x-model="mensch21FirstBonusSkill" @change="setMensch21FirstBonusSkill(mensch21FirstBonusSkill)">
+                                    <option value="Bildung" :disabled="mensch21SecondBonusSkill === 'Bildung'">Bildung (+1)</option>
+                                    <option value="Pilot" :disabled="mensch21SecondBonusSkill === 'Pilot'">Pilot (+1)</option>
+                                    <option value="Techniker" :disabled="mensch21SecondBonusSkill === 'Techniker'">Techniker (+1)</option>
+                                    <option value="Wissenschaftler" :disabled="mensch21SecondBonusSkill === 'Wissenschaftler'">Wissenschaftler (+1)</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label for="mensch-21-second-bonus-select" class="text-sm font-medium text-base-content mb-1">21. Jahrhundert Bonus 2</label>
+                                <select id="mensch-21-second-bonus-select" class="select select-bordered w-full" x-model="mensch21SecondBonusSkill" @change="setMensch21SecondBonusSkill(mensch21SecondBonusSkill)">
+                                    <option value="Bildung" :disabled="mensch21FirstBonusSkill === 'Bildung'">Bildung (+1)</option>
+                                    <option value="Pilot" :disabled="mensch21FirstBonusSkill === 'Pilot'">Pilot (+1)</option>
+                                    <option value="Techniker" :disabled="mensch21FirstBonusSkill === 'Techniker'">Techniker (+1)</option>
+                                    <option value="Wissenschaftler" :disabled="mensch21FirstBonusSkill === 'Wissenschaftler'">Wissenschaftler (+1)</option>
+                                </select>
+                            </div>
                         </div>
                         <div x-show="culture === 'Nomade'" class="mb-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
                             <div>

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -431,6 +431,58 @@ class RpgCharEditorPdfTest extends TestCase
         $response->assertSessionHasErrors('culture');
     }
 
+    public function test_pdf_export_accepts_praekristofluu_with_mensch_des_21_jahrhunderts_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(fn ($data) => $data['character']['race'] === 'Präkristofluu'
+                && $data['character']['culture'] === 'Mensch des 21. Jahrhunderts'))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Präkristofluu',
+            'culture' => 'Mensch des 21. Jahrhunderts',
+        ]));
+
+        $response->assertOk();
+    }
+
+    public function test_pdf_export_rejects_praekristofluu_with_other_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Präkristofluu',
+            'culture' => 'Landbewohner',
+        ]));
+
+        $response->assertSessionHasErrors('culture');
+    }
+
+    public function test_pdf_export_rejects_mensch_des_21_jahrhunderts_for_non_praekristofluu(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')->never();
+
+        $response = $this->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Barbar',
+            'culture' => 'Mensch des 21. Jahrhunderts',
+        ]));
+
+        $response->assertSessionHasErrors('culture');
+    }
+
     public function test_pdf_export_accepts_nomade_culture(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -365,6 +365,59 @@ describe('charEditor – Rassen-Logik', () => {
         expect(e.raceGrants.Heiler).toBeUndefined();
         expect(e.skills.find(s => s.name === 'Heiler')).toBeUndefined();
     });
+
+    it('Präkristofluu erhält Beruf, High-Tech-Ausrüstung und 12 Rassen-Fertigkeitspunkte', () => {
+        const e = createEditor({ race: 'Präkristofluu' });
+        e.applyRacePraekristofluu();
+
+        expect(e.apRemaining()).toBe(2);
+        expect(e.praekristofluuPoolUsed()).toBe(12);
+        expect(e.praekristofluuSkillPoolComplete()).toBe(true);
+        expect(e.raceGrants.Beruf).toEqual({ type: 'min', value: 3 });
+        expect(e.raceGrants.Bildung).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Fahren).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Feuerwaffen).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Pilot).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Techniker).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Wissenschaftler).toEqual({ type: 'min', value: 2 });
+        expect(e.raceLocked.advantages).toEqual(['High-Tech-Ausrüstung']);
+        expect(e.raceLocked.disadvantages).toEqual([]);
+        expect(e.selectedAdvantages).toEqual(expect.arrayContaining(['Zäh', 'High-Tech-Ausrüstung']));
+    });
+
+    it('Präkristofluu-Pool begrenzt Einzelwerte und verlangt exakt 12 verteilte Punkte', () => {
+        const e = createEditor({ race: 'Präkristofluu' });
+        e.applyRacePraekristofluu();
+
+        e.setPraekristofluuSkillPoints('Bildung', 9);
+
+        expect(e.praekristofluuSkillPoints.Bildung).toBe(4);
+        expect(e.raceGrants.Bildung).toEqual({ type: 'min', value: 4 });
+        expect(e.praekristofluuPoolUsed()).toBe(14);
+        expect(e.praekristofluuSkillPoolComplete()).toBe(false);
+        expect(e.formValid()).toBe(false);
+
+        e.setPraekristofluuSkillPoints('Feuerwaffen', 0);
+
+        expect(e.praekristofluuPoolUsed()).toBe(12);
+        expect(e.praekristofluuSkillPoolComplete()).toBe(true);
+        expect(e.raceGrants.Feuerwaffen).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Feuerwaffen')).toBeUndefined();
+    });
+
+    it('Rassenwechsel entfernt Präkristofluu-Pflichtvorteil und Pool-Grants', () => {
+        const e = createEditor({ race: 'Präkristofluu' });
+        e.applyRacePraekristofluu();
+
+        e.clearRace();
+
+        expect(e.raceLocked.advantages).toEqual([]);
+        expect(e.selectedAdvantages).toEqual(['Zäh']);
+        expect(e.raceGrants).toEqual({});
+        expect(e.praekristofluuPoolUsed()).toBe(0);
+        expect(e.skills.find(s => s.name === 'Beruf')).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Bildung')).toBeUndefined();
+    });
 });
 
 describe('charEditor – Kultur-Logik', () => {
@@ -497,6 +550,40 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 1 });
         expect(e.cultureGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
         expect(e.cultureGrants.Feuerwaffen).toEqual({ type: 'min', value: 3 });
+    });
+
+    it('Präkristofluu erlaubt nur Mensch des 21. Jahrhunderts als Kultur', () => {
+        const praekristofluu = createEditor({ race: 'Präkristofluu' });
+
+        expect(praekristofluu.allowedCulturesForRace()).toEqual(['Mensch des 21. Jahrhunderts']);
+        expect(praekristofluu.isCultureSelectable('Mensch des 21. Jahrhunderts')).toBe(true);
+        expect(praekristofluu.isCultureSelectable('Landbewohner')).toBe(false);
+        expect(praekristofluu.isCultureSelectable('Bunkermensch')).toBe(false);
+
+        const barbar = createEditor({ race: 'Barbar' });
+
+        expect(barbar.isCultureSelectable('Mensch des 21. Jahrhunderts')).toBe(false);
+        expect(barbar.allowedCulturesForRace()).not.toContain('Mensch des 21. Jahrhunderts');
+    });
+
+    it('Rassenwechsel zu Präkristofluu setzt Mensch des 21. Jahrhunderts und ersetzt alte Kultur-Grants', () => {
+        const e = createEditor({ race: 'Präkristofluu', culture: 'Landbewohner' });
+        e.applyCultureLandbewohner();
+
+        expect(e.cultureGrants['Beruf: Landwirt']).toEqual({ type: 'exact', value: 2 });
+
+        e.handleRaceChange();
+
+        expect(e.culture).toBe('Mensch des 21. Jahrhunderts');
+        expect(e.cultureGrants['Beruf: Landwirt']).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Beruf: Landwirt')).toBeUndefined();
+
+        e.handleCultureChange();
+
+        expect(e.cultureGrants.Beruf).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 3 });
+        expect(e.cultureGrants.Pilot).toEqual({ type: 'min', value: 3 });
+        expect(e.skills.find(s => s.name === 'Beruf')).toMatchObject({ value: 3, badge: 'Rasse/Kultur' });
     });
 
     it('Kulturwechsel auf Bunkermensch setzt Techno automatisch und ersetzt alte Rassen-Grants', () => {
@@ -633,6 +720,45 @@ describe('charEditor – Kultur-Logik', () => {
         expect(e.raceGrants.Feuerwaffen).toEqual({ type: 'min', value: 4 });
         expect(e.cultureGrants.Pilot).toEqual({ type: 'min', value: 3 });
         expect(e.skills.find(s => s.name === 'Pilot')).toMatchObject({ value: 3, badge: 'Rasse/Kultur' });
+    });
+
+    it('Mensch des 21. Jahrhunderts setzt Beruf und zwei unterschiedliche Zusatzboni', () => {
+        const e = createEditor({ race: 'Präkristofluu', culture: 'Mensch des 21. Jahrhunderts' });
+        e.applyRacePraekristofluu();
+        e.applyCultureMensch21();
+
+        expect(e.cultureGrants.Beruf).toEqual({ type: 'min', value: 1 });
+        expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 3 });
+        expect(e.cultureGrants.Pilot).toEqual({ type: 'min', value: 3 });
+        expect(e.mensch21FirstBonusSkill).toBe('Bildung');
+        expect(e.mensch21SecondBonusSkill).toBe('Pilot');
+        expect(e.skills.find(s => s.name === 'Bildung')).toMatchObject({ value: 3, badge: 'Rasse/Kultur' });
+
+        e.setMensch21FirstBonusSkill('Techniker');
+
+        expect(e.cultureGrants.Bildung).toBeUndefined();
+        expect(e.raceGrants.Bildung).toEqual({ type: 'min', value: 2 });
+        expect(e.skills.find(s => s.name === 'Bildung')).toMatchObject({ value: 2, badge: 'Rasse' });
+        expect(e.cultureGrants.Techniker).toEqual({ type: 'min', value: 3 });
+        expect(e.cultureGrants.Pilot).toEqual({ type: 'min', value: 3 });
+
+        e.setMensch21SecondBonusSkill('Techniker');
+
+        expect(e.mensch21FirstBonusSkill).toBe('Techniker');
+        expect(e.mensch21SecondBonusSkill).toBe('Bildung');
+        expect(e.cultureGrants.Pilot).toBeUndefined();
+        expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 3 });
+    });
+
+    it('Mensch-des-21-Jahrhunderts-Boni addieren auf Präkristofluu-Poolpunkte bis zum Maximum', () => {
+        const e = createEditor({ race: 'Präkristofluu', culture: 'Mensch des 21. Jahrhunderts' });
+        e.applyRacePraekristofluu();
+        e.applyCultureMensch21();
+
+        e.setPraekristofluuSkillPoints('Bildung', 4);
+
+        expect(e.cultureGrants.Bildung).toEqual({ type: 'min', value: 4 });
+        expect(e.getGrant('Bildung')).toEqual({ type: 'min', value: 4 });
     });
 
     it('Landbewohner erhält Viehzüchter und Landwirt als Exact-Grants', () => {

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -317,6 +317,107 @@ test.describe('RPG Charakter-Editor', () => {
         ]));
     });
 
+    test('erzwingt Mensch des 21. Jahrhunderts als einzige Kultur fuer Praekristofluu', async ({ page }) => {
+        await login(page, 'info@maddraxikon.com');
+        await page.goto('/rpg/char-editor');
+
+        await expect(page.locator('#culture option[value="Mensch des 21. Jahrhunderts"]')).toBeDisabled();
+
+        await page.getByLabel('Spielername').fill('Playwright Spieler');
+        await page.getByLabel('Charaktername').fill('Wudan');
+        await page.locator('#gender').selectOption('maennlich');
+        await page.locator('#culture').selectOption('Landbewohner');
+        await expect(page.locator('#culture')).toHaveValue('Landbewohner');
+
+        await page.locator('#race').selectOption('Präkristofluu');
+
+        await expect(page.locator('#culture')).toHaveValue('Mensch des 21. Jahrhunderts');
+
+        const cultureOptions = await page.locator('#culture').evaluate((select) => Object.fromEntries(
+            Array.from(select.options).map((option) => [option.value || 'placeholder', option.disabled]),
+        ));
+
+        expect(cultureOptions).toMatchObject({
+            Landbewohner: true,
+            Stadtbewohner: true,
+            Meeresbewohner: true,
+            Bunkermensch: true,
+            'Mensch des 21. Jahrhunderts': false,
+            Nomade: true,
+            Ruinenbewohner: true,
+            Untergrundbewohner: true,
+            'Volk der 13 Inseln': true,
+        });
+
+        await page.getByTestId('char-editor-continue-button').click();
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+            };
+        });
+
+        expect(payload).toEqual({
+            race: 'Präkristofluu',
+            culture: 'Mensch des 21. Jahrhunderts',
+        });
+    });
+
+    test('setzt Praekristofluu- und Mensch-21-Regeln inklusive Pool im Formularpayload um', async ({ page }) => {
+        await openAdvancedEditor(page, { race: 'Präkristofluu', culture: 'Mensch des 21. Jahrhunderts' });
+
+        await expect(checkbox(page, 'advantages[]', 'High-Tech-Ausrüstung')).toBeChecked();
+        await expect(checkbox(page, 'advantages[]', 'High-Tech-Ausrüstung')).toBeDisabled();
+        await expect(page.getByText('Freie Vorteile: 2')).toBeVisible();
+        await expect(page.getByText('Verteilt: 12 / 12')).toBeVisible();
+
+        await page.getByTestId('praekristofluu-skill-points-input').first().fill('4');
+        await page.getByTestId('praekristofluu-skill-points-input').nth(2).fill('0');
+        await page.locator('#mensch-21-first-bonus-select').selectOption('Techniker');
+        await page.locator('#mensch-21-second-bonus-select').selectOption('Wissenschaftler');
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+            const skillsByIndex = {};
+
+            for (const [key, value] of data.entries()) {
+                const match = key.match(/^skills\[(\d+)]\[(name|value)]$/);
+
+                if (!match) {
+                    continue;
+                }
+
+                const [, index, field] = match;
+                skillsByIndex[index] ??= {};
+                skillsByIndex[index][field] = value;
+            }
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+                advantages: data.getAll('advantages[]'),
+                skills: Object.values(skillsByIndex),
+            };
+        });
+
+        expect(payload.race).toBe('Präkristofluu');
+        expect(payload.culture).toBe('Mensch des 21. Jahrhunderts');
+        expect(payload.advantages).toEqual(expect.arrayContaining(['Zäh', 'High-Tech-Ausrüstung']));
+        expect(payload.skills).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Beruf', value: '3' }),
+            expect.objectContaining({ name: 'Bildung', value: '4' }),
+            expect.objectContaining({ name: 'Fahren', value: '2' }),
+            expect.objectContaining({ name: 'Pilot', value: '2' }),
+            expect.objectContaining({ name: 'Techniker', value: '3' }),
+            expect.objectContaining({ name: 'Wissenschaftler', value: '3' }),
+        ]));
+        expect(payload.skills).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Feuerwaffen' }),
+        ]));
+    });
 
     test('erlaubt Volk der 13 Inseln nur fuer Barbaren und erzwingt Psychische Kraft fuer weiblich', async ({ page }) => {
         await login(page, 'info@maddraxikon.com');


### PR DESCRIPTION
This pull request introduces a new playable race, "Präkristofluu", and its associated culture, "Mensch des 21. Jahrhunderts", to the RPG character editor. It implements all necessary validation, UI, and logic changes to support this addition, including skill point allocation, race/culture restrictions, and bonus skill handling.

**New Race and Culture Support:**

* Added the new race `Präkristofluu` and its description to the character editor, along with the associated culture `Mensch des 21. Jahrhunderts` and its description. These are now selectable in the UI, with appropriate enable/disable logic. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808L5-R14) [[2]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R88) [[3]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R100)

* Implemented strict validation rules:  
  - `Präkristofluu` can only select the culture `Mensch des 21. Jahrhunderts`, and vice versa.  
  - Other races/cultures are prevented from selecting this combination. [[1]](diffhunk://#diff-cc4e8a0530fc1f0b8a79eef9d32623f68bfc4dcf332e23360b25f2c63b266c1eR229-R246) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R230-R240)

**Skill and Bonus Logic:**

* Introduced a dedicated skill pool for `Präkristofluu`, similar to the existing `Techno` logic, including initialization, allocation, and validation for skill points. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R23-R30) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R95-R106) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R191) [[4]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R503-R546) [[5]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R593) [[6]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R607) [[7]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R630-R633) [[8]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R645) [[9]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R690-R697)

* Added logic for handling bonus skills for the `Mensch des 21. Jahrhunderts` culture, including UI state, selection, and grant application. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R764-R765) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R798-R802) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R931-R987)

**Race and Culture Application:**

* Updated the race/culture application logic to initialize and reset relevant fields, enforce restrictions, and grant automatic advantages as per the new rules for `Präkristofluu` and `Mensch des 21. Jahrhunderts`. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R730) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R764-R765) [[3]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R690-R697)

These changes ensure that the new race and culture are fully integrated and behave consistently with the rest of the character editor.