### PR TITLE
Feature: Download of Novel Text in Kompendium for Admins

### DIFF
--- a/app/Http/Controllers/Admin/KompendiumRomanDownloadController.php
+++ b/app/Http/Controllers/Admin/KompendiumRomanDownloadController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\KompendiumRoman;
+use App\Services\KompendiumService;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class KompendiumRomanDownloadController extends Controller
+{
+    public function __invoke(KompendiumRoman $roman): StreamedResponse
+    {
+        abort_unless($this->hasValidStoragePath($roman), 404);
+
+        $disk = Storage::disk('private');
+
+        abort_unless($disk->exists($roman->dateipfad), 404);
+
+        return $disk->download($roman->dateipfad, $roman->dateiname, [
+            'Content-Type' => 'text/plain; charset=UTF-8',
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+    }
+
+    private function hasValidStoragePath(KompendiumRoman $roman): bool
+    {
+        if (! array_key_exists($roman->serie, KompendiumService::SERIEN)) {
+            return false;
+        }
+
+        if ($roman->dateiname === '' || ! str_ends_with(strtolower($roman->dateiname), '.txt')) {
+            return false;
+        }
+
+        if (preg_match('/[\x00-\x1F\x7F\/\\\\]/', $roman->dateiname) !== 0) {
+            return false;
+        }
+
+        $expectedPath = "romane/{$roman->serie}/{$roman->dateiname}";
+
+        return hash_equals($expectedPath, $roman->dateipfad);
+    }
+}

--- a/resources/views/livewire/kompendium-admin-dashboard.blade.php
+++ b/resources/views/livewire/kompendium-admin-dashboard.blade.php
@@ -285,6 +285,15 @@
                                     {{ $roman->hochgeladen_am->format('d.m.Y H:i') }}
                                 </td>
                                 <td class="text-right space-x-1">
+                                    <x-button
+                                        link="{{ route('kompendium.admin.romane.download', $roman) }}"
+                                        :no-wire-navigate="true"
+                                        icon="o-arrow-down-tray"
+                                        class="btn-ghost btn-xs"
+                                        title="Herunterladen"
+                                        aria-label="{{ $roman->titel }} herunterladen"
+                                        data-testid="download-btn-{{ $roman->id }}" />
+
                                     {{-- Bearbeiten (immer außer bei laufender Indexierung) --}}
                                     @if($roman->status !== 'indexierung_laeuft')
                                         <x-button

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Admin\DatabaseMaintenanceController;
+use App\Http\Controllers\Admin\KompendiumRomanDownloadController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\AdminMessageController;
 use App\Http\Controllers\ArbeitsgruppenController;
@@ -450,6 +451,10 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::get('admin', KompendiumAdminDashboard::class)
             ->middleware('admin')
             ->name('admin');
+
+        Route::get('admin/romane/{roman}/herunterladen', KompendiumRomanDownloadController::class)
+            ->middleware('admin')
+            ->name('admin.romane.download');
 
         Route::get('admin/suchstatistik', KompendiumSearchAnalyticsDashboard::class)
             ->middleware('admin')

--- a/tests/Feature/KompendiumRomanDownloadTest.php
+++ b/tests/Feature/KompendiumRomanDownloadTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Http\Controllers\Admin\KompendiumRomanDownloadController;
+use App\Models\KompendiumRoman;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Concerns\CreatesUserWithRole;
+use Tests\TestCase;
+
+#[CoversClass(KompendiumRomanDownloadController::class)]
+class KompendiumRomanDownloadTest extends TestCase
+{
+    use CreatesUserWithRole;
+    use RefreshDatabase;
+
+    private User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('private');
+        $this->admin = $this->createUserWithRole(Role::Admin);
+    }
+
+    public function test_admin_can_download_current_roman_file(): void
+    {
+        $roman = $this->createRoman();
+        Storage::disk('private')->put($roman->dateipfad, 'Aktueller Romantext');
+
+        $response = $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download', $roman));
+
+        $response->assertOk()
+            ->assertDownload($roman->dateiname)
+            ->assertHeader('Content-Type', 'text/plain; charset=UTF-8')
+            ->assertHeader('X-Content-Type-Options', 'nosniff');
+        $this->assertSame('Aktueller Romantext', $response->streamedContent());
+    }
+
+    public function test_download_uses_current_path_and_filename_after_rename(): void
+    {
+        $roman = $this->createRoman([
+            'dateiname' => '009 - Neuer Titel.txt',
+            'dateipfad' => 'romane/maddrax/009 - Neuer Titel.txt',
+            'roman_nr' => 9,
+            'titel' => 'Neuer Titel',
+        ]);
+        Storage::disk('private')->put('romane/maddrax/009 - Alter Titel.txt', 'Alter Romantext');
+        Storage::disk('private')->put($roman->dateipfad, 'Umbenannter Romantext');
+
+        $response = $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download', $roman));
+
+        $response->assertOk()
+            ->assertDownload('009 - Neuer Titel.txt');
+        $this->assertSame('Umbenannter Romantext', $response->streamedContent());
+    }
+
+    #[DataProvider('nonAdminRoles')]
+    public function test_non_admin_cannot_download_roman_file(Role $role): void
+    {
+        $roman = $this->createRoman();
+        Storage::disk('private')->put($roman->dateipfad, 'Geheimer Romantext');
+        $nonAdmin = $this->createUserWithRole($role);
+
+        $this->actingAs($nonAdmin)
+            ->get(route('kompendium.admin.romane.download', $roman))
+            ->assertForbidden();
+    }
+
+    public static function nonAdminRoles(): array
+    {
+        return [
+            'Mitglied' => [Role::Mitglied],
+            'Vorstand' => [Role::Vorstand],
+            'Kassenwart' => [Role::Kassenwart],
+            'Ehrenmitglied' => [Role::Ehrenmitglied],
+        ];
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $roman = $this->createRoman();
+
+        $this->get(route('kompendium.admin.romane.download', $roman))
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_unknown_roman_returns_not_found(): void
+    {
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download', ['roman' => 999999]))
+            ->assertNotFound();
+    }
+
+    public function test_missing_file_returns_not_found(): void
+    {
+        $roman = $this->createRoman();
+
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download', $roman))
+            ->assertNotFound();
+    }
+
+    #[DataProvider('unsafeStoredLocations')]
+    public function test_unsafe_stored_location_cannot_be_downloaded(
+        string $serie,
+        string $dateiname,
+        string $dateipfad,
+    ): void {
+        $roman = $this->createRoman([
+            'serie' => $serie,
+            'dateiname' => $dateiname,
+            'dateipfad' => $dateipfad,
+        ]);
+        Storage::disk('private')->put($dateipfad, 'Darf nicht ausgeliefert werden');
+
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download', $roman))
+            ->assertNotFound();
+    }
+
+    public static function unsafeStoredLocations(): array
+    {
+        return [
+            'unbekannte Serie' => [
+                'unbekannt',
+                '001 - Geheim.txt',
+                'romane/unbekannt/001 - Geheim.txt',
+            ],
+            'Unterverzeichnis im Dateinamen' => [
+                'maddrax',
+                'archiv/001 - Geheim.txt',
+                'romane/maddrax/archiv/001 - Geheim.txt',
+            ],
+            'Backslash im Dateinamen' => [
+                'maddrax',
+                'archiv\\001 - Geheim.txt',
+                'romane/maddrax/archiv\\001 - Geheim.txt',
+            ],
+            'andere Dateiendung' => [
+                'maddrax',
+                '001 - Geheim.html',
+                'romane/maddrax/001 - Geheim.html',
+            ],
+            'abweichender Dateipfad' => [
+                'maddrax',
+                '001 - Erwartet.txt',
+                'romane/maddrax/001 - Andere Datei.txt',
+            ],
+        ];
+    }
+
+    #[DataProvider('unsafePathsRejectedBeforeStorageAccess')]
+    public function test_unsafe_path_is_rejected_before_storage_access(
+        string $dateiname,
+        string $dateipfad,
+    ): void {
+        $roman = $this->createRoman([
+            'dateiname' => $dateiname,
+            'dateipfad' => $dateipfad,
+        ]);
+        Storage::shouldReceive('disk')->never();
+
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download', $roman))
+            ->assertNotFound();
+    }
+
+    public static function unsafePathsRejectedBeforeStorageAccess(): array
+    {
+        return [
+            'leerer Dateiname' => [
+                '',
+                'romane/maddrax/',
+            ],
+            'Traversal' => [
+                '001 - Geheim.txt',
+                'romane/maddrax/../001 - Geheim.txt',
+            ],
+            'Steuerzeichen' => [
+                "001 - Geheim\n.txt",
+                "romane/maddrax/001 - Geheim\n.txt",
+            ],
+        ];
+    }
+
+    public function test_admin_dashboard_shows_regular_download_link_for_running_indexation(): void
+    {
+        $roman = $this->createRoman(['status' => 'indexierung_laeuft']);
+        $downloadUrl = route('kompendium.admin.romane.download', $roman);
+
+        $response = $this->actingAs($this->admin)
+            ->get(route('kompendium.admin'));
+
+        $response->assertOk()
+            ->assertSee('data-testid="download-btn-'.$roman->id.'"', false)
+            ->assertSee('href="'.$downloadUrl.'"', false);
+
+        $this->assertMatchesRegularExpression(
+            '/<a(?=[^>]*data-testid="download-btn-'.$roman->id.'")(?=[^>]*href="'.preg_quote($downloadUrl, '/').'")(?![^>]*wire:navigate)[^>]*>/',
+            $response->getContent(),
+        );
+    }
+
+    private function createRoman(array $attributes = []): KompendiumRoman
+    {
+        return KompendiumRoman::query()->create(array_merge([
+            'dateiname' => '001 - Der Gott aus dem Eis.txt',
+            'dateipfad' => 'romane/maddrax/001 - Der Gott aus dem Eis.txt',
+            'serie' => 'maddrax',
+            'roman_nr' => 1,
+            'titel' => 'Der Gott aus dem Eis',
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $this->admin->id,
+            'status' => 'hochgeladen',
+        ], $attributes));
+    }
+}

--- a/tests/e2e/kompendium-admin.spec.js
+++ b/tests/e2e/kompendium-admin.spec.js
@@ -44,23 +44,23 @@ test.describe('Kompendium Admin Dashboard', () => {
         await expect(page.getByTestId('novels-table')).toBeVisible();
 
         // Prüfe auf Seeder-Daten - verwende spezifische Zelle
-        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis' })).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis', exact: true })).toBeVisible();
     });
 
     test('can filter by series', async ({ page }) => {
         await page.goto('/kompendium/admin');
 
         // Standard-Tab ist Maddrax - prüfe dass Maddrax-Roman sichtbar ist
-        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis' })).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis', exact: true })).toBeVisible();
 
         // Auf Mission Mars Tab klicken
         await page.getByTestId('tab-missionmars').click();
 
         // Warten bis Livewire die Mission-Mars-Daten gerendert hat
-        await expect(page.getByRole('cell', { name: 'Expedition zum roten Planeten' })).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Expedition zum roten Planeten', exact: true })).toBeVisible();
 
         // Maddrax Romane sollten nicht sichtbar sein
-        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis' })).not.toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis', exact: true })).not.toBeVisible();
     });
 
     test('can filter by status', async ({ page }) => {
@@ -71,10 +71,10 @@ test.describe('Kompendium Admin Dashboard', () => {
         await filterSection.getByLabel('Status').selectOption('indexiert');
 
         // Warten bis Livewire die gefilterten Daten gerendert hat
-        await expect(page.getByRole('cell', { name: 'Stadt ohne Hoffnung' })).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Stadt ohne Hoffnung', exact: true })).toBeVisible();
 
         // Nicht indexierter Roman sollte nicht sichtbar sein
-        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis' })).not.toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis', exact: true })).not.toBeVisible();
     });
 
     test('can search for novels', async ({ page }) => {
@@ -84,10 +84,10 @@ test.describe('Kompendium Admin Dashboard', () => {
         await page.getByTestId('search-input').fill('Dämonen');
 
         // Warten bis Livewire die Suche ausgeführt hat (debounce + Render)
-        await expect(page.getByRole('cell', { name: 'Dämonen der Vergangenheit' })).toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Dämonen der Vergangenheit', exact: true })).toBeVisible();
 
         // Andere Romane sollten nicht sichtbar sein
-        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis' })).not.toBeVisible();
+        await expect(page.getByRole('cell', { name: 'Der Gott aus dem Eis', exact: true })).not.toBeVisible();
     });
 
     test('shows status badges correctly', async ({ page }) => {
@@ -144,7 +144,10 @@ test.describe('Kompendium Admin Dashboard', () => {
         await filterSection.getByLabel('Status').selectOption('fehler');
 
         // Warten bis Livewire die Fehler-Romane gerendert hat
-        await expect(page.getByRole('cell', { name: 'Fehlerhafter Roman' })).toBeVisible();
+        const errorNovelCell = page.getByTestId('novels-table')
+            .getByRole('cell')
+            .filter({ hasText: 'Fehlerhafter Roman' });
+        await expect(errorNovelCell).toBeVisible();
     });
 
     test('admin link visible on kompendium page', async ({ page }) => {


### PR DESCRIPTION
This pull request adds a secure download feature for Kompendium Roman text files in the admin area, with robust validation and access control. It introduces a dedicated controller, route, UI integration, and comprehensive tests to ensure only valid, authorized downloads are possible. Additionally, it improves test precision in the E2E suite.

**Kompendium Roman Download Feature**

* Added `KompendiumRomanDownloadController` to handle secure downloads of Roman text files, including validation of series, filename, and storage path to prevent unauthorized access or path traversal.
* Registered a new admin route `admin/romane/{roman}/herunterladen` for downloading Roman files, protected by the `admin` middleware.
* Integrated the download button into the admin dashboard UI, always visible regardless of the Roman's indexation status.

**Testing and Validation**

* Added a comprehensive feature test suite (`KompendiumRomanDownloadTest`) covering access control (admin only), validation of storage paths, file existence, and UI integration.
* Improved E2E tests for the admin dashboard to use exact cell matching, reducing false positives and increasing reliability. [[1]](diffhunk://#diff-3bc2ae2b8b87cbd7ff614a59df9496e197c0e79527ff85d8a4b2f3f9efaf6047L47-R63) [[2]](diffhunk://#diff-3bc2ae2b8b87cbd7ff614a59df9496e197c0e79527ff85d8a4b2f3f9efaf6047L74-R77) [[3]](diffhunk://#diff-3bc2ae2b8b87cbd7ff614a59df9496e197c0e79527ff85d8a4b2f3f9efaf6047L87-R90) [[4]](diffhunk://#diff-3bc2ae2b8b87cbd7ff614a59df9496e197c0e79527ff85d8a4b2f3f9efaf6047L147-R150)

**Other**

* Registered the new controller in `routes/web.php`.