### PR TITLE
Feature: Use Nickname as primary Display Name sitewide

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -17,6 +17,15 @@ use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
 class UpdateUserProfileInformation implements UpdatesUserProfileInformation
 {
+    private const MEMBER_MAP_CACHE_FIELDS = [
+        'alias',
+        'vorname',
+        'nachname',
+        'plz',
+        'stadt',
+        'land',
+    ];
+
     public function __construct(
         private readonly MemberMapCacheService $memberMapCacheService,
     ) {}
@@ -124,7 +133,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             $user->forceFill($updates)->save();
         }
 
-        if ($user->wasChanged('alias') && ($membersTeam = Team::membersTeam())) {
+        if ($user->wasChanged(self::MEMBER_MAP_CACHE_FIELDS) && ($membersTeam = Team::membersTeam())) {
             $this->memberMapCacheService->invalidate($membersTeam);
         }
 

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -6,6 +6,7 @@ use App\Enums\Role;
 use App\Mail\ProfileContactUpdated;
 use App\Models\Team;
 use App\Models\User;
+use App\Services\MemberMapCacheService;
 use Carbon\CarbonInterface;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Support\Facades\Log;
@@ -16,6 +17,10 @@ use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
 class UpdateUserProfileInformation implements UpdatesUserProfileInformation
 {
+    public function __construct(
+        private readonly MemberMapCacheService $memberMapCacheService,
+    ) {}
+
     /**
      * Validate and update the given user's profile information.
      *
@@ -117,6 +122,10 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             $this->updateVerifiedUser($user, $updates);
         } else {
             $user->forceFill($updates)->save();
+        }
+
+        if ($user->wasChanged('alias') && ($membersTeam = Team::membersTeam())) {
+            $this->memberMapCacheService->invalidate($membersTeam);
         }
 
         if ($changedContactLabels !== []) {

--- a/app/Livewire/MitgliederIndex.php
+++ b/app/Livewire/MitgliederIndex.php
@@ -30,6 +30,8 @@ class MitgliederIndex extends Component
 
     private const ALLOWED_SORT_FIELDS = ['name', 'role', 'mitgliedsbeitrag', 'mitglied_seit', 'last_activity'];
 
+    private const DISPLAY_NAME_SORT_EXPRESSION = "COALESCE(NULLIF(TRIM(users.alias), ''), TRIM(users.name))";
+
     private const ROLE_RANKS = [
         Role::Mitglied->value => 1,
         Role::Ehrenmitglied->value => 2,
@@ -78,17 +80,10 @@ class MitgliederIndex extends Component
         }
 
         if ($this->sortBy === 'name') {
-            $direction = $this->sortDir === 'desc' ? -1 : 1;
-
-            return $query->get()
-                ->sort(function (User $left, User $right) use ($direction): int {
-                    $nameComparison = strnatcasecmp($left->nicknameOrName(), $right->nicknameOrName());
-
-                    return $nameComparison === 0
-                        ? $left->id <=> $right->id
-                        : $nameComparison * $direction;
-                })
-                ->values();
+            return $query
+                ->orderBy(DB::raw(self::DISPLAY_NAME_SORT_EXPRESSION), $this->sortDir)
+                ->orderBy('users.id')
+                ->get();
         }
 
         return $query->orderBy($this->sortBy, $this->sortDir)->get();

--- a/app/Livewire/MitgliederIndex.php
+++ b/app/Livewire/MitgliederIndex.php
@@ -15,8 +15,8 @@ use Livewire\Component;
 
 class MitgliederIndex extends Component
 {
-    #[Url(as: 'sort', except: 'nachname')]
-    public string $sortBy = 'nachname';
+    #[Url(as: 'sort', except: 'name')]
+    public string $sortBy = 'name';
 
     #[Url(as: 'dir', except: 'asc')]
     public string $sortDir = 'asc';
@@ -28,7 +28,7 @@ class MitgliederIndex extends Component
 
     private MembersTeamProvider $membersTeamProvider;
 
-    private const ALLOWED_SORT_FIELDS = ['nachname', 'role', 'mitgliedsbeitrag', 'mitglied_seit', 'last_activity'];
+    private const ALLOWED_SORT_FIELDS = ['name', 'role', 'mitgliedsbeitrag', 'mitglied_seit', 'last_activity'];
 
     private const ROLE_RANKS = [
         Role::Mitglied->value => 1,
@@ -48,9 +48,13 @@ class MitgliederIndex extends Component
 
     public function mount(): void
     {
+        if ($this->sortBy === 'nachname') {
+            $this->sortBy = 'name';
+        }
+
         // Validate sort params from URL
         if (! in_array($this->sortBy, self::ALLOWED_SORT_FIELDS)) {
-            $this->sortBy = 'nachname';
+            $this->sortBy = 'name';
         }
         if (! in_array($this->sortDir, ['asc', 'desc'])) {
             $this->sortDir = $this->sortBy === 'last_activity' ? 'desc' : 'asc';
@@ -71,6 +75,20 @@ class MitgliederIndex extends Component
 
         if ($this->sortBy === 'role') {
             return $query->orderByPivot('role', $this->sortDir)->get();
+        }
+
+        if ($this->sortBy === 'name') {
+            $direction = $this->sortDir === 'desc' ? -1 : 1;
+
+            return $query->get()
+                ->sort(function (User $left, User $right) use ($direction): int {
+                    $nameComparison = strnatcasecmp($left->nicknameOrName(), $right->nicknameOrName());
+
+                    return $nameComparison === 0
+                        ? $left->id <=> $right->id
+                        : $nameComparison * $direction;
+                })
+                ->values();
         }
 
         return $query->orderBy($this->sortBy, $this->sortDir)->get();

--- a/app/Livewire/MitgliederIndex.php
+++ b/app/Livewire/MitgliederIndex.php
@@ -30,8 +30,6 @@ class MitgliederIndex extends Component
 
     private const ALLOWED_SORT_FIELDS = ['name', 'role', 'mitgliedsbeitrag', 'mitglied_seit', 'last_activity'];
 
-    private const DISPLAY_NAME_SORT_EXPRESSION = "COALESCE(NULLIF(TRIM(users.alias), ''), TRIM(users.name))";
-
     private const ROLE_RANKS = [
         Role::Mitglied->value => 1,
         Role::Ehrenmitglied->value => 2,
@@ -81,12 +79,22 @@ class MitgliederIndex extends Component
 
         if ($this->sortBy === 'name') {
             return $query
-                ->orderBy(DB::raw(self::DISPLAY_NAME_SORT_EXPRESSION), $this->sortDir)
+                ->orderBy(DB::raw($this->displayNameSortExpression()), $this->sortDir)
                 ->orderBy('users.id')
                 ->get();
         }
 
         return $query->orderBy($this->sortBy, $this->sortDir)->get();
+    }
+
+    private function displayNameSortExpression(): string
+    {
+        $civilNameExpression = DB::getDriverName() === 'sqlite'
+            ? "TRIM(COALESCE(NULLIF(TRIM(users.vorname), ''), '') || ' ' || COALESCE(NULLIF(TRIM(users.nachname), ''), ''))"
+            : "TRIM(CONCAT_WS(' ', NULLIF(TRIM(users.vorname), ''), NULLIF(TRIM(users.nachname), '')))";
+        $placeholder = str_replace("'", "''", User::UNKNOWN_DISPLAY_NAME);
+
+        return "COALESCE(NULLIF(TRIM(users.alias), ''), NULLIF(TRIM(users.name), ''), NULLIF({$civilNameExpression}, ''), '{$placeholder}')";
     }
 
     #[Computed]

--- a/app/Models/Fanfiction.php
+++ b/app/Models/Fanfiction.php
@@ -110,6 +110,15 @@ class Fanfiction extends Model
         return $this->author_name ?? 'Unbekannt';
     }
 
+    public function memberAuthorDisplayName(): string
+    {
+        if ($this->author) {
+            return $this->author->nicknameOrName();
+        }
+
+        return $this->author_name ?? 'Unbekannt';
+    }
+
     /**
      * Comments belonging to this fanfiction.
      */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,6 +36,8 @@ use Laravel\Sanctum\HasApiTokens;
  */
 class User extends Authenticatable
 {
+    public const UNKNOWN_DISPLAY_NAME = 'Unbekanntes Mitglied';
+
     use HasApiTokens;
 
     /** @use HasFactory<UserFactory> */
@@ -372,7 +374,24 @@ class User extends Authenticatable
 
     public function nicknameOrName(): string
     {
-        return $this->displayAlias() ?? trim((string) $this->name);
+        $alias = $this->displayAlias();
+
+        if ($alias !== null) {
+            return $alias;
+        }
+
+        $name = trim((string) $this->name);
+
+        if ($name !== '') {
+            return $name;
+        }
+
+        $civilName = implode(' ', array_filter([
+            trim((string) $this->vorname),
+            trim((string) $this->nachname),
+        ], static fn (string $part): bool => $part !== ''));
+
+        return $civilName !== '' ? $civilName : self::UNKNOWN_DISPLAY_NAME;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -370,6 +370,11 @@ class User extends Authenticatable
         return $alias === '' ? null : $alias;
     }
 
+    public function nicknameOrName(): string
+    {
+        return $this->displayAlias() ?? trim((string) $this->name);
+    }
+
     /**
      * @return array<int, string>
      */

--- a/app/Services/MemberMapCacheService.php
+++ b/app/Services/MemberMapCacheService.php
@@ -21,7 +21,7 @@ class MemberMapCacheService
 
         $members = $team->activeUsers()
             ->as('pivot')
-            ->select('users.id', 'users.name', 'users.alias', 'users.plz', 'users.land', 'users.stadt', 'users.lat', 'users.lon')
+            ->select('users.id', 'users.name', 'users.alias', 'users.vorname', 'users.nachname', 'users.plz', 'users.land', 'users.stadt', 'users.lat', 'users.lon')
             ->withPivot('role')
             ->get();
 

--- a/app/Services/MemberMapCacheService.php
+++ b/app/Services/MemberMapCacheService.php
@@ -13,9 +13,10 @@ class MemberMapCacheService
     public function getMemberMapData(Team $team): array
     {
         $cacheKey = $this->cacheKey($team);
+        $cachedData = Cache::get($cacheKey);
 
-        if (Cache::has($cacheKey)) {
-            return Cache::get($cacheKey);
+        if ($cachedData !== null) {
+            return $cachedData;
         }
 
         $members = $team->activeUsers()

--- a/app/Services/MemberMapCacheService.php
+++ b/app/Services/MemberMapCacheService.php
@@ -8,9 +8,11 @@ use Illuminate\Support\Facades\Cache;
 
 class MemberMapCacheService
 {
+    private const CACHE_VERSION = 'v2';
+
     public function getMemberMapData(Team $team): array
     {
-        $cacheKey = "member_map_data_team_{$team->id}";
+        $cacheKey = $this->cacheKey($team);
 
         if (Cache::has($cacheKey)) {
             return Cache::get($cacheKey);
@@ -18,7 +20,7 @@ class MemberMapCacheService
 
         $members = $team->activeUsers()
             ->as('pivot')
-            ->select('users.id', 'users.name', 'users.plz', 'users.land', 'users.stadt', 'users.lat', 'users.lon')
+            ->select('users.id', 'users.name', 'users.alias', 'users.plz', 'users.land', 'users.stadt', 'users.lat', 'users.lon')
             ->withPivot('role')
             ->get();
 
@@ -42,7 +44,7 @@ class MemberMapCacheService
                     $jitter = $this->addJitter($member->lat, $member->lon);
 
                     $memberData[] = [
-                        'name' => $member->name,
+                        'name' => $member->nicknameOrName(),
                         'city' => $member->stadt,
                         'role' => $member->pivot->role,
                         'lat' => $jitter['lat'],
@@ -69,9 +71,19 @@ class MemberMapCacheService
 
     public function refresh(Team $team): array
     {
-        Cache::forget("member_map_data_team_{$team->id}");
+        $this->invalidate($team);
 
         return $this->getMemberMapData($team);
+    }
+
+    public function invalidate(Team $team): void
+    {
+        Cache::forget($this->cacheKey($team));
+    }
+
+    private function cacheKey(Team $team): string
+    {
+        return 'member_map_data_'.self::CACHE_VERSION."_team_{$team->id}";
     }
 
     private function addJitter($lat, $lon): array

--- a/package-lock.json
+++ b/package-lock.json
@@ -857,49 +857,49 @@
             "license": "MIT"
         },
         "node_modules/@tailwindcss/node": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-            "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+            "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/remapping": "^2.3.5",
-                "enhanced-resolve": "5.21.6",
+                "enhanced-resolve": "^5.24.1",
                 "jiti": "^2.7.0",
                 "lightningcss": "1.32.0",
                 "magic-string": "^0.30.21",
                 "source-map-js": "^1.2.1",
-                "tailwindcss": "4.3.2"
+                "tailwindcss": "4.3.3"
             }
         },
         "node_modules/@tailwindcss/oxide": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-            "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+            "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 20"
             },
             "optionalDependencies": {
-                "@tailwindcss/oxide-android-arm64": "4.3.2",
-                "@tailwindcss/oxide-darwin-arm64": "4.3.2",
-                "@tailwindcss/oxide-darwin-x64": "4.3.2",
-                "@tailwindcss/oxide-freebsd-x64": "4.3.2",
-                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-                "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-                "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-                "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-                "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-                "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-                "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-                "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+                "@tailwindcss/oxide-android-arm64": "4.3.3",
+                "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+                "@tailwindcss/oxide-darwin-x64": "4.3.3",
+                "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+                "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+                "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+                "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+                "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+                "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+                "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+                "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+                "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
             }
         },
         "node_modules/@tailwindcss/oxide-android-arm64": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-            "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+            "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
             "cpu": [
                 "arm64"
             ],
@@ -914,9 +914,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-arm64": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-            "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+            "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
             "cpu": [
                 "arm64"
             ],
@@ -931,9 +931,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-darwin-x64": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-            "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+            "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
             "cpu": [
                 "x64"
             ],
@@ -948,9 +948,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-freebsd-x64": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-            "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+            "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
             "cpu": [
                 "x64"
             ],
@@ -965,9 +965,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-            "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+            "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
             "cpu": [
                 "arm"
             ],
@@ -982,9 +982,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-            "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+            "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
             "cpu": [
                 "arm64"
             ],
@@ -1002,9 +1002,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-            "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+            "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
             "cpu": [
                 "arm64"
             ],
@@ -1022,9 +1022,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-            "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+            "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
             "cpu": [
                 "x64"
             ],
@@ -1042,9 +1042,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-            "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+            "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
             "cpu": [
                 "x64"
             ],
@@ -1062,9 +1062,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-            "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+            "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
             "bundleDependencies": [
                 "@napi-rs/wasm-runtime",
                 "@emnapi/core",
@@ -1092,9 +1092,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-            "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+            "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1109,9 +1109,9 @@
             }
         },
         "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-            "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+            "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
             "cpu": [
                 "x64"
             ],
@@ -1126,17 +1126,17 @@
             }
         },
         "node_modules/@tailwindcss/postcss": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.2.tgz",
-            "integrity": "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+            "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
-                "@tailwindcss/node": "4.3.2",
-                "@tailwindcss/oxide": "4.3.2",
-                "postcss": "^8.5.15",
-                "tailwindcss": "4.3.2"
+                "@tailwindcss/node": "4.3.3",
+                "@tailwindcss/oxide": "4.3.3",
+                "postcss": "^8.5.16",
+                "tailwindcss": "4.3.3"
             }
         },
         "node_modules/@tailwindcss/typography": {
@@ -1153,15 +1153,15 @@
             }
         },
         "node_modules/@tailwindcss/vite": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
-            "integrity": "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+            "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@tailwindcss/node": "4.3.2",
-                "@tailwindcss/oxide": "4.3.2",
-                "tailwindcss": "4.3.2"
+                "@tailwindcss/node": "4.3.3",
+                "@tailwindcss/oxide": "4.3.3",
+                "tailwindcss": "4.3.3"
             },
             "peerDependencies": {
                 "vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -1408,9 +1408,9 @@
             }
         },
         "node_modules/ast-v8-to-istanbul": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
-            "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+            "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1420,9 +1420,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.5.2",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
-            "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+            "version": "10.5.4",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+            "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
             "dev": true,
             "funding": [
                 {
@@ -1440,8 +1440,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.28.4",
-                "caniuse-lite": "^1.0.30001799",
+                "browserslist": "^4.28.6",
+                "caniuse-lite": "^1.0.30001806",
                 "fraction.js": "^5.3.4",
                 "picocolors": "^1.1.1",
                 "postcss-value-parser": "^4.2.0"
@@ -1467,9 +1467,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.42",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+            "version": "2.10.43",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+            "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -1490,9 +1490,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.5",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
-            "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+            "version": "4.28.6",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+            "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
             "dev": true,
             "funding": [
                 {
@@ -1511,9 +1511,9 @@
             "license": "MIT",
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.42",
-                "caniuse-lite": "^1.0.30001800",
-                "electron-to-chromium": "^1.5.387",
-                "node-releases": "^2.0.50",
+                "caniuse-lite": "^1.0.30001803",
+                "electron-to-chromium": "^1.5.389",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -1524,9 +1524,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001803",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
-            "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
             "dev": true,
             "funding": [
                 {
@@ -1682,9 +1682,9 @@
             }
         },
         "node_modules/daisyui": {
-            "version": "5.6.17",
-            "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.6.17.tgz",
-            "integrity": "sha512-e/+8lJc2/GiMrnm6bVL+0K3pYE2mUP4DY/IFUcOCQdcocvRkDsmXGIIaC87JMedJJSKXVCuFpOVSZqMwaRcIGg==",
+            "version": "5.6.18",
+            "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.6.18.tgz",
+            "integrity": "sha512-6y9rboRQl8fosnusy/5pg11yp+H0LtK3YdtfS4Vf2QVnaYOKasNdYm6hDxeiT6bwZPdl4WRPzVIlIApdo2ssBg==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1730,9 +1730,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.389",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-            "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+            "version": "1.5.393",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+            "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
             "dev": true,
             "license": "ISC"
         },
@@ -1744,9 +1744,9 @@
             "license": "MIT"
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.21.6",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-            "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+            "version": "5.24.2",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+            "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1771,9 +1771,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "dev": true,
             "license": "MIT"
         },
@@ -2041,9 +2041,9 @@
             }
         },
         "node_modules/laravel-vite-plugin": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.1.0.tgz",
-            "integrity": "sha512-Fzocl+X4eQ9jOi0RwdphYRGkUbPJ3ky1pTAST5Ot18cS2gw6d2vldK2eCrlKDVjtibCjCx5qptYDlA0373n7qg==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/laravel-vite-plugin/-/laravel-vite-plugin-3.1.3.tgz",
+            "integrity": "sha512-cI5Anw4QHY+UzvZczFaj+j8NhwT2FtyEN8aqS/hOdt6DpEFBsn6x3GENxALem3cc+TsGvd9MacneimEvShvKMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2058,7 +2058,7 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "fontaine": "^0.5.0",
+                "fontaine": "^0.8.0",
                 "vite": "^8.0.0"
             },
             "peerDependenciesMeta": {
@@ -2441,9 +2441,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -2470,9 +2470,9 @@
             }
         },
         "node_modules/obug": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
             "dev": true,
             "funding": [
                 "https://github.com/sponsors/sxzz",
@@ -2556,9 +2556,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.17",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
-            "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
+            "version": "8.5.19",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+            "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
             "dev": true,
             "funding": [
                 {
@@ -2840,9 +2840,9 @@
             "license": "MIT"
         },
         "node_modules/tailwindcss": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-            "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+            "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -2911,22 +2911,22 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.4.8",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
-            "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+            "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.4.8"
+                "tldts-core": "^7.4.9"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.4.8",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
-            "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+            "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
             "dev": true,
             "license": "MIT"
         },
@@ -3029,16 +3029,16 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "8.1.4",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-            "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.5",
-                "postcss": "^8.5.16",
-                "rolldown": "~1.1.4",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -3326,9 +3326,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/resources/js/mitglieder/accessibility.js
+++ b/resources/js/mitglieder/accessibility.js
@@ -1,13 +1,13 @@
 const sortLabels = {
-    nachname: 'Nachname',
+    name: 'Nickname/Name',
     mitglied_seit: 'Mitglied seit',
     role: 'Rolle',
     last_activity: 'Zuletzt online',
     mitgliedsbeitrag: 'Beitrag',
 };
 
-const resolveSortLabel = (sortKey = 'nachname') => {
-    return sortLabels[sortKey] ?? sortLabels.nachname;
+const resolveSortLabel = (sortKey = 'name') => {
+    return sortLabels[sortKey] ?? sortLabels.name;
 };
 
 const resolveDirectionLabel = (direction = 'asc') => {
@@ -25,7 +25,7 @@ const formatMemberCount = (count) => {
 };
 
 export const buildMembersTableSummary = ({
-    sortBy = 'nachname',
+    sortBy = 'name',
     sortDir = 'asc',
     filterOnline = false,
     totalMembers,
@@ -95,7 +95,7 @@ export const enhanceMembersTable = (table) => {
 
     const dataset = table.dataset ?? {};
     const summaryId = dataset.membersSummaryId ?? table.getAttribute('aria-describedby') ?? '';
-    const sortBy = dataset.membersSort ?? 'nachname';
+    const sortBy = dataset.membersSort ?? 'name';
     const sortDir = dataset.membersDir ?? 'asc';
     const filterOnline = parseBoolean(dataset.membersFilterOnline);
     const totalMembers = parseTotal(dataset.membersTotal);

--- a/resources/views/components/fanfiction-comment.blade.php
+++ b/resources/views/components/fanfiction-comment.blade.php
@@ -4,6 +4,7 @@
     $maxDepth = 3;
     $canEdit = auth()->id() === $comment->user_id;
     $canDelete = auth()->id() === $comment->user_id || auth()->user()?->hasTeamRole(auth()->user()?->currentTeam, 'Vorstand') || auth()->user()?->hasTeamRole(auth()->user()?->currentTeam, 'Admin');
+    $commentAuthorName = $comment->user?->nicknameOrName();
 @endphp
 
 <div class="@if($depth > 0) ml-8 pl-4 border-l-2 border-gray-200 dark:border-gray-700 @endif" x-data="{ editing: false, replying: false }">
@@ -11,15 +12,15 @@
         <div class="flex items-start justify-between mb-2">
             <div class="flex items-center gap-2">
                 @if($comment->user && $comment->user->profile_photo_path)
-                    <img src="{{ $comment->user->profile_photo_url }}" alt="{{ $comment->user->name }}" class="w-8 h-8 rounded-full">
+                    <img src="{{ $comment->user->profile_photo_url }}" alt="{{ $commentAuthorName }}" class="w-8 h-8 rounded-full">
                 @else
                     <div class="w-8 h-8 rounded-full bg-indigo-500 flex items-center justify-center text-white text-sm font-medium">
-                        {{ $comment->user ? substr($comment->user->name, 0, 1) : '?' }}
+                        {{ $commentAuthorName ? \Illuminate\Support\Str::substr($commentAuthorName, 0, 1) : '?' }}
                     </div>
                 @endif
                 <div>
                     <span class="font-medium text-gray-900 dark:text-gray-100">
-                        {{ $comment->user?->name ?? 'Gelöschter Benutzer' }}
+                        {{ $commentAuthorName ?? 'Gelöschter Benutzer' }}
                     </span>
                     <span class="text-sm text-gray-500 dark:text-gray-400">
                         • {{ $comment->created_at->diffForHumans() }}

--- a/resources/views/dashboard/partials/activity-feed.blade.php
+++ b/resources/views/dashboard/partials/activity-feed.blade.php
@@ -22,6 +22,7 @@
                 $isFantreffenRegistration = $activity->subject_type === \App\Models\FantreffenAnmeldung::class;
                 $isSwapCompletion = $activity->subject_type === \App\Models\BookSwap::class && $activity->action === 'swap_completed';
                 $activityUser = $activity->user;
+                $activityUserName = $activityUser?->nicknameOrName();
                 $showProfileLink = ! $isFantreffenRegistration && ! $isSwapCompletion && $activityUser;
                 $typeLabels = [
                     \App\Models\Review::class => 'Rezension',
@@ -54,7 +55,7 @@
                         <span class="inline-flex items-center gap-1 rounded-full bg-base-100 px-2 py-1 ring-1 ring-base-200">
                             <span class="sr-only">von Nutzer</span>
                             <x-icon name="o-user" class="w-3.5 h-3.5" />
-                            <a href="{{ route('profile.view', $activityUser->id) }}" wire:navigate class="font-semibold text-primary hover:underline">{{ $activityUser->name }}</a>
+                            <a href="{{ route('profile.view', $activityUser->id) }}" wire:navigate class="font-semibold text-primary hover:underline">{{ $activityUserName }}</a>
                         </span>
                     @elseif(! $isFantreffenRegistration && ! $isSwapCompletion)
                         <span class="inline-flex items-center gap-1 rounded-full bg-base-100 px-2 py-1 ring-1 ring-base-200">
@@ -71,7 +72,8 @@
                         </span>
                     @elseif($isFantreffenRegistration)
                         @php
-                            $registrantName = $subject?->vorname
+                            $registrantName = $activityUser?->displayAlias()
+                                ?? $subject?->vorname
                                 ?? $activityUser?->vorname
                                 ?? $activityUser?->name
                                 ?? 'Teilnehmer';
@@ -116,7 +118,7 @@
                         @php
                             $review = $subject?->review;
                             $commentPreview = \App\Support\PreviewText::make($subject?->content ?? '', 140);
-                            $commentAuthorName = $activityUser?->name ?? 'Unbekannter Nutzer';
+                            $commentAuthorName = $activityUserName ?? 'Unbekannter Nutzer';
                         @endphp
                         @if($review)
                             <div class="space-y-1">
@@ -141,7 +143,7 @@
                         @php
                             $fanfiction = $subject?->fanfiction;
                             $commentPreview = \App\Support\PreviewText::make($subject?->content ?? '', 140);
-                            $commentAuthorName = $activityUser?->name ?? 'Unbekannter Nutzer';
+                            $commentAuthorName = $activityUserName ?? 'Unbekannter Nutzer';
                         @endphp
                         @if($fanfiction)
                             <div class="space-y-1">
@@ -188,13 +190,13 @@
                             <a href="{{ route('romantausch.index') }}" wire:navigate class="font-semibold text-info hover:underline">Tausch erfolgreich abgeschlossen</a>
                             <p>
                                 @if($offerOwner)
-                                    <a href="{{ route('profile.view', $offerOwner->id) }}" wire:navigate class="text-primary hover:underline">{{ $offerOwner->name }}</a>
+                                    <a href="{{ route('profile.view', $offerOwner->id) }}" wire:navigate class="text-primary hover:underline">{{ $offerOwner->nicknameOrName() }}</a>
                                 @else
                                     <span>Ein Mitglied</span>
                                 @endif
                                 und
                                 @if($requestOwner)
-                                    <a href="{{ route('profile.view', $requestOwner->id) }}" wire:navigate class="text-primary hover:underline">{{ $requestOwner->name }}</a>
+                                    <a href="{{ route('profile.view', $requestOwner->id) }}" wire:navigate class="text-primary hover:underline">{{ $requestOwner->nicknameOrName() }}</a>
                                 @else
                                     <span>ein weiteres Mitglied</span>
                                 @endif
@@ -218,7 +220,7 @@
                             <span>hat {{ $milestoneValue }} Baxx erreicht</span>
                         @endif
                     @elseif($activity->subject_type === \App\Models\User::class && $activity->action === 'member_approved')
-                        <span>Wir begrüßen unser neues Mitglied <a href="{{ route('profile.view', $subject->id) }}" wire:navigate class="text-primary hover:underline">{{ $subject->name }}</a></span>
+                        <span>Wir begrüßen unser neues Mitglied <a href="{{ route('profile.view', $subject->id) }}" wire:navigate class="text-primary hover:underline">{{ $subject->nicknameOrName() }}</a></span>
                     @endif
                 </div>
             </li>

--- a/resources/views/fanfiction/index.blade.php
+++ b/resources/views/fanfiction/index.blade.php
@@ -68,7 +68,7 @@
                                 @endif
                             </h3>
                             <p class="text-sm text-base-content">
-                                von <span class="font-medium">{{ $fanfiction->author_display_name }}</span>
+                                von <span class="font-medium">{{ $fanfiction->memberAuthorDisplayName() }}</span>
                                 @if ($fanfiction->published_at)
                                     • {{ $fanfiction->published_at->format('d.m.Y') }}
                                 @endif
@@ -167,11 +167,12 @@
                                 @else
                                     <div class="space-y-3">
                                         @foreach ($fanfiction->comments->take(3) as $comment)
+                                            @php $commentAuthorName = $comment->user?->nicknameOrName(); @endphp
                                             <div class="flex items-start gap-3 text-sm">
-                                                <x-avatar value="{{ $comment->user ? substr($comment->user->name, 0, 1) : '?' }}" class="!w-8 !h-8 !text-xs" />
+                                                <x-avatar value="{{ $commentAuthorName ? \Illuminate\Support\Str::substr($commentAuthorName, 0, 1) : '?' }}" class="!w-8 !h-8 !text-xs" />
                                                 <div class="flex-grow min-w-0">
                                                     <p class="font-medium">
-                                                        {{ $comment->user?->name ?? 'Unbekannt' }}
+                                                        {{ $commentAuthorName ?? 'Unbekannt' }}
                                                         <span class="font-normal text-base-content">
                                                             • {{ $comment->created_at->diffForHumans() }}
                                                         </span>

--- a/resources/views/fanfiction/show.blade.php
+++ b/resources/views/fanfiction/show.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-member-page class="max-w-4xl">
         @php
-            $pageDescription = 'von '.$fanfiction->author_display_name;
+            $pageDescription = 'von '.$fanfiction->memberAuthorDisplayName();
 
             if ($fanfiction->published_at) {
                 $pageDescription .= ' • Veröffentlicht am '.$fanfiction->published_at->format('d.m.Y');

--- a/resources/views/livewire/mitglieder-index.blade.php
+++ b/resources/views/livewire/mitglieder-index.blade.php
@@ -38,13 +38,13 @@
 
     @php
         $sortLabels = [
-            'nachname' => 'Nachname',
+            'name' => 'Nickname/Name',
             'mitglied_seit' => 'Mitglied seit',
             'role' => 'Rolle',
             'last_activity' => 'Zuletzt online',
             'mitgliedsbeitrag' => 'Beitrag',
         ];
-        $sortLabel = $sortLabels[$sortBy] ?? $sortLabels['nachname'];
+        $sortLabel = $sortLabels[$sortBy] ?? $sortLabels['name'];
         $directionLabel = $sortDir === 'desc' ? 'absteigender' : 'aufsteigender';
         $filterOnlineActive = $nurOnline;
         $filterSummary = $filterOnlineActive
@@ -149,7 +149,7 @@
     {{-- Echte Tabelle --}}
     <div wire:loading.remove wire:target="sort, nurOnline">
     @php
-        $nachnameSortState = $sortBy === 'nachname' ? ($sortDir === 'desc' ? 'descending' : 'ascending') : 'none';
+        $nameSortState = $sortBy === 'name' ? ($sortDir === 'desc' ? 'descending' : 'ascending') : 'none';
         $mitgliedSeitSortState = $sortBy === 'mitglied_seit' ? ($sortDir === 'desc' ? 'descending' : 'ascending') : 'none';
         $roleSortState = $sortBy === 'role' ? ($sortDir === 'desc' ? 'descending' : 'ascending') : 'none';
         $lastActivitySortState = $sortBy === 'last_activity' ? ($sortDir === 'desc' ? 'descending' : 'ascending') : 'none';
@@ -167,11 +167,11 @@
         aria-describedby="members-table-summary">
     <thead class="text-base-content">
     <tr>
-        <th scope="col" data-members-sort-column="nachname" aria-sort="{{ $nachnameSortState }}">
-            <button wire:click="sort('nachname')" type="button"
+        <th scope="col" data-members-sort-column="name" aria-sort="{{ $nameSortState }}">
+            <button wire:click="sort('name')" type="button"
                class="flex items-center group text-base-content hover:text-primary">
-                Name
-                @if($sortBy === 'nachname')
+                Nickname/Name
+                @if($sortBy === 'name')
                     <x-icon name="{{ $sortDir === 'asc' ? 'o-chevron-up' : 'o-chevron-down' }}" class="h-4 w-4 ml-1" />
                 @endif
             </button>
@@ -228,6 +228,7 @@
     @forelse($this->members as $member)
     @php
         $memberAlias = $member->displayAlias();
+        $memberDisplayName = $member->nicknameOrName();
         $memberAuthorAliases = collect($member->displayAliases())
             ->reject(fn (string $alias) => $memberAlias && $alias === $memberAlias)
             ->values();
@@ -237,15 +238,12 @@
         {{-- Name --}}
         <td>
             <a href="{{ route('profile.view', $member->id) }}" wire:navigate class="flex items-center">
-                <x-avatar :image="$member->profile_photo_url" :alt="$member->name" class="!w-10 !h-10" />
+                <x-avatar :image="$member->profile_photo_url" :alt="$memberDisplayName" class="!w-10 !h-10" />
                 <div class="ml-4">
                     <div class="font-medium text-base-content flex items-center">
                         <span class="inline-block w-2 h-2 rounded-full mr-2 {{ isset($this->onlineUserIdSet[$member->id]) ? 'bg-success' : 'bg-base-content/40' }}" title="{{ isset($this->onlineUserIdSet[$member->id]) ? 'Online' : 'Offline' }}"></span>
-                        {{ $member->name }}
+                        {{ $memberDisplayName }}
                     </div>
-                    @if($memberAlias)
-                        <div class="text-sm font-medium text-primary">Alias: {{ $memberAlias }}</div>
-                    @endif
                     @if($memberAuthorAliases->isNotEmpty())
                         <div class="mt-1 flex flex-wrap gap-1">
                             @foreach($memberAuthorAliases as $authorAlias)
@@ -253,7 +251,7 @@
                             @endforeach
                         </div>
                     @endif
-                    @if($this->canViewDetails)
+                    @if($this->canViewDetails && $memberAlias)
                     <div class="text-sm text-base-content">{{ $member->vorname }} {{ $member->nachname }}</div>
                     @endif
                 </div>
@@ -265,7 +263,7 @@
                             href="{{ $method['href'] }}"
                             @if(in_array($method['key'], ['maddraxikon', 'nextcloud'], true)) target="_blank" rel="noopener noreferrer" @endif
                             class="inline-flex items-center gap-1 rounded-full bg-base-200 px-2 py-1 text-xs text-base-content hover:bg-primary hover:text-primary-content"
-                            aria-label="{{ $method['label'] }} von {{ $member->name }}"
+                            aria-label="{{ $method['label'] }} von {{ $memberDisplayName }}"
                         >
                             <x-icon name="{{ $method['icon'] }}" class="h-3.5 w-3.5" />
                             <span>{{ $method['label'] }}</span>
@@ -414,9 +412,9 @@
         <div class="mb-4 bg-base-200 rounded-lg p-3">
             <h3 class="text-sm font-medium text-base-content mb-2">Sortieren nach:</h3>
             <div class="flex flex-wrap gap-2">
-                <button wire:click="sort('nachname')" type="button"
-                   class="px-3 py-1 text-xs rounded-full {{ $sortBy === 'nachname' ? 'bg-primary text-white' : 'bg-base-200 text-base-content' }}">
-                    Name {{ $sortBy === 'nachname' ? ($sortDir === 'asc' ? '↑' : '↓') : '' }}
+                <button wire:click="sort('name')" type="button"
+                   class="px-3 py-1 text-xs rounded-full {{ $sortBy === 'name' ? 'bg-primary text-white' : 'bg-base-200 text-base-content' }}">
+                    Nickname/Name {{ $sortBy === 'name' ? ($sortDir === 'asc' ? '↑' : '↓') : '' }}
                 </button>
                 <button wire:click="sort('mitglied_seit')" type="button"
                    class="px-3 py-1 text-xs rounded-full {{ $sortBy === 'mitglied_seit' ? 'bg-primary text-white' : 'bg-base-200 text-base-content' }}">
@@ -442,6 +440,7 @@
         @forelse($this->members as $member)
         @php
             $memberAlias = $member->displayAlias();
+            $memberDisplayName = $member->nicknameOrName();
             $memberAuthorAliases = collect($member->displayAliases())
                 ->reject(fn (string $alias) => $memberAlias && $alias === $memberAlias)
                 ->values();
@@ -449,14 +448,14 @@
         @endphp
         <x-ui.panel class="!p-4" wire:key="member-mobile-{{ $member->id }}">
             <a href="{{ route('profile.view', $member->id) }}" wire:navigate class="flex items-center mb-4">
-                <x-avatar :image="$member->profile_photo_url" :alt="$member->name" class="!w-12 !h-12" />
+                <x-avatar :image="$member->profile_photo_url" :alt="$memberDisplayName" class="!w-12 !h-12" />
                 <div class="ml-4">
                     <div class="font-medium text-base-content flex items-center">
                         <span class="inline-block w-2 h-2 rounded-full mr-2 {{ isset($this->onlineUserIdSet[$member->id]) ? 'bg-success' : 'bg-base-content/40' }}" title="{{ isset($this->onlineUserIdSet[$member->id]) ? 'Online' : 'Offline' }}"></span>
-                        {{ $member->name }}
+                        {{ $memberDisplayName }}
                     </div>
-                    @if($memberAlias)
-                        <div class="text-sm font-medium text-primary">Alias: {{ $memberAlias }}</div>
+                    @if($this->canViewDetails && $memberAlias)
+                        <div class="text-sm text-base-content">{{ $member->vorname }} {{ $member->nachname }}</div>
                     @endif
                     @if($memberAuthorAliases->isNotEmpty())
                         <div class="mt-1 flex flex-wrap gap-1">
@@ -479,7 +478,7 @@
                         href="{{ $method['href'] }}"
                         @if(in_array($method['key'], ['maddraxikon', 'nextcloud'], true)) target="_blank" rel="noopener noreferrer" @endif
                         class="inline-flex items-center gap-1 rounded-full bg-base-200 px-2 py-1 text-xs text-base-content hover:bg-primary hover:text-primary-content"
-                        aria-label="{{ $method['label'] }} von {{ $member->name }}"
+                        aria-label="{{ $method['label'] }} von {{ $memberDisplayName }}"
                     >
                         <x-icon name="{{ $method['icon'] }}" class="h-3.5 w-3.5" />
                         <span>{{ $method['label'] }}</span>

--- a/resources/views/livewire/rezension-show.blade.php
+++ b/resources/views/livewire/rezension-show.blade.php
@@ -10,7 +10,7 @@
             <h2 class="text-lg font-semibold text-base-content">{{ $review->title }}</h2>
             <p class="text-sm text-base-content">
                 von
-                <a href="{{ route('profile.view', $review->user->id) }}" wire:navigate class="text-primary hover:underline">{{ $review->user->name }}</a>
+                <a href="{{ route('profile.view', $review->user->id) }}" wire:navigate class="text-primary hover:underline">{{ $review->user->nicknameOrName() }}</a>
                 am {{ $review->created_at->format('d.m.Y H:i') }} Uhr
                 @if(!$review->created_at->eq($review->updated_at))
                     , geändert am {{ $review->updated_at->format('d.m.Y') }} um {{ $review->updated_at->format('H:i') }} Uhr

--- a/resources/views/reviews/partials/comment.blade.php
+++ b/resources/views/reviews/partials/comment.blade.php
@@ -3,7 +3,7 @@
 @endphp
 <div class="mt-4 bg-base-200 p-4 rounded">
     <p class="text-sm text-base-content">
-        <a href="{{ route('profile.view', $comment->user->id) }}" wire:navigate class="text-primary hover:underline">{{ $comment->user->name }}</a> am {{ $comment->created_at->format('d.m.Y H:i') }}
+        <a href="{{ route('profile.view', $comment->user->id) }}" wire:navigate class="text-primary hover:underline">{{ $comment->user->nicknameOrName() }}</a> am {{ $comment->created_at->format('d.m.Y H:i') }}
     </p>
     @isset($parentAuthor)
         <p class="text-xs text-base-content md:hidden">
@@ -53,7 +53,7 @@
             @include('reviews.partials.comment', [
                 'comment' => $child,
                 'role' => $role,
-                'parentAuthor' => $comment->user->name,
+                'parentAuthor' => $comment->user->nicknameOrName(),
                 'depth' => $nextDepth,
             ])
         </div>

--- a/tests/Feature/ActivityFeedTest.php
+++ b/tests/Feature/ActivityFeedTest.php
@@ -125,6 +125,7 @@ class ActivityFeedTest extends TestCase
         $book = Book::first();
 
         $user = $this->actingMember();
+        $user->update(['alias' => 'ReviewNick']);
         $this->actingAs($user);
 
         $review = Review::create([
@@ -149,7 +150,7 @@ class ActivityFeedTest extends TestCase
 
         $dashboard = $this->get('/dashboard');
         $dashboard->assertOk();
-        $dashboard->assertSeeTextInOrder(['Kommentar zu', 'Meine Rezension', 'von', $user->name]);
+        $dashboard->assertSeeTextInOrder(['Kommentar zu', 'Meine Rezension', 'von', 'ReviewNick']);
         $dashboard->assertSee('<a href="'.route('reviews.show', $review->book_id).'" wire:navigate class="text-info hover:underline">Meine Rezension</a>', false);
         $dashboard->assertSee('<a href="'.route('profile.view', $user->id).'" wire:navigate', false);
         $dashboard->assertSeeText('Tolles Buch!');
@@ -316,6 +317,7 @@ class ActivityFeedTest extends TestCase
     public function test_activity_created_and_displayed_for_reward_unlock(): void
     {
         $user = $this->actingMember();
+        $user->update(['alias' => 'RewardNick']);
         $this->actingAs($user);
 
         UserPoint::create([
@@ -343,7 +345,7 @@ class ActivityFeedTest extends TestCase
         $response = $this->get('/dashboard');
 
         $response->assertOk();
-        $response->assertSeeText($user->name);
+        $response->assertSeeText('RewardNick');
         $response->assertSeeText('Mitgliederkarte');
         $response->assertSeeText('freigeschaltet');
     }
@@ -440,6 +442,7 @@ class ActivityFeedTest extends TestCase
     public function test_dashboard_shows_fanfiction_comment_activity(): void
     {
         $user = $this->actingMember();
+        $user->update(['alias' => 'FanfictionNick']);
         $this->actingAs($user);
 
         $fanfiction = Fanfiction::factory()->published()->create([
@@ -465,7 +468,7 @@ class ActivityFeedTest extends TestCase
         $response = $this->get('/dashboard');
 
         $response->assertOk();
-        $response->assertSeeTextInOrder(['Kommentar zu', $fanfiction->title, 'von', $user->name]);
+        $response->assertSeeTextInOrder(['Kommentar zu', $fanfiction->title, 'von', 'FanfictionNick']);
         $response->assertSeeText(PreviewText::make($comment->content, 140));
     }
 
@@ -503,6 +506,8 @@ class ActivityFeedTest extends TestCase
     {
         $offerUser = $this->actingMember();
         $requestUser = $this->actingMember();
+        $offerUser->update(['alias' => 'AngebotNick']);
+        $requestUser->update(['alias' => 'GesuchNick']);
         $this->actingAs($offerUser);
 
         $offer = BookOffer::create([
@@ -543,8 +548,8 @@ class ActivityFeedTest extends TestCase
 
         $response->assertOk();
         $response->assertSeeText('Tausch erfolgreich abgeschlossen');
-        $response->assertSeeText($offerUser->name);
-        $response->assertSeeText($requestUser->name);
+        $response->assertSeeText('AngebotNick');
+        $response->assertSeeText('GesuchNick');
         $response->assertSeeText('haben ihren Romantausch bestätigt.');
         $response->assertSeeText('Maddrax 21');
         $response->assertDontSeeText('Unbekannter Nutzer');
@@ -584,6 +589,7 @@ class ActivityFeedTest extends TestCase
     public function test_dashboard_shows_baxx_milestone_activity(): void
     {
         $user = $this->actingMember();
+        $user->update(['alias' => 'MeilensteinNick']);
         $this->actingAs($user);
 
         UserPoint::create([
@@ -596,7 +602,7 @@ class ActivityFeedTest extends TestCase
         $response = $this->get('/dashboard');
 
         $response->assertOk();
-        $response->assertSeeText($user->name);
+        $response->assertSeeText('MeilensteinNick');
         $response->assertSeeText('100 Baxx erreicht');
         $response->assertSeeText('Meilenstein');
     }
@@ -654,6 +660,7 @@ class ActivityFeedTest extends TestCase
     public function test_dashboard_displays_fantreffen_registration_activity_without_profile_link(): void
     {
         $user = $this->actingMember();
+        $user->update(['alias' => 'FantreffenNick']);
         $this->actingAs($user);
 
         $anmeldung = FantreffenAnmeldung::create([
@@ -679,7 +686,7 @@ class ActivityFeedTest extends TestCase
         $response = $this->get('/dashboard');
 
         $response->assertOk();
-        $response->assertSeeText('Alex hat sich zum Fantreffen in Coellen angemeldet');
+        $response->assertSeeText('FantreffenNick hat sich zum Fantreffen in Coellen angemeldet');
         $response->assertDontSee('<a href="'.route('profile.view', $user->id).'"', false);
     }
 
@@ -824,8 +831,12 @@ class ActivityFeedTest extends TestCase
     {
         Mail::fake();
         $admin = $this->actingMember(Role::Admin);
+        $admin->update(['alias' => 'AdminNick']);
         $team = $admin->currentTeam;
-        $anwaerter = User::factory()->create(['current_team_id' => $team->id]);
+        $anwaerter = User::factory()->create([
+            'current_team_id' => $team->id,
+            'alias' => 'NeuNick',
+        ]);
         $team->users()->attach($anwaerter, ['role' => Role::Anwaerter->value]);
 
         $this->actingAs($admin)->post(route('anwaerter.approve', $anwaerter));
@@ -838,7 +849,8 @@ class ActivityFeedTest extends TestCase
         ]);
 
         $dashboard = $this->get('/dashboard');
-        $dashboard->assertSeeText('Wir begrüßen unser neues Mitglied '.$anwaerter->name);
+        $dashboard->assertSeeText('AdminNick');
+        $dashboard->assertSeeText('Wir begrüßen unser neues Mitglied NeuNick');
     }
 
     public function test_dashboard_shows_fallback_when_activity_subject_missing(): void

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -167,6 +167,10 @@ class DashboardTest extends TestCase
         $team = Team::membersTeam();
 
         $topUsers = User::factory()->count(3)->create(['current_team_id' => $team->id]);
+        $topUsers->first()->update([
+            'name' => 'Top Klarname',
+            'alias' => 'TopNickname',
+        ]);
 
         foreach ($topUsers as $index => $topUser) {
             $team->users()->attach($topUser, ['role' => Role::Mitglied->value]);
@@ -194,6 +198,7 @@ class DashboardTest extends TestCase
         $this->assertSame(1, $srSummary->count());
         $this->assertStringContainsString('Top 3 Baxx-Sammler', trim($srSummary->text()));
         $payload = json_decode($topList->attr('data-dashboard-top-users'), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame('Top Klarname', $payload[0]['name']);
         $this->assertSame('1.234', $payload[0]['formatted_points']);
         $this->assertSame(1234, $payload[0]['points']);
     }
@@ -227,6 +232,7 @@ class DashboardTest extends TestCase
         $user = User::factory()->create([
             'current_team_id' => $team->id,
             'vorname' => 'Alex',
+            'alias' => 'DashboardNick',
         ]);
         $team->users()->attach($user, ['role' => Role::Mitglied->value]);
 
@@ -234,6 +240,7 @@ class DashboardTest extends TestCase
 
         $response->assertOk();
         $response->assertSeeText('Willkommen zurück, Alex');
+        $response->assertDontSeeText('Willkommen zurück, DashboardNick');
         $response->assertSeeText('Schnellstart');
         $response->assertSeeText('Baxx verdienen');
         $response->assertSeeText('Aktuelle Veranstaltung ansehen');

--- a/tests/Feature/FanfictionControllerTest.php
+++ b/tests/Feature/FanfictionControllerTest.php
@@ -105,6 +105,59 @@ class FanfictionControllerTest extends TestCase
         $response->assertSee($fanfiction->title);
     }
 
+    public function test_member_pages_use_nicknames_while_public_teaser_keeps_name(): void
+    {
+        $this->member->update([
+            'name' => 'Mara Mitglied',
+            'alias' => 'MaddraxMara',
+        ]);
+        $commenter = User::factory()->create([
+            'name' => 'Karla Kommentar',
+            'alias' => 'KommentarKarla',
+        ]);
+        $fanfiction = Fanfiction::factory()->published()->create([
+            'team_id' => $this->memberTeam->id,
+            'user_id' => $this->member->id,
+            'created_by' => $this->member->id,
+            'title' => 'Nickname-Geschichte',
+        ]);
+        FanfictionComment::factory()->create([
+            'fanfiction_id' => $fanfiction->id,
+            'user_id' => $commenter->id,
+            'content' => 'Kommentar mit Nickname',
+        ]);
+
+        $this->get(route('fanfiction.public'))
+            ->assertOk()
+            ->assertSee('Mara Mitglied')
+            ->assertDontSee('MaddraxMara');
+
+        $this->actingAs($this->member)
+            ->get(route('fanfiction.index'))
+            ->assertOk()
+            ->assertSee('MaddraxMara')
+            ->assertSee('KommentarKarla');
+
+        $this->get(route('fanfiction.show', $fanfiction))
+            ->assertOk()
+            ->assertSee('MaddraxMara')
+            ->assertSee('KommentarKarla');
+    }
+
+    public function test_member_page_keeps_external_author_name(): void
+    {
+        $fanfiction = Fanfiction::factory()->published()->externalAuthor()->create([
+            'team_id' => $this->memberTeam->id,
+            'created_by' => $this->member->id,
+            'author_name' => 'Externe Autorin',
+        ]);
+
+        $this->actingAs($this->member)
+            ->get(route('fanfiction.show', $fanfiction))
+            ->assertOk()
+            ->assertSee('Externe Autorin');
+    }
+
     public function test_member_cannot_view_draft_fanfiction(): void
     {
         $fanfiction = Fanfiction::factory()->draft()->create([

--- a/tests/Feature/MemberMapCacheServiceTest.php
+++ b/tests/Feature/MemberMapCacheServiceTest.php
@@ -128,15 +128,28 @@ class MemberMapCacheServiceTest extends TestCase
             'lon' => 30.0,
             'current_team_id' => $team->id,
         ]);
+        $withCivilNameFallback = User::factory()->create([
+            'name' => '   ',
+            'alias' => '   ',
+            'vorname' => 'Civil',
+            'nachname' => 'Fallback',
+            'plz' => '33333',
+            'stadt' => 'Civil City',
+            'lat' => 30.0,
+            'lon' => 40.0,
+            'current_team_id' => $team->id,
+        ]);
 
         $team->users()->attach($withNickname, ['role' => Role::Mitglied->value]);
         $team->users()->attach($withoutNickname, ['role' => Role::Mitglied->value]);
+        $team->users()->attach($withCivilNameFallback, ['role' => Role::Mitglied->value]);
 
         $data = (new MemberMapCacheService)->getMemberMapData($team);
         $names = array_column($data['memberData'], 'name');
 
         $this->assertContains('Kiki', $names);
         $this->assertContains('Name Ohne Alias', $names);
+        $this->assertContains('Civil Fallback', $names);
         $this->assertNotContains('Klara Klarname', $names);
     }
 

--- a/tests/Feature/MemberMapCacheServiceTest.php
+++ b/tests/Feature/MemberMapCacheServiceTest.php
@@ -82,6 +82,43 @@ class MemberMapCacheServiceTest extends TestCase
         $this->assertEquals((float) self::DEFAULT_LON, $data['centerLon']);
     }
 
+    public function test_map_data_uses_nickname_with_name_fallback(): void
+    {
+        Cache::flush();
+
+        $team = Team::factory()->create();
+        $team->users()->detach();
+
+        $withNickname = User::factory()->create([
+            'name' => 'Klara Klarname',
+            'alias' => 'Kiki',
+            'plz' => '11111',
+            'stadt' => 'Nickname City',
+            'lat' => 10.0,
+            'lon' => 20.0,
+            'current_team_id' => $team->id,
+        ]);
+        $withoutNickname = User::factory()->create([
+            'name' => 'Name Ohne Alias',
+            'alias' => null,
+            'plz' => '22222',
+            'stadt' => 'Fallback City',
+            'lat' => 20.0,
+            'lon' => 30.0,
+            'current_team_id' => $team->id,
+        ]);
+
+        $team->users()->attach($withNickname, ['role' => Role::Mitglied->value]);
+        $team->users()->attach($withoutNickname, ['role' => Role::Mitglied->value]);
+
+        $data = (new MemberMapCacheService)->getMemberMapData($team);
+        $names = array_column($data['memberData'], 'name');
+
+        $this->assertContains('Kiki', $names);
+        $this->assertContains('Name Ohne Alias', $names);
+        $this->assertNotContains('Klara Klarname', $names);
+    }
+
     public function test_members_without_plz_or_with_anwaerter_role_are_excluded(): void
     {
         Cache::flush();

--- a/tests/Feature/MemberMapCacheServiceTest.php
+++ b/tests/Feature/MemberMapCacheServiceTest.php
@@ -14,6 +14,27 @@ class MemberMapCacheServiceTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function test_cached_map_data_is_retrieved_with_one_cache_read(): void
+    {
+        $team = Team::factory()->create();
+        $cachedData = [
+            'memberData' => [],
+            'centerLat' => 51.1657,
+            'centerLon' => 10.4515,
+        ];
+
+        Cache::shouldReceive('get')
+            ->once()
+            ->with("member_map_data_v2_team_{$team->id}")
+            ->andReturn($cachedData);
+        Cache::shouldReceive('has')->never();
+
+        $this->assertSame(
+            $cachedData,
+            (new MemberMapCacheService)->getMemberMapData($team)
+        );
+    }
+
     public function test_service_caches_and_refreshes_member_map_data(): void
     {
         Cache::flush();

--- a/tests/Feature/MitgliederIndexAccessibilityTest.php
+++ b/tests/Feature/MitgliederIndexAccessibilityTest.php
@@ -88,7 +88,7 @@ class MitgliederIndexAccessibilityTest extends TestCase
         $this->assertSame('descending', $mitgliedSeitHeader->attr('aria-sort'));
         $this->assertSame('col', $mitgliedSeitHeader->attr('scope'));
 
-        $nameHeader = $crawler->filter('[data-members-sort-column="nachname"]')->first();
+        $nameHeader = $crawler->filter('[data-members-sort-column="name"]')->first();
         $this->assertSame('none', $nameHeader->attr('aria-sort'));
     }
 
@@ -108,7 +108,7 @@ class MitgliederIndexAccessibilityTest extends TestCase
         $crawler = new Crawler($response->getContent());
         $table = $crawler->filter('[data-members-table]')->first();
 
-        $this->assertSame('nachname', $table->attr('data-members-sort'));
+        $this->assertSame('name', $table->attr('data-members-sort'));
         $this->assertSame('asc', $table->attr('data-members-dir'));
         $this->assertSame(
             (string) $team->activeUsers()->count(),

--- a/tests/Feature/MitgliederIndexLivewireTest.php
+++ b/tests/Feature/MitgliederIndexLivewireTest.php
@@ -70,6 +70,15 @@ class MitgliederIndexLivewireTest extends TestCase
         ]);
         $team->users()->attach($z, ['role' => Role::Kassenwart->value]);
 
+        $blankAlias = User::factory()->create([
+            'name' => 'Barry Blank',
+            'vorname' => 'Barry',
+            'nachname' => 'Blank',
+            'alias' => '   ',
+            'current_team_id' => $team->id,
+        ]);
+        $team->users()->attach($blankAlias, ['role' => Role::Mitglied->value]);
+
         $acting = $this->actingMember('Mitglied');
         $acting->update([
             'name' => 'Mike Member',
@@ -83,10 +92,57 @@ class MitgliederIndexLivewireTest extends TestCase
             ->set('sortDir', 'asc')
             ->assertSeeInOrder([
                 'Abby',
+                'Barry Blank',
                 'Holger Ehrmann',
                 'Mike Member',
                 'Zebra',
             ]);
+    }
+
+    public function test_visible_name_sort_runs_in_database_with_stable_id_tiebreaker(): void
+    {
+        $team = Team::membersTeam();
+
+        $first = User::factory()->create([
+            'name' => 'Anna Früh',
+            'vorname' => 'Anna',
+            'nachname' => 'Früh',
+            'alias' => 'Gleicher Nickname',
+            'current_team_id' => $team->id,
+        ]);
+        $team->users()->attach($first, ['role' => Role::Mitglied->value]);
+
+        $second = User::factory()->create([
+            'name' => 'Berta Spät',
+            'vorname' => 'Berta',
+            'nachname' => 'Spät',
+            'alias' => 'Gleicher Nickname',
+            'current_team_id' => $team->id,
+        ]);
+        $team->users()->attach($second, ['role' => Role::Mitglied->value]);
+
+        $this->actingAs($this->actingMember('Admin'));
+
+        DB::flushQueryLog();
+        DB::enableQueryLog();
+
+        Livewire::test(MitgliederIndex::class, ['sortBy' => 'name', 'sortDir' => 'desc'])
+            ->assertSeeInOrder(['Anna Früh', 'Berta Spät']);
+
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        $sortQuery = collect($queries)
+            ->pluck('query')
+            ->first(fn (string $query): bool => str_contains(
+                strtolower($query),
+                "coalesce(nullif(trim(users.alias), ''), trim(users.name)) desc"
+            ));
+
+        $this->assertNotNull($sortQuery);
+
+        $normalizedQuery = str_replace(['"', '`'], '', strtolower($sortQuery));
+        $this->assertStringContainsString('users.id asc', $normalizedQuery);
     }
 
     public function test_index_shows_alias_author_aliases_and_released_contact_links(): void

--- a/tests/Feature/MitgliederIndexLivewireTest.php
+++ b/tests/Feature/MitgliederIndexLivewireTest.php
@@ -48,7 +48,7 @@ class MitgliederIndexLivewireTest extends TestCase
             ]);
     }
 
-    public function test_index_sorts_members_by_nachname_asc(): void
+    public function test_index_sorts_members_by_visible_nickname_or_name_asc(): void
     {
         $team = Team::membersTeam();
 
@@ -56,6 +56,7 @@ class MitgliederIndexLivewireTest extends TestCase
             'name' => 'Anna Alpha',
             'vorname' => 'Anna',
             'nachname' => 'Alpha',
+            'alias' => 'Zebra',
             'current_team_id' => $team->id,
         ]);
         $team->users()->attach($a, ['role' => Role::Ehrenmitglied->value]);
@@ -64,6 +65,7 @@ class MitgliederIndexLivewireTest extends TestCase
             'name' => 'Zara Zulu',
             'vorname' => 'Zara',
             'nachname' => 'Zulu',
+            'alias' => 'Abby',
             'current_team_id' => $team->id,
         ]);
         $team->users()->attach($z, ['role' => Role::Kassenwart->value]);
@@ -77,13 +79,13 @@ class MitgliederIndexLivewireTest extends TestCase
         $this->actingAs($acting);
 
         Livewire::test(MitgliederIndex::class)
-            ->set('sortBy', 'nachname')
+            ->set('sortBy', 'name')
             ->set('sortDir', 'asc')
             ->assertSeeInOrder([
-                'Anna Alpha',
+                'Abby',
                 'Holger Ehrmann',
                 'Mike Member',
-                'Zara Zulu',
+                'Zebra',
             ]);
     }
 
@@ -108,12 +110,41 @@ class MitgliederIndexLivewireTest extends TestCase
         $this->actingAs($this->actingMember('Mitglied'));
 
         Livewire::test(MitgliederIndex::class)
-            ->assertSee('Alias: Stefan K')
+            ->assertSee('Stefan K')
+            ->assertDontSee('Alias: Stefan K')
+            ->assertDontSee('Stefan Kontakt')
             ->assertSee('Ian Rolf Hill')
             ->assertSee('Maddraxikon')
             ->assertSee('Nextcloud')
             ->assertSee('https://de.maddraxikon.com/index.php?title=Benutzer:Stefan_K', false)
             ->assertSee('https://cloud.maddrax-fanclub.de/u/Holger', false);
+    }
+
+    public function test_privileged_member_sees_nickname_and_civil_name(): void
+    {
+        $team = Team::membersTeam();
+        $member = User::factory()->create([
+            'name' => 'Stefan Kontakt',
+            'vorname' => 'Stefan',
+            'nachname' => 'Kontakt',
+            'alias' => 'Stefan K',
+            'current_team_id' => $team->id,
+        ]);
+        $team->users()->attach($member, ['role' => Role::Mitglied->value]);
+
+        $this->actingAs($this->actingMember('Admin'));
+
+        Livewire::test(MitgliederIndex::class)
+            ->assertSee('Stefan K')
+            ->assertSee('Stefan Kontakt');
+    }
+
+    public function test_legacy_nachname_sort_parameter_maps_to_visible_name(): void
+    {
+        $this->actingAs($this->actingMember('Mitglied'));
+
+        Livewire::test(MitgliederIndex::class, ['sortBy' => 'nachname'])
+            ->assertSet('sortBy', 'name');
     }
 
     public function test_index_sorts_members_by_last_activity_desc(): void
@@ -136,7 +167,7 @@ class MitgliederIndexLivewireTest extends TestCase
             ->assertSeeInOrder(['Ralf Recent', 'Olaf Old']);
     }
 
-    public function test_index_falls_back_to_nachname_on_invalid_sort(): void
+    public function test_index_falls_back_to_visible_name_on_invalid_sort(): void
     {
         $team = Team::membersTeam();
 
@@ -165,13 +196,13 @@ class MitgliederIndexLivewireTest extends TestCase
         $this->actingAs($acting);
 
         Livewire::test(MitgliederIndex::class, ['sortBy' => 'foo'])
-            ->assertSet('sortBy', 'nachname')
+            ->assertSet('sortBy', 'name')
             ->assertSet('sortDir', 'asc')
             ->assertSeeInOrder([
-                'Charlie Current',
-                'Holger Ehrmann',
                 'Alice First',
                 'Bob Second',
+                'Charlie Current',
+                'Holger Ehrmann',
             ]);
     }
 
@@ -223,11 +254,11 @@ class MitgliederIndexLivewireTest extends TestCase
         $this->actingAs($this->actingMember('Mitglied'));
 
         Livewire::test(MitgliederIndex::class)
-            ->assertSet('sortBy', 'nachname')
+            ->assertSet('sortBy', 'name')
             ->assertSet('sortDir', 'asc')
-            ->call('sort', 'nachname')
+            ->call('sort', 'name')
             ->assertSet('sortDir', 'desc')
-            ->call('sort', 'nachname')
+            ->call('sort', 'name')
             ->assertSet('sortDir', 'asc');
     }
 
@@ -236,7 +267,7 @@ class MitgliederIndexLivewireTest extends TestCase
         $this->actingAs($this->actingMember('Mitglied'));
 
         Livewire::test(MitgliederIndex::class)
-            ->assertSet('sortBy', 'nachname')
+            ->assertSet('sortBy', 'name')
             ->call('sort', 'mitglied_seit')
             ->assertSet('sortBy', 'mitglied_seit')
             ->assertSet('sortDir', 'asc');
@@ -258,6 +289,6 @@ class MitgliederIndexLivewireTest extends TestCase
 
         Livewire::test(MitgliederIndex::class)
             ->call('sort', 'email')
-            ->assertSet('sortBy', 'nachname');
+            ->assertSet('sortBy', 'name');
     }
 }

--- a/tests/Feature/MitgliederIndexLivewireTest.php
+++ b/tests/Feature/MitgliederIndexLivewireTest.php
@@ -79,6 +79,15 @@ class MitgliederIndexLivewireTest extends TestCase
         ]);
         $team->users()->attach($blankAlias, ['role' => Role::Mitglied->value]);
 
+        $civilFallback = User::factory()->create([
+            'name' => '   ',
+            'vorname' => 'Carl',
+            'nachname' => 'Civil',
+            'alias' => '   ',
+            'current_team_id' => $team->id,
+        ]);
+        $team->users()->attach($civilFallback, ['role' => Role::Mitglied->value]);
+
         $acting = $this->actingMember('Mitglied');
         $acting->update([
             'name' => 'Mike Member',
@@ -93,6 +102,7 @@ class MitgliederIndexLivewireTest extends TestCase
             ->assertSeeInOrder([
                 'Abby',
                 'Barry Blank',
+                'Carl Civil',
                 'Holger Ehrmann',
                 'Mike Member',
                 'Zebra',
@@ -134,15 +144,21 @@ class MitgliederIndexLivewireTest extends TestCase
 
         $sortQuery = collect($queries)
             ->pluck('query')
+            ->map(fn (string $query): string => str_replace(
+                ['"', '`', '[', ']'],
+                '',
+                strtolower($query)
+            ))
             ->first(fn (string $query): bool => str_contains(
-                strtolower($query),
-                "coalesce(nullif(trim(users.alias), ''), trim(users.name)) desc"
-            ));
+                $query,
+                "coalesce(nullif(trim(users.alias), ''), nullif(trim(users.name), '')"
+            ) && str_contains($query, ' desc'));
 
         $this->assertNotNull($sortQuery);
-
-        $normalizedQuery = str_replace(['"', '`'], '', strtolower($sortQuery));
-        $this->assertStringContainsString('users.id asc', $normalizedQuery);
+        $this->assertStringContainsString('users.vorname', $sortQuery);
+        $this->assertStringContainsString('users.nachname', $sortQuery);
+        $this->assertStringContainsString(strtolower(User::UNKNOWN_DISPLAY_NAME), $sortQuery);
+        $this->assertStringContainsString('users.id asc', $sortQuery);
     }
 
     public function test_index_shows_alias_author_aliases_and_released_contact_links(): void

--- a/tests/Feature/MitgliederKarteFeatureTest.php
+++ b/tests/Feature/MitgliederKarteFeatureTest.php
@@ -209,7 +209,7 @@ class MitgliederKarteFeatureTest extends TestCase
         $this->get('/mitglieder/karte');
 
         $team = Team::membersTeam();
-        $cacheKey = "member_map_data_team_{$team->id}";
+        $cacheKey = "member_map_data_v2_team_{$team->id}";
         $this->assertTrue(Cache::has($cacheKey));
     }
 
@@ -241,8 +241,8 @@ class MitgliederKarteFeatureTest extends TestCase
         $memberData = json_decode($response->viewData('memberData'), true);
 
         $this->assertContains('Musterstadt', array_column($memberData, 'city'));
-        $this->assertTrue(Cache::has("member_map_data_team_{$membersTeam->id}"));
-        $this->assertFalse(Cache::has("member_map_data_team_{$otherTeam->id}"));
+        $this->assertTrue(Cache::has("member_map_data_v2_team_{$membersTeam->id}"));
+        $this->assertFalse(Cache::has("member_map_data_v2_team_{$otherTeam->id}"));
     }
 
     public function test_map_view_contains_accessibility_attributes_and_data(): void

--- a/tests/Feature/RezensionLivewireTest.php
+++ b/tests/Feature/RezensionLivewireTest.php
@@ -10,6 +10,7 @@ use App\Mail\NewReviewNotification;
 use App\Models\Book;
 use App\Models\Review;
 use App\Models\ReviewBaxxSpecialOffer;
+use App\Models\ReviewComment;
 use App\Models\Team;
 use App\Models\User;
 use Carbon\Carbon;
@@ -450,7 +451,46 @@ class RezensionLivewireTest extends TestCase
         Livewire::actingAs($user)
             ->test(RezensionShow::class, ['book' => $book])
             ->assertSee('R')
+            ->assertSee($user->name)
             ->assertOk();
+    }
+
+    public function test_show_uses_nicknames_for_review_comments_and_replies(): void
+    {
+        $reviewer = $this->actingMember();
+        $reviewer->update(['name' => 'Rita Review', 'alias' => 'ReziRita']);
+        $commenter = User::factory()->create(['name' => 'Karl Kommentar', 'alias' => 'Kommentator']);
+        $replier = User::factory()->create(['name' => 'Anna Antwort', 'alias' => 'AntwortAss']);
+        $book = Book::create([
+            'roman_number' => 1,
+            'title' => 'Roman mit Nicknames',
+            'author' => 'Author',
+        ]);
+        $review = Review::create([
+            'team_id' => $reviewer->currentTeam->id,
+            'user_id' => $reviewer->id,
+            'book_id' => $book->id,
+            'title' => 'Nickname-Rezension',
+            'content' => str_repeat('A', 140),
+        ]);
+        $comment = ReviewComment::create([
+            'review_id' => $review->id,
+            'user_id' => $commenter->id,
+            'content' => 'Kommentar mit Nickname',
+        ]);
+        ReviewComment::create([
+            'review_id' => $review->id,
+            'user_id' => $replier->id,
+            'parent_id' => $comment->id,
+            'content' => 'Antwort mit Nickname',
+        ]);
+
+        Livewire::actingAs($reviewer)
+            ->test(RezensionShow::class, ['book' => $book])
+            ->assertSee('ReziRita')
+            ->assertSee('Kommentator')
+            ->assertSee('AntwortAss')
+            ->assertSee('Antwort auf Kommentator');
     }
 
     public function test_show_displays_update_information_when_review_was_edited(): void

--- a/tests/Feature/UpdateProfileInformationFormTest.php
+++ b/tests/Feature/UpdateProfileInformationFormTest.php
@@ -7,9 +7,11 @@ use App\Livewire\Profile\UpdateProfileInformationForm;
 use App\Mail\ProfileContactUpdated;
 use App\Models\Team;
 use App\Models\User;
+use App\Services\MemberMapCacheService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
@@ -226,6 +228,25 @@ class UpdateProfileInformationFormTest extends TestCase
         $this->assertSame('Stefan K', $user->alias);
         $this->assertSame([], $user->author_aliases);
         Mail::assertNotQueued(ProfileContactUpdated::class);
+    }
+
+    public function test_changing_alias_invalidates_member_map_cache(): void
+    {
+        Mail::fake();
+        $team = Team::membersTeam();
+        $this->actingAs($user = $this->createMember());
+        app(MemberMapCacheService::class)->getMemberMapData($team);
+        $cacheKey = "member_map_data_v2_team_{$team->id}";
+
+        $this->assertTrue(Cache::has($cacheKey));
+
+        Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', $this->profileFormData(['alias' => 'Neuer Nickname']))
+            ->call('updateProfileInformation')
+            ->assertHasNoErrors();
+
+        $this->assertSame('Neuer Nickname', $user->refresh()->alias);
+        $this->assertFalse(Cache::has($cacheKey));
     }
 
     public function test_ehrenmitglied_can_store_multiple_author_aliases(): void

--- a/tests/Feature/UpdateProfileInformationFormTest.php
+++ b/tests/Feature/UpdateProfileInformationFormTest.php
@@ -18,6 +18,7 @@ use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\Livewire;
 use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class UpdateProfileInformationFormTest extends TestCase
@@ -230,23 +231,72 @@ class UpdateProfileInformationFormTest extends TestCase
         Mail::assertNotQueued(ProfileContactUpdated::class);
     }
 
-    public function test_changing_alias_invalidates_member_map_cache(): void
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function memberMapCacheFieldProvider(): array
     {
+        return [
+            'alias' => ['alias', 'Neuer Nickname'],
+            'first name' => ['vorname', 'Moritz'],
+            'last name' => ['nachname', 'Musterfrau'],
+            'postal code' => ['plz', '54321'],
+            'city' => ['stadt', 'Neue Stadt'],
+            'country' => ['land', 'Schweiz'],
+        ];
+    }
+
+    #[DataProvider('memberMapCacheFieldProvider')]
+    public function test_changing_member_map_profile_field_invalidates_member_map_cache(
+        string $field,
+        string $newValue,
+    ): void {
         Mail::fake();
         $team = Team::membersTeam();
-        $this->actingAs($user = $this->createMember());
+        $this->actingAs($user = $this->createMember(attributes: [
+            'lat' => 50.0,
+            'lon' => 10.0,
+        ]));
         app(MemberMapCacheService::class)->getMemberMapData($team);
         $cacheKey = "member_map_data_v2_team_{$team->id}";
 
         $this->assertTrue(Cache::has($cacheKey));
 
         Livewire::test(UpdateProfileInformationForm::class)
-            ->set('state', $this->profileFormData(['alias' => 'Neuer Nickname']))
+            ->set('state', $this->profileFormData([
+                'alias' => $field === 'alias' ? $newValue : $user->alias,
+                $field => $newValue,
+            ]))
             ->call('updateProfileInformation')
             ->assertHasNoErrors();
 
-        $this->assertSame('Neuer Nickname', $user->refresh()->alias);
+        $this->assertSame($newValue, $user->refresh()->{$field});
         $this->assertFalse(Cache::has($cacheKey));
+    }
+
+    public function test_changing_unrelated_profile_field_keeps_member_map_cache(): void
+    {
+        Mail::fake();
+        $team = Team::membersTeam();
+        $this->actingAs($user = $this->createMember(attributes: [
+            'lat' => 50.0,
+            'lon' => 10.0,
+        ]));
+        app(MemberMapCacheService::class)->getMemberMapData($team);
+        $cacheKey = "member_map_data_v2_team_{$team->id}";
+
+        $this->assertTrue(Cache::has($cacheKey));
+
+        Livewire::test(UpdateProfileInformationForm::class)
+            ->set('state', $this->profileFormData([
+                'alias' => $user->alias,
+                'telefon' => '09876',
+            ]))
+            ->call('updateProfileInformation')
+            ->assertHasNoErrors();
+
+        $this->assertSame('09876', $user->refresh()->telefon);
+        $this->assertTrue(Cache::has($cacheKey));
     }
 
     public function test_ehrenmitglied_can_store_multiple_author_aliases(): void

--- a/tests/Unit/UserNicknameOrNameTest.php
+++ b/tests/Unit/UserNicknameOrNameTest.php
@@ -38,4 +38,28 @@ class UserNicknameOrNameTest extends TestCase
 
         $this->assertSame('Max Mustermann', $user->nicknameOrName());
     }
+
+    public function test_it_falls_back_to_the_civil_name_when_name_is_blank(): void
+    {
+        $user = new User([
+            'name' => '   ',
+            'alias' => '   ',
+            'vorname' => '  Max  ',
+            'nachname' => '  Mustermann  ',
+        ]);
+
+        $this->assertSame('Max Mustermann', $user->nicknameOrName());
+    }
+
+    public function test_it_returns_a_safe_placeholder_when_all_names_are_blank(): void
+    {
+        $user = new User([
+            'name' => '   ',
+            'alias' => null,
+            'vorname' => '   ',
+            'nachname' => null,
+        ]);
+
+        $this->assertSame(User::UNKNOWN_DISPLAY_NAME, $user->nicknameOrName());
+    }
 }

--- a/tests/Unit/UserNicknameOrNameTest.php
+++ b/tests/Unit/UserNicknameOrNameTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(User::class)]
+class UserNicknameOrNameTest extends TestCase
+{
+    public function test_it_prefers_a_trimmed_nickname(): void
+    {
+        $user = new User([
+            'name' => 'Max Mustermann',
+            'alias' => '  Maxi  ',
+        ]);
+
+        $this->assertSame('Maxi', $user->nicknameOrName());
+    }
+
+    public function test_it_falls_back_to_the_name_without_a_nickname(): void
+    {
+        $user = new User([
+            'name' => 'Max Mustermann',
+            'alias' => null,
+        ]);
+
+        $this->assertSame('Max Mustermann', $user->nicknameOrName());
+    }
+
+    public function test_it_falls_back_to_the_name_for_a_blank_nickname(): void
+    {
+        $user = new User([
+            'name' => '  Max Mustermann  ',
+            'alias' => '   ',
+        ]);
+
+        $this->assertSame('Max Mustermann', $user->nicknameOrName());
+    }
+}

--- a/tests/Vitest/mitglieder-accessibility.test.js
+++ b/tests/Vitest/mitglieder-accessibility.test.js
@@ -15,7 +15,7 @@ describe('buildMembersTableSummary', () => {
         expect(summary).toContain('3 Mitglieder');
     });
 
-    it('falls back to Nachname and ignores invalid totals', () => {
+    it('falls back to Nickname/Name and ignores invalid totals', () => {
         const summary = buildMembersTableSummary({
             sortBy: 'unbekannt',
             sortDir: 'asc',
@@ -23,7 +23,7 @@ describe('buildMembersTableSummary', () => {
             totalMembers: 'abc',
         });
 
-        expect(summary).toContain('Nachname');
+        expect(summary).toContain('Nickname/Name');
         expect(summary).toContain('aufsteigender');
         expect(summary).not.toContain('Mitglieder sichtbar. Insgesamt sind sichtbar.');
     });
@@ -54,7 +54,7 @@ describe('enhanceMembersTable', () => {
         const thead = document.createElement('thead');
         const row = document.createElement('tr');
         headerName = document.createElement('th');
-        headerName.dataset.membersSortColumn = 'nachname';
+        headerName.dataset.membersSortColumn = 'name';
         headerRole = document.createElement('th');
         headerRole.dataset.membersSortColumn = 'role';
 
@@ -88,7 +88,7 @@ describe('setupMitgliederAccessibility', () => {
                 <thead>
                     <tr>
                         <th data-members-sort-column="mitglied_seit"></th>
-                        <th data-members-sort-column="nachname"></th>
+                        <th data-members-sort-column="name"></th>
                     </tr>
                 </thead>
             </table>

--- a/tests/e2e/mitglieder.spec.js
+++ b/tests/e2e/mitglieder.spec.js
@@ -19,10 +19,10 @@ test.describe('Mitgliederliste', () => {
 
         const heading = page.locator('[data-members-heading]');
         await expect(heading).toBeVisible();
-        await expect(page.locator('[data-members-summary]')).toContainText('Mitgliederliste, sortiert nach Nachname');
-        await expect(page.locator('[data-members-table]')).toHaveAttribute('data-members-sort', 'nachname');
+        await expect(page.locator('[data-members-summary]')).toContainText('Mitgliederliste, sortiert nach Nickname/Name');
+        await expect(page.locator('[data-members-table]')).toHaveAttribute('data-members-sort', 'name');
 
-        const nameHeader = page.getByRole('columnheader', { name: 'Name' });
+        const nameHeader = page.getByRole('columnheader', { name: 'Nickname/Name' });
         await expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
 
         const onlineCheckbox = page.getByRole('checkbox', { name: 'Nur online' });


### PR DESCRIPTION
This pull request focuses on standardizing how member display names are determined and shown throughout the application, improving consistency and accessibility. It introduces a new `nicknameOrName()` method to the `User` model, updates sorting and display logic to use this method, and ensures member map data and UI components reflect these changes. Additionally, it improves cache management for member map data and updates UI labels for clarity.

**Display Name Standardization:**

* Added a `nicknameOrName()` method to the `User` model, which returns the user's alias if set, otherwise falls back to their name, civil name, or a default placeholder. This method is now used throughout the app for consistent member name display (`app/Models/User.php`, `app/Models/Fanfiction.php`, `resources/views/components/fanfiction-comment.blade.php`, `resources/views/dashboard/partials/activity-feed.blade.php`, `resources/views/fanfiction/index.blade.php`). [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR375-R396) [[2]](diffhunk://#diff-465be5b5f3537a00af438c29adc081ab0311568d152d91e8d4e3edf56490b5dfR113-R121) [[3]](diffhunk://#diff-c8e840a079b459fa7b6c92c3952d5c7f8ef7726f11ad9ab6298d1ce10e39bfbfR7-R23) [[4]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cR25) [[5]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL57-R58) [[6]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL74-R76) [[7]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL119-R121) [[8]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL144-R146) [[9]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL191-R199) [[10]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL221-R223) [[11]](diffhunk://#diff-dda826f53854c2cb7823858315205fa92b3c570c4644efa916c5ea69b57f8ab9L71-R71)

**Member Map Improvements:**

* Updated member map data to use the new display name logic, and included more user fields in the map cache. Introduced a cache version constant and improved cache key management, with explicit `invalidate()` and `refresh()` methods. The cache is now invalidated when a user's alias changes (`app/Services/MemberMapCacheService.php`, `app/Actions/Fortify/UpdateUserProfileInformation.php`). [[1]](diffhunk://#diff-402cc51902ba4b5b8ff2bfb810dbaff995ef1b46ce162bf908e5ddb71f8461dfR11-R24) [[2]](diffhunk://#diff-402cc51902ba4b5b8ff2bfb810dbaff995ef1b46ce162bf908e5ddb71f8461dfL45-R48) [[3]](diffhunk://#diff-402cc51902ba4b5b8ff2bfb810dbaff995ef1b46ce162bf908e5ddb71f8461dfL72-R89) [[4]](diffhunk://#diff-83aa1538b4dfb05f0a07973b306e51307a3a16212d1c29e2bc988f451affd0beR9) [[5]](diffhunk://#diff-83aa1538b4dfb05f0a07973b306e51307a3a16212d1c29e2bc988f451affd0beR20-R23) [[6]](diffhunk://#diff-83aa1538b4dfb05f0a07973b306e51307a3a16212d1c29e2bc988f451affd0beR127-R130)

**Sorting and Accessibility Updates:**

* Changed the default and allowed sort field for member lists from `nachname` to `name` (nickname/name), updated the sort expression to use the new display name logic, and adjusted accessibility labels and JS defaults accordingly (`app/Livewire/MitgliederIndex.php`, `resources/js/mitglieder/accessibility.js`). [[1]](diffhunk://#diff-83a19bc39e00ccfce48a7f3d40cf4f5e93680aa98a71a93d939b064d49d1a155L18-R19) [[2]](diffhunk://#diff-83a19bc39e00ccfce48a7f3d40cf4f5e93680aa98a71a93d939b064d49d1a155L31-R31) [[3]](diffhunk://#diff-83a19bc39e00ccfce48a7f3d40cf4f5e93680aa98a71a93d939b064d49d1a155R51-R57) [[4]](diffhunk://#diff-83a19bc39e00ccfce48a7f3d40cf4f5e93680aa98a71a93d939b064d49d1a155R80-R99) [[5]](diffhunk://#diff-362dec4212e1e6c10f910b95ade02097a3812c42ec1099f0ed698df462144874L2-R10) [[6]](diffhunk://#diff-362dec4212e1e6c10f910b95ade02097a3812c42ec1099f0ed698df462144874L28-R28) [[7]](diffhunk://#diff-362dec4212e1e6c10f910b95ade02097a3812c42ec1099f0ed698df462144874L98-R98)

**Fanfiction and Activity Feed Display:**

* Updated fanfiction and activity feed views to use the new display name logic for authors and users, ensuring consistent and user-friendly naming throughout the UI (`app/Models/Fanfiction.php`, `resources/views/fanfiction/index.blade.php`, `resources/views/dashboard/partials/activity-feed.blade.php`). [[1]](diffhunk://#diff-465be5b5f3537a00af438c29adc081ab0311568d152d91e8d4e3edf56490b5dfR113-R121) [[2]](diffhunk://#diff-dda826f53854c2cb7823858315205fa92b3c570c4644efa916c5ea69b57f8ab9L71-R71) [[3]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cR25) [[4]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL57-R58) [[5]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL74-R76) [[6]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL119-R121) [[7]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL144-R146) [[8]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL191-R199) [[9]](diffhunk://#diff-2924b353fff343db9daf6888f23e5eaebd88339abd67ba1a316d1db52828bc3cL221-R223)

**Constants and Refactoring:**

* Introduced a new constant `UNKNOWN_DISPLAY_NAME` to the `User` model for a standardized placeholder when no name information is available (`app/Models/User.php`).

These changes collectively enhance the user experience by ensuring names are displayed consistently and meaningfully across the platform, while also improving backend cache management and frontend accessibility.