### PR TITLE
Feature: Races Taratze and Wulfane in Charakter Editor

### DIFF
--- a/resources/js/alpine/char-editor.js
+++ b/resources/js/alpine/char-editor.js
@@ -3,6 +3,8 @@ const RACE_DESCRIPTIONS = {
     Guul: 'Guule sind bedauernswerte Mutationen des Homo Sapiens. Sie sind dürr, fast zwei Meter groß und völlig unbehaart. Ihre langen knochigen Arme enden in Krallen. Die verhornten Füße laufen an den Fersen in einem fingerdicken Stachel aus. Aus dem Maul tropft weißlicher Schleim, was ihr abstoßendes Äußeres zusätzlich verstärkt. Guule sind meist nur mit einem Lendenschurz bekleidet. Sie ernähren sich von Aas und Gebeinen, die sie u.a. aus Gräbern holen.',
     Hydrit: 'Hydriten, von den Menschen oft Fischmenschen genannt, sind ein friedliebendes und altes Volk. Sie leben in geheimen Unterseestädten, sind amphibisch, kultiviert und verfügen über fortgeschrittene biogenetische Technologien. Der Genuss von Fleisch verwandelt Hydriten in gefährliche Bestien, weshalb sie sich meist vegetarisch ernähren.',
     Nosfera: 'Nosfera sind mumienartige Erscheinungen mit pergamentartiger Haut und einer knochig dürren Gestalt. Durch eine seltene Form der Sichelzellenanämie benötigen sie stetig frisches Blut und werden deshalb von den meisten Völkern gefürchtet und verhasst. Viele Nosfera verfügen über erstaunlich starke psychische Fähigkeiten.',
+    Taratze: 'Taratzen sind mutierte, auf über zwei Meter angewachsene Ratten zwischen tierischer und menschlicher Intelligenz. Sie haben ein drahtiges Fell, spitze Ohren, rote Farbschattierungen und gelten durch ihre raubtierhaften Sinne, ihre Robustheit und ihre Tarnfähigkeit als gefürchtete Gegner. Nur wenige haben die friedlichen Kontaktversuche anderer Rassen gesucht.',
+    Wulfane: 'Wulfanen sind von langen, überwiegend dunklen Körperhaaren bedeckt und haben wolfsähnliche Züge. Ihr Gesicht wird durch Hasenscharte und spitze, lange Zähne geprägt. Sie sind durchschnittlich intelligent, verfügen über einen ausgeprägten Geruchssinn und leben nach einem strengen Ehrenkodex bevorzugt in alten Ruinenstädten.',
     Techno: 'Technos sind Nachfahren der Menschen, die den Kometeneinschlag in Bunkern überlebt und eine neue Zivilisation aufgebaut haben. Aufgrund ihres technologischen Fortschritts gelten sie vielen Barbaren als Götter oder Dämonen. Sie leiden jedoch an einer tödlichen Immunschwäche und können die Außenwelt nur mit Schutzanzug betreten.',
     Präkristofluu: 'Präkristofluu sind Menschen aus dem 21. Jahrhundert, die durch Gefrierkammern oder mysteriöse Zeitphänomene in das 26. Jahrhundert gelangt sind. Ihr technisches Wissen und ihre Kenntnisse der Vergangenheit gleichen ihre geringe Anpassungsfähigkeit aus.'
 };
@@ -595,6 +597,8 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         if (this.race === 'Guul') this.applyRaceGuul();
         if (this.race === 'Hydrit') this.applyRaceHydrit();
         if (this.race === NOSFERA_RACE) this.applyRaceNosfera();
+        if (this.race === 'Taratze') this.applyRaceTaratze();
+        if (this.race === 'Wulfane') this.applyRaceWulfane();
         if (this.race === 'Techno') this.applyRaceTechno();
         if (this.race === PRAEKRISTOFLUU_RACE) this.applyRacePraekristofluu();
         this.restoreRaceState(this.race);
@@ -691,6 +695,23 @@ function registerCharEditor({ hydrateExisting = false } = {}) {
         this.raceLocked.disadvantages = ['Blutdurst', 'Lichtscheu', 'Gejagt'];
         this.selectedAdvantages = [...new Set([...this.selectedAdvantages, 'Nachtsicht', 'Psychisches Reservoir'])];
         this.selectedDisadvantages = [...new Set([...this.selectedDisadvantages, 'Blutdurst', 'Lichtscheu', 'Gejagt'])];
+    },
+
+    applyRaceTaratze() {
+        this.setRaceAttributeModifiers({ st: 1, wa: 1, in: -1, au: -1 });
+        this.setFreeMin('Intuition', 2, 'Rasse');
+        this.setFreeMin('Heimlichkeit', 1, 'Rasse');
+        this.setFreeMin('Überleben', 1, 'Rasse');
+        this.raceLocked.disadvantages = ['Auffällig', 'Primitiv', 'Gejagt'];
+        this.selectedDisadvantages = [...new Set([...this.selectedDisadvantages, 'Auffällig', 'Primitiv', 'Gejagt'])];
+    },
+
+    applyRaceWulfane() {
+        this.setRaceAttributeModifiers({ ro: 1, au: -1 });
+        this.setFreeMin('Intuition', 1, 'Rasse');
+        this.setFreeMin('Nahkampf', 1, 'Rasse');
+        this.raceLocked.disadvantages = ['Ehrenkodex'];
+        this.selectedDisadvantages = [...new Set([...this.selectedDisadvantages, 'Ehrenkodex'])];
     },
 
     applyRaceTechno() {

--- a/resources/views/rpg/char-editor.blade.php
+++ b/resources/views/rpg/char-editor.blade.php
@@ -86,6 +86,8 @@
                             <option value="Guul" :disabled="!isRaceSelectable('Guul')">Guul</option>
                             <option value="Hydrit" :disabled="!isRaceSelectable('Hydrit')">Hydrit</option>
                             <option value="Nosfera" :disabled="!isRaceSelectable('Nosfera')">Nosfera</option>
+                            <option value="Taratze" :disabled="!isRaceSelectable('Taratze')">Taratze</option>
+                            <option value="Wulfane" :disabled="!isRaceSelectable('Wulfane')">Wulfane</option>
                             <option value="Techno" :disabled="!isRaceSelectable('Techno')">Techno</option>
                             <option value="Präkristofluu" :disabled="!isRaceSelectable('Präkristofluu')">Präkristofluu</option>
                         </select>

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -530,6 +530,100 @@ class RpgCharEditorPdfTest extends TestCase
         $response->assertOk();
     }
 
+    public function test_pdf_export_accepts_taratze_with_general_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(function ($data) {
+                $skills = collect($data['skills'])->keyBy('name');
+
+                return $data['character']['race'] === 'Taratze'
+                    && $data['character']['culture'] === 'Stadtbewohner'
+                    && ($data['attributes']['st'] ?? null) === '1'
+                    && ($data['attributes']['wa'] ?? null) === '1'
+                    && ($data['attributes']['in'] ?? null) === '-1'
+                    && ($data['attributes']['au'] ?? null) === '-1'
+                    && ($skills['Intuition']['value'] ?? null) === '2'
+                    && ($skills['Heimlichkeit']['value'] ?? null) === '1'
+                    && ($skills['Überleben']['value'] ?? null) === '1'
+                    && in_array('Auffällig', $data['disadvantages'], true)
+                    && in_array('Primitiv', $data['disadvantages'], true)
+                    && in_array('Gejagt', $data['disadvantages'], true);
+            }))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Taratze',
+            'culture' => 'Stadtbewohner',
+            'attributes' => [
+                'st' => 1,
+                'wa' => 1,
+                'in' => -1,
+                'au' => -1,
+            ],
+            'skills' => [
+                ['name' => 'Intuition', 'value' => 2],
+                ['name' => 'Heimlichkeit', 'value' => 1],
+                ['name' => 'Überleben', 'value' => 1],
+            ],
+            'advantages' => ['Zäh'],
+            'disadvantages' => ['Auffällig', 'Primitiv', 'Gejagt'],
+        ]));
+
+        $response->assertOk();
+    }
+
+    public function test_pdf_export_accepts_wulfane_with_general_culture(): void
+    {
+        $member = $this->addAgRollenspielMembership($this->createMember());
+
+        Pdf::shouldReceive('view')
+            ->once()
+            ->with('rpg.char-sheet', \Mockery::on(function ($data) {
+                $skills = collect($data['skills'])->keyBy('name');
+
+                return $data['character']['race'] === 'Wulfane'
+                    && $data['character']['culture'] === 'Landbewohner'
+                    && ($data['attributes']['ro'] ?? null) === '1'
+                    && ($data['attributes']['au'] ?? null) === '-1'
+                    && ($skills['Intuition']['value'] ?? null) === '1'
+                    && ($skills['Nahkampf']['value'] ?? null) === '1'
+                    && in_array('Ehrenkodex', $data['disadvantages'], true);
+            }))
+            ->andReturn(new class extends PdfBuilder
+            {
+                public function toResponse($request): Response
+                {
+                    return response('PDF', 200, $this->responseHeaders);
+                }
+            });
+
+        $response = $this->followingRedirects()->actingAs($member)->post('/rpg/char-editor/pdf', $this->validPdfPayload([
+            'race' => 'Wulfane',
+            'culture' => 'Landbewohner',
+            'attributes' => [
+                'ro' => 1,
+                'au' => -1,
+            ],
+            'skills' => [
+                ['name' => 'Intuition', 'value' => 1],
+                ['name' => 'Nahkampf', 'value' => 1],
+            ],
+            'advantages' => ['Zäh'],
+            'disadvantages' => ['Ehrenkodex'],
+        ]));
+
+        $response->assertOk();
+    }
+
     public function test_pdf_export_accepts_nomade_culture(): void
     {
         $member = $this->addAgRollenspielMembership($this->createMember());

--- a/tests/Feature/RpgCharEditorPdfTest.php
+++ b/tests/Feature/RpgCharEditorPdfTest.php
@@ -538,6 +538,7 @@ class RpgCharEditorPdfTest extends TestCase
             ->once()
             ->with('rpg.char-sheet', \Mockery::on(function ($data) {
                 $skills = collect($data['skills'])->keyBy('name');
+                $skillValue = fn (string $skillName) => ($skills[$skillName] ?? [])['value'] ?? null;
 
                 return $data['character']['race'] === 'Taratze'
                     && $data['character']['culture'] === 'Stadtbewohner'
@@ -545,9 +546,9 @@ class RpgCharEditorPdfTest extends TestCase
                     && ($data['attributes']['wa'] ?? null) === '1'
                     && ($data['attributes']['in'] ?? null) === '-1'
                     && ($data['attributes']['au'] ?? null) === '-1'
-                    && ($skills['Intuition']['value'] ?? null) === '2'
-                    && ($skills['Heimlichkeit']['value'] ?? null) === '1'
-                    && ($skills['Überleben']['value'] ?? null) === '1'
+                    && $skillValue('Intuition') === '2'
+                    && $skillValue('Heimlichkeit') === '1'
+                    && $skillValue('Überleben') === '1'
                     && in_array('Auffällig', $data['disadvantages'], true)
                     && in_array('Primitiv', $data['disadvantages'], true)
                     && in_array('Gejagt', $data['disadvantages'], true);
@@ -589,13 +590,14 @@ class RpgCharEditorPdfTest extends TestCase
             ->once()
             ->with('rpg.char-sheet', \Mockery::on(function ($data) {
                 $skills = collect($data['skills'])->keyBy('name');
+                $skillValue = fn (string $skillName) => ($skills[$skillName] ?? [])['value'] ?? null;
 
                 return $data['character']['race'] === 'Wulfane'
                     && $data['character']['culture'] === 'Landbewohner'
                     && ($data['attributes']['ro'] ?? null) === '1'
                     && ($data['attributes']['au'] ?? null) === '-1'
-                    && ($skills['Intuition']['value'] ?? null) === '1'
-                    && ($skills['Nahkampf']['value'] ?? null) === '1'
+                    && $skillValue('Intuition') === '1'
+                    && $skillValue('Nahkampf') === '1'
                     && in_array('Ehrenkodex', $data['disadvantages'], true);
             }))
             ->andReturn(new class extends PdfBuilder

--- a/tests/Vitest/char-editor.test.js
+++ b/tests/Vitest/char-editor.test.js
@@ -332,6 +332,95 @@ describe('charEditor – Rassen-Logik', () => {
         expect(e.skills.find(s => s.name === 'Heimlichkeit')).toBeUndefined();
     });
 
+    it('Taratze erhält kostenlose Attributsmodifikatoren, Fertigkeiten und Pflichtnachteile', () => {
+        const e = createEditor({ race: 'Taratze' });
+        e.applyRaceTaratze();
+
+        expect(e.attributes).toMatchObject({ st: 1, wa: 1, in: -1, au: -1 });
+        expect(e.apUsed()).toBe(0);
+        expect(e.apRemaining()).toBe(2);
+        expect(e.getAttributeMax('st')).toBe(2);
+        expect(e.getAttributeMax('wa')).toBe(2);
+        expect(e.getAttributeMax('in')).toBe(0);
+        expect(e.getAttributeMax('au')).toBe(0);
+        expect(e.raceGrants.Intuition).toEqual({ type: 'min', value: 2 });
+        expect(e.raceGrants.Heimlichkeit).toEqual({ type: 'min', value: 1 });
+        expect(e.raceGrants['Überleben']).toEqual({ type: 'min', value: 1 });
+        expect(e.skills.find(s => s.name === 'Intuition')).toMatchObject({ value: 2, badge: 'Rasse' });
+        expect(e.skills.find(s => s.name === 'Heimlichkeit')).toMatchObject({ value: 1, badge: 'Rasse' });
+        expect(e.skills.find(s => s.name === 'Überleben')).toMatchObject({ value: 1, badge: 'Rasse' });
+        expect(e.raceLocked.advantages).toEqual([]);
+        expect(e.raceLocked.disadvantages).toEqual(['Auffällig', 'Primitiv', 'Gejagt']);
+        expect(e.selectedDisadvantages).toEqual(expect.arrayContaining(['Auffällig', 'Primitiv', 'Gejagt']));
+        expect(e.chosenAdvantagesCount()).toBe(0);
+        expect(e.freeAdvantagePoints()).toBe(2);
+        expect(e.selectedLockedDisadvantages()).toEqual(['Auffällig', 'Primitiv', 'Gejagt']);
+    });
+
+    it('Rassenwechsel entfernt Taratze-Pflichtnachteile, Fertigkeiten und Attributsmodifikatoren', () => {
+        const e = createEditor({ race: 'Taratze' });
+        e.applyRaceTaratze();
+        e.clearRace();
+
+        expect(e.attributes).toMatchObject({ st: 0, wa: 0, in: 0, au: 0 });
+        expect(e.raceLocked.disadvantages).toEqual([]);
+        expect(e.selectedDisadvantages).toEqual([]);
+        expect(e.skills.find(s => s.name === 'Intuition')).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Heimlichkeit')).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Überleben')).toBeUndefined();
+    });
+
+    it('Wulfane erhält kostenlose Attributsmodifikatoren, Fertigkeiten und Ehrenkodex', () => {
+        const e = createEditor({ race: 'Wulfane' });
+        e.applyRaceWulfane();
+
+        expect(e.attributes).toMatchObject({ ro: 1, au: -1 });
+        expect(e.apUsed()).toBe(0);
+        expect(e.apRemaining()).toBe(2);
+        expect(e.getAttributeMax('ro')).toBe(2);
+        expect(e.getAttributeMax('au')).toBe(0);
+        expect(e.raceGrants.Intuition).toEqual({ type: 'min', value: 1 });
+        expect(e.raceGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.skills.find(s => s.name === 'Intuition')).toMatchObject({ value: 1, badge: 'Rasse' });
+        expect(e.skills.find(s => s.name === 'Nahkampf')).toMatchObject({ value: 1, badge: 'Rasse' });
+        expect(e.raceLocked.advantages).toEqual([]);
+        expect(e.raceLocked.disadvantages).toEqual(['Ehrenkodex']);
+        expect(e.selectedDisadvantages).toContain('Ehrenkodex');
+        expect(e.selectedLockedDisadvantages()).toEqual(['Ehrenkodex']);
+    });
+
+    it('Rassenwechsel entfernt Wulfane-Pflichtnachteil, Fertigkeiten und Attributsmodifikatoren', () => {
+        const e = createEditor({ race: 'Wulfane' });
+        e.applyRaceWulfane();
+        e.clearRace();
+
+        expect(e.attributes.ro).toBe(0);
+        expect(e.attributes.au).toBe(0);
+        expect(e.raceLocked.disadvantages).toEqual([]);
+        expect(e.selectedDisadvantages).toEqual([]);
+        expect(e.skills.find(s => s.name === 'Intuition')).toBeUndefined();
+        expect(e.skills.find(s => s.name === 'Nahkampf')).toBeUndefined();
+    });
+
+    it('Rassenwechsel zu Taratze und Wulfane wendet die neuen Rassenregeln im Editorfluss an', () => {
+        const e = createEditor({ race: 'Taratze', culture: 'Stadtbewohner' });
+        e.handleRaceChange();
+
+        expect(e.raceGrants.Intuition).toEqual({ type: 'min', value: 2 });
+        expect(e.raceLocked.disadvantages).toEqual(['Auffällig', 'Primitiv', 'Gejagt']);
+        expect(e.culture).toBe('Stadtbewohner');
+
+        e.race = 'Wulfane';
+        e.handleRaceChange();
+
+        expect(e.raceGrants.Intuition).toEqual({ type: 'min', value: 1 });
+        expect(e.raceGrants.Nahkampf).toEqual({ type: 'min', value: 1 });
+        expect(e.raceGrants.Heimlichkeit).toBeUndefined();
+        expect(e.raceLocked.disadvantages).toEqual(['Ehrenkodex']);
+        expect(e.selectedDisadvantages).toEqual(['Ehrenkodex']);
+        expect(e.culture).toBe('Stadtbewohner');
+    });
+
     it('Techno erhält kostenlose Attributsmodifikatoren, Pflichtmerkmale und 12 Rassen-Fertigkeitspunkte', () => {
         const e = createEditor({ race: 'Techno' });
         e.applyRaceTechno();

--- a/tests/e2e/char-editor.spec.js
+++ b/tests/e2e/char-editor.spec.js
@@ -213,6 +213,107 @@ test.describe('RPG Charakter-Editor', () => {
         expect(payload).toContain('Gejagt');
     });
 
+    test('setzt Taratze-Regeln inklusive Pflichtnachteilen im Formularpayload um', async ({ page }) => {
+        await openAdvancedEditor(page, { race: 'Taratze', culture: 'Stadtbewohner' });
+
+        await expect(page.locator('#st')).toHaveValue('1');
+        await expect(page.locator('#wa')).toHaveValue('1');
+        await expect(page.locator('#in')).toHaveValue('-1');
+        await expect(page.locator('#au')).toHaveValue('-1');
+        await expect(checkbox(page, 'disadvantages[]', 'Auffällig')).toBeChecked();
+        await expect(checkbox(page, 'disadvantages[]', 'Auffällig')).toBeDisabled();
+        await expect(checkbox(page, 'disadvantages[]', 'Primitiv')).toBeChecked();
+        await expect(checkbox(page, 'disadvantages[]', 'Primitiv')).toBeDisabled();
+        await expect(checkbox(page, 'disadvantages[]', 'Gejagt')).toBeChecked();
+        await expect(checkbox(page, 'disadvantages[]', 'Gejagt')).toBeDisabled();
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+            const skillsByIndex = {};
+
+            for (const [key, value] of data.entries()) {
+                const match = key.match(/^skills\[(\d+)]\[(name|value)]$/);
+
+                if (!match) {
+                    continue;
+                }
+
+                const [, index, field] = match;
+                skillsByIndex[index] ??= {};
+                skillsByIndex[index][field] = value;
+            }
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+                st: data.get('attributes[st]'),
+                wa: data.get('attributes[wa]'),
+                in: data.get('attributes[in]'),
+                au: data.get('attributes[au]'),
+                disadvantages: data.getAll('disadvantages[]'),
+                skills: Object.values(skillsByIndex),
+            };
+        });
+
+        expect(payload.race).toBe('Taratze');
+        expect(payload.culture).toBe('Stadtbewohner');
+        expect(payload.st).toBe('1');
+        expect(payload.wa).toBe('1');
+        expect(payload.in).toBe('-1');
+        expect(payload.au).toBe('-1');
+        expect(payload.disadvantages).toEqual(expect.arrayContaining(['Auffällig', 'Primitiv', 'Gejagt']));
+        expect(payload.skills).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Intuition', value: '2' }),
+            expect.objectContaining({ name: 'Heimlichkeit', value: '1' }),
+            expect.objectContaining({ name: 'Überleben', value: '1' }),
+        ]));
+    });
+
+    test('setzt Wulfane-Regeln inklusive Ehrenkodex im Formularpayload um', async ({ page }) => {
+        await openAdvancedEditor(page, { race: 'Wulfane', culture: 'Landbewohner' });
+
+        await expect(page.locator('#ro')).toHaveValue('1');
+        await expect(page.locator('#au')).toHaveValue('-1');
+        await expect(checkbox(page, 'disadvantages[]', 'Ehrenkodex')).toBeChecked();
+        await expect(checkbox(page, 'disadvantages[]', 'Ehrenkodex')).toBeDisabled();
+
+        const payload = await page.getByTestId('char-editor-form').evaluate((form) => {
+            const data = new FormData(form);
+            const skillsByIndex = {};
+
+            for (const [key, value] of data.entries()) {
+                const match = key.match(/^skills\[(\d+)]\[(name|value)]$/);
+
+                if (!match) {
+                    continue;
+                }
+
+                const [, index, field] = match;
+                skillsByIndex[index] ??= {};
+                skillsByIndex[index][field] = value;
+            }
+
+            return {
+                race: data.get('race'),
+                culture: data.get('culture'),
+                ro: data.get('attributes[ro]'),
+                au: data.get('attributes[au]'),
+                disadvantages: data.getAll('disadvantages[]'),
+                skills: Object.values(skillsByIndex),
+            };
+        });
+
+        expect(payload.race).toBe('Wulfane');
+        expect(payload.culture).toBe('Landbewohner');
+        expect(payload.ro).toBe('1');
+        expect(payload.au).toBe('-1');
+        expect(payload.disadvantages).toContain('Ehrenkodex');
+        expect(payload.skills).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Intuition', value: '1' }),
+            expect.objectContaining({ name: 'Nahkampf', value: '1' }),
+        ]));
+    });
+
     test('setzt Nosfera-Regeln inklusive Pflichtmerkmalen im Formularpayload um', async ({ page }) => {
         await openAdvancedEditor(page, { race: 'Nosfera', culture: 'Stadtbewohner' });
 


### PR DESCRIPTION
This pull request adds full support for the new races "Taratze" and "Wulfane" to the RPG character editor. This includes their rules, attribute modifiers, skill minimums, mandatory disadvantages, UI integration, and comprehensive test coverage to ensure correct behavior in both the frontend and backend.

### Feature: Support for Taratze and Wulfane races

* Added "Taratze" and "Wulfane" to the list of selectable races in the character editor dropdown (`char-editor.blade.php`) and provided detailed race descriptions (`char-editor.js`). [[1]](diffhunk://#diff-140b641dce48711580c9c11059c44c2c332f8b1232f4b217cb2a1ad7ee792eb2R89-R90) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R6-R7)
* Implemented `applyRaceTaratze` and `applyRaceWulfane` methods in `char-editor.js` to set the correct attribute modifiers, skill minimums, and mandatory disadvantages for each race. Integrated these methods into the race selection logic. [[1]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R700-R716) [[2]](diffhunk://#diff-92eef70584b6a72e1bbd2798a7e0bb9038f1ef303f63a3cc62079b10777a5808R600-R601)

### Testing: Validation of new race rules

* Added comprehensive unit tests in `char-editor.test.js` to verify that both Taratze and Wulfane receive the correct attribute and skill bonuses, locked disadvantages, and that these are properly cleared on race change.
* Added end-to-end tests in `char-editor.spec.js` to ensure the UI correctly applies the new race rules, including form payload validation and disabled mandatory disadvantages.
* Extended PDF export feature tests to accept Taratze and Wulfane characters with their specific rules and verify correct data mapping in the generated PDF.