### PR TITLE
Feature: Download all Novel texts in Kompendium for Admins

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -34,6 +34,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.5'
+          extensions: zip
           tools: composer:v2
 
       - name: Setup Node.js

--- a/.github/workflows/performance-benchmark.yml
+++ b/.github/workflows/performance-benchmark.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.5'
+          extensions: zip
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.5'
-          extensions: intl
+          extensions: intl, zip
       - name: Copy .env
         run: php -r "file_exists('.env') || copy('.env.example', '.env');"
       - name: Cache Composer dependencies
@@ -56,7 +56,7 @@ jobs:
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.5'
-          extensions: gd, exif
+          extensions: gd, exif, zip
       - name: Generate ephemeral application key
         run: php -r "file_put_contents(getenv('GITHUB_ENV'), 'APP_KEY=base64:'.base64_encode(random_bytes(32)).PHP_EOL, FILE_APPEND);"
       - name: Copy .env
@@ -136,7 +136,7 @@ jobs:
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.5'
-          extensions: pdo_mysql
+          extensions: pdo_mysql, zip
       - name: Generate ephemeral application key
         run: php -r "file_put_contents(getenv('GITHUB_ENV'), 'APP_KEY=base64:'.base64_encode(random_bytes(32)).PHP_EOL, FILE_APPEND);"
       - name: Copy .env
@@ -169,6 +169,7 @@ jobs:
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.5'
+          extensions: zip
       - name: Generate ephemeral application key
         run: php -r "file_put_contents(getenv('GITHUB_ENV'), 'APP_KEY=base64:'.base64_encode(random_bytes(32)).PHP_EOL, FILE_APPEND);"
       - name: Copy .env
@@ -227,7 +228,7 @@ jobs:
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.5'
-          extensions: gd, exif
+          extensions: gd, exif, zip
           coverage: xdebug
           ini-values: xdebug.mode=coverage
       - name: Generate ephemeral application key

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.5'
+          extensions: zip
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: '.node-version'

--- a/.github/workflows/tia-baseline.yml
+++ b/.github/workflows/tia-baseline.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: '8.5'
-          extensions: gd, exif
+          extensions: gd, exif, zip
           coverage: xdebug
           ini-values: xdebug.mode=coverage
       - name: Generate ephemeral application key

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libwebp-dev \
     libonig-dev \
     libicu-dev \
+    libzip-dev \
     libsqlite3-dev \
     libxml2-dev \
     zip \
     unzip \
     mariadb-client \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
-    && docker-php-ext-install pdo_mysql pdo_sqlite mbstring exif pcntl bcmath gd sockets intl \
+    && docker-php-ext-install pdo_mysql pdo_sqlite mbstring exif pcntl bcmath gd sockets intl zip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Composer

--- a/app/Http/Controllers/Admin/KompendiumRomanArchiveDownloadController.php
+++ b/app/Http/Controllers/Admin/KompendiumRomanArchiveDownloadController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\KompendiumRomanArchiveException;
+use App\Services\KompendiumRomanArchiveService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class KompendiumRomanArchiveDownloadController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        KompendiumRomanArchiveService $archiveService,
+    ): BinaryFileResponse|RedirectResponse {
+        try {
+            $archive = $archiveService->create();
+        } catch (KompendiumRomanArchiveException $exception) {
+            Log::warning('Kompendium: ZIP-Export wurde abgebrochen.', [
+                'user_id' => $request->user()?->id,
+                'fehler' => $exception->getMessage(),
+            ]);
+
+            return redirect()
+                ->route('kompendium.admin')
+                ->with('error', $exception->getMessage());
+        }
+
+        return response()
+            ->download($archive->path, $archive->downloadName, [
+                'Content-Type' => 'application/zip',
+                'X-Content-Type-Options' => 'nosniff',
+            ])
+            ->deleteFileAfterSend(true);
+    }
+}

--- a/app/Http/Controllers/Admin/KompendiumRomanArchiveDownloadController.php
+++ b/app/Http/Controllers/Admin/KompendiumRomanArchiveDownloadController.php
@@ -22,6 +22,7 @@ class KompendiumRomanArchiveDownloadController extends Controller
             Log::warning('Kompendium: ZIP-Export wurde abgebrochen.', [
                 'user_id' => $request->user()?->id,
                 'fehler' => $exception->getMessage(),
+                'exception' => $exception,
             ]);
 
             return redirect()

--- a/app/Http/Controllers/Admin/KompendiumRomanDownloadController.php
+++ b/app/Http/Controllers/Admin/KompendiumRomanDownloadController.php
@@ -4,15 +4,17 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\KompendiumRoman;
-use App\Services\KompendiumService;
+use App\Services\KompendiumRomanFileValidator;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class KompendiumRomanDownloadController extends Controller
 {
-    public function __invoke(KompendiumRoman $roman): StreamedResponse
-    {
-        abort_unless($this->hasValidStoragePath($roman), 404);
+    public function __invoke(
+        KompendiumRoman $roman,
+        KompendiumRomanFileValidator $fileValidator,
+    ): StreamedResponse {
+        abort_unless($fileValidator->hasValidStoragePath($roman), 404);
 
         $disk = Storage::disk('private');
 
@@ -22,24 +24,5 @@ class KompendiumRomanDownloadController extends Controller
             'Content-Type' => 'text/plain; charset=UTF-8',
             'X-Content-Type-Options' => 'nosniff',
         ]);
-    }
-
-    private function hasValidStoragePath(KompendiumRoman $roman): bool
-    {
-        if (! array_key_exists($roman->serie, KompendiumService::SERIEN)) {
-            return false;
-        }
-
-        if ($roman->dateiname === '' || ! str_ends_with(strtolower($roman->dateiname), '.txt')) {
-            return false;
-        }
-
-        if (preg_match('/[\x00-\x1F\x7F\/\\\\]/', $roman->dateiname) !== 0) {
-            return false;
-        }
-
-        $expectedPath = "romane/{$roman->serie}/{$roman->dateiname}";
-
-        return hash_equals($expectedPath, $roman->dateipfad);
     }
 }

--- a/app/Services/KompendiumRomanArchiveException.php
+++ b/app/Services/KompendiumRomanArchiveException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Services;
+
+use RuntimeException;
+
+class KompendiumRomanArchiveException extends RuntimeException
+{
+    //
+}

--- a/app/Services/KompendiumRomanArchiveFile.php
+++ b/app/Services/KompendiumRomanArchiveFile.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Services;
+
+final readonly class KompendiumRomanArchiveFile
+{
+    public function __construct(
+        public string $path,
+        public string $downloadName,
+    ) {}
+}

--- a/app/Services/KompendiumRomanArchiveService.php
+++ b/app/Services/KompendiumRomanArchiveService.php
@@ -12,6 +12,7 @@ class KompendiumRomanArchiveService
     public function __construct(
         private readonly KompendiumRomanFileValidator $fileValidator,
         private readonly KompendiumRomanArchiveWriter $archiveWriter,
+        private readonly KompendiumRomanArchiveTemporaryFileFactory $temporaryFileFactory,
     ) {}
 
     public function create(): KompendiumRomanArchiveFile
@@ -86,12 +87,7 @@ class KompendiumRomanArchiveService
         }
 
         $temporaryDirectory = $disk->path('temp/kompendium-exports');
-        File::ensureDirectoryExists($temporaryDirectory, 0700);
-
-        $temporaryPath = @tempnam($temporaryDirectory, 'romane-');
-        if ($temporaryPath === false) {
-            throw new KompendiumRomanArchiveException('Das temporäre ZIP-Archiv konnte nicht angelegt werden.');
-        }
+        $temporaryPath = $this->temporaryFileFactory->create($temporaryDirectory);
 
         try {
             $this->archiveWriter->write($temporaryPath, $entries);

--- a/app/Services/KompendiumRomanArchiveService.php
+++ b/app/Services/KompendiumRomanArchiveService.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\KompendiumRoman;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+class KompendiumRomanArchiveService
+{
+    public function __construct(
+        private readonly KompendiumRomanFileValidator $fileValidator,
+        private readonly KompendiumRomanArchiveWriter $archiveWriter,
+    ) {}
+
+    public function create(): KompendiumRomanArchiveFile
+    {
+        try {
+            return $this->createArchive();
+        } catch (KompendiumRomanArchiveException $exception) {
+            throw $exception;
+        } catch (Throwable $exception) {
+            throw new KompendiumRomanArchiveException(
+                'Das ZIP-Archiv konnte nicht erstellt werden.',
+                previous: $exception,
+            );
+        }
+    }
+
+    private function createArchive(): KompendiumRomanArchiveFile
+    {
+        $romane = KompendiumRoman::query()
+            ->orderBy('serie')
+            ->orderBy('roman_nr')
+            ->orderBy('id')
+            ->get();
+
+        if ($romane->isEmpty()) {
+            throw new KompendiumRomanArchiveException('Es sind keine Romane für den ZIP-Export vorhanden.');
+        }
+
+        $disk = Storage::disk('private');
+        $entries = [];
+        $archivePaths = [];
+
+        foreach ($romane as $roman) {
+            if (! $this->fileValidator->hasValidStoragePath($roman)) {
+                throw new KompendiumRomanArchiveException(
+                    "Die Dateiinformationen für Roman #{$roman->id} sind ungültig. Der Export wurde abgebrochen.",
+                );
+            }
+
+            if (! $disk->exists($roman->dateipfad)) {
+                throw new KompendiumRomanArchiveException(
+                    "Die Datei \"{$roman->dateiname}\" fehlt. Der Export wurde abgebrochen.",
+                );
+            }
+
+            $sourcePath = $disk->path($roman->dateipfad);
+            if (! is_file($sourcePath) || ! is_readable($sourcePath)) {
+                throw new KompendiumRomanArchiveException(
+                    "Die Datei \"{$roman->dateiname}\" kann nicht gelesen werden. Der Export wurde abgebrochen.",
+                );
+            }
+
+            $seriesDirectory = KompendiumService::SERIEN[$roman->serie];
+            if (! $this->hasValidArchiveDirectory($seriesDirectory)) {
+                throw new KompendiumRomanArchiveException(
+                    "Der Serienname für Roman #{$roman->id} kann nicht sicher exportiert werden.",
+                );
+            }
+
+            $archivePath = $seriesDirectory.'/'.$roman->dateiname;
+            if (array_key_exists($archivePath, $archivePaths)) {
+                throw new KompendiumRomanArchiveException(
+                    "Der Archivpfad für Roman #{$roman->id} ist nicht eindeutig. Der Export wurde abgebrochen.",
+                );
+            }
+
+            $archivePaths[$archivePath] = true;
+            $entries[] = [
+                'sourcePath' => $sourcePath,
+                'archivePath' => $archivePath,
+            ];
+        }
+
+        $temporaryDirectory = $disk->path('temp/kompendium-exports');
+        File::ensureDirectoryExists($temporaryDirectory, 0700);
+
+        $temporaryPath = @tempnam($temporaryDirectory, 'romane-');
+        if ($temporaryPath === false) {
+            throw new KompendiumRomanArchiveException('Das temporäre ZIP-Archiv konnte nicht angelegt werden.');
+        }
+
+        try {
+            $this->archiveWriter->write($temporaryPath, $entries);
+        } catch (Throwable $exception) {
+            File::delete($temporaryPath);
+
+            if ($exception instanceof KompendiumRomanArchiveException) {
+                throw $exception;
+            }
+
+            throw new KompendiumRomanArchiveException(
+                'Das ZIP-Archiv konnte nicht erstellt werden.',
+                previous: $exception,
+            );
+        }
+
+        $archiveSize = @filesize($temporaryPath);
+        if (! is_file($temporaryPath) || ! is_readable($temporaryPath) || ! is_int($archiveSize) || $archiveSize <= 0) {
+            File::delete($temporaryPath);
+
+            throw new KompendiumRomanArchiveException('Das erstellte ZIP-Archiv ist ungültig.');
+        }
+
+        return new KompendiumRomanArchiveFile(
+            path: $temporaryPath,
+            downloadName: 'omxfc-kompendium-romane-'.now()->format('Y-m-d-His').'.zip',
+        );
+    }
+
+    private function hasValidArchiveDirectory(string $directory): bool
+    {
+        return $directory !== ''
+            && $directory !== '.'
+            && $directory !== '..'
+            && preg_match('/[\x00-\x1F\x7F\/\\\\]/', $directory) === 0;
+    }
+}

--- a/app/Services/KompendiumRomanArchiveTemporaryFileFactory.php
+++ b/app/Services/KompendiumRomanArchiveTemporaryFileFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services;
+
+use Throwable;
+
+class KompendiumRomanArchiveTemporaryFileFactory
+{
+    private const MAX_ATTEMPTS = 10;
+
+    public function create(string $directory): string
+    {
+        if (! is_dir($directory) && ! @mkdir($directory, 0700, true) && ! is_dir($directory)) {
+            throw new KompendiumRomanArchiveException(
+                'Das temporäre ZIP-Verzeichnis konnte nicht angelegt werden.',
+            );
+        }
+
+        for ($attempt = 0; $attempt < self::MAX_ATTEMPTS; $attempt++) {
+            $path = $this->candidatePath($directory);
+            $handle = @fopen($path, 'x+b');
+
+            if ($handle === false) {
+                clearstatcache(true, $path);
+
+                if (file_exists($path)) {
+                    continue;
+                }
+
+                throw new KompendiumRomanArchiveException(
+                    'Das temporäre ZIP-Archiv konnte nicht angelegt werden.',
+                );
+            }
+
+            $permissionsSet = @chmod($path, 0600);
+            $closed = @fclose($handle);
+
+            if (! $permissionsSet || ! $closed) {
+                @unlink($path);
+
+                throw new KompendiumRomanArchiveException(
+                    'Das temporäre ZIP-Archiv konnte nicht angelegt werden.',
+                );
+            }
+
+            return $path;
+        }
+
+        throw new KompendiumRomanArchiveException(
+            'Das temporäre ZIP-Archiv konnte nach mehreren Versuchen nicht angelegt werden.',
+        );
+    }
+
+    protected function candidatePath(string $directory): string
+    {
+        try {
+            $suffix = bin2hex(random_bytes(16));
+        } catch (Throwable $exception) {
+            throw new KompendiumRomanArchiveException(
+                'Das temporäre ZIP-Archiv konnte nicht sicher benannt werden.',
+                previous: $exception,
+            );
+        }
+
+        return rtrim($directory, DIRECTORY_SEPARATOR)
+            .DIRECTORY_SEPARATOR
+            .'romane-'.$suffix.'.zip';
+    }
+}

--- a/app/Services/KompendiumRomanArchiveWriter.php
+++ b/app/Services/KompendiumRomanArchiveWriter.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Services;
+
+use Throwable;
+use ZipArchive;
+
+class KompendiumRomanArchiveWriter
+{
+    /**
+     * @param  list<array{sourcePath: string, archivePath: string}>  $entries
+     */
+    public function write(string $archivePath, array $entries): void
+    {
+        $zip = new ZipArchive;
+        $openResult = @$zip->open($archivePath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+        if ($openResult !== true) {
+            throw new KompendiumRomanArchiveException('Das ZIP-Archiv konnte nicht erstellt werden.');
+        }
+
+        try {
+            foreach ($entries as $entry) {
+                if (! is_file($entry['sourcePath']) || ! is_readable($entry['sourcePath'])) {
+                    throw new KompendiumRomanArchiveException('Eine Roman-Datei konnte nicht zum ZIP-Archiv hinzugefügt werden.');
+                }
+
+                if (! @$zip->addFile($entry['sourcePath'], $entry['archivePath'])) {
+                    throw new KompendiumRomanArchiveException('Eine Roman-Datei konnte nicht zum ZIP-Archiv hinzugefügt werden.');
+                }
+            }
+
+            if (! @$zip->close()) {
+                throw new KompendiumRomanArchiveException('Das ZIP-Archiv konnte nicht abgeschlossen werden.');
+            }
+        } catch (Throwable $exception) {
+            try {
+                @$zip->close();
+            } catch (Throwable) {
+                // Das unvollständige Archiv wird vom aufrufenden Service entfernt.
+            }
+
+            if ($exception instanceof KompendiumRomanArchiveException) {
+                throw $exception;
+            }
+
+            throw new KompendiumRomanArchiveException(
+                'Das ZIP-Archiv konnte nicht erstellt werden.',
+                previous: $exception,
+            );
+        }
+    }
+}

--- a/app/Services/KompendiumRomanFileValidator.php
+++ b/app/Services/KompendiumRomanFileValidator.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\KompendiumRoman;
+
+class KompendiumRomanFileValidator
+{
+    public function hasValidStoragePath(KompendiumRoman $roman): bool
+    {
+        if (! array_key_exists($roman->serie, KompendiumService::SERIEN)) {
+            return false;
+        }
+
+        if ($roman->dateiname === '' || ! str_ends_with(strtolower($roman->dateiname), '.txt')) {
+            return false;
+        }
+
+        if (preg_match('/[\x00-\x1F\x7F\/\\\\]/', $roman->dateiname) !== 0) {
+            return false;
+        }
+
+        $expectedPath = "romane/{$roman->serie}/{$roman->dateiname}";
+
+        return hash_equals($expectedPath, $roman->dateipfad);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "license": "GPL-3.0-or-later",
     "require": {
+        "ext-zip": "*",
         "php": "~8.5.0",
         "dompdf/dompdf": "^3.1",
         "guzzlehttp/psr7": "^2.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cea56cd9983ff390a4c29884476c43f",
+    "content-hash": "0e60c46d5ac9a8cdd8a35300eb076b54",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -15112,6 +15112,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
+        "ext-zip": "*",
         "php": "~8.5.0"
     },
     "platform-dev": {},

--- a/docker/playwright-php.Dockerfile
+++ b/docker/playwright-php.Dockerfile
@@ -1,7 +1,10 @@
 FROM php:8.5-cli@sha256:58b996c35ce0511cdbaa1fc0476a194fd0221097d721ff7df5af0b6f1a3d0202
 
 # php:8.5-cli ships with sqlite3 and pdo_sqlite already enabled.
-RUN docker-php-ext-install bcmath \
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends libzip-dev \
+	&& docker-php-ext-install bcmath zip \
+	&& rm -rf /var/lib/apt/lists/* \
 	&& php -m | grep -q '^pdo_sqlite$' \
 	&& php -m | grep -q '^sqlite3$'
 

--- a/resources/views/livewire/kompendium-admin-dashboard.blade.php
+++ b/resources/views/livewire/kompendium-admin-dashboard.blade.php
@@ -9,6 +9,13 @@
         >
             <x-slot:actions>
                 <x-button label="Zurück zum Kompendium" link="{{ route('kompendium.index') }}" wire:navigate icon="o-arrow-left" class="btn-ghost" />
+                <x-button
+                    label="Alle Romane als ZIP"
+                    link="{{ route('kompendium.admin.romane.download-all') }}"
+                    :no-wire-navigate="true"
+                    icon="o-arrow-down-tray"
+                    class="btn-secondary"
+                    data-testid="download-all-novels" />
                 <x-button label="Suchstatistik" link="{{ route('kompendium.admin.search-statistics') }}" wire:navigate icon="o-chart-bar-square" class="btn-primary" />
             </x-slot:actions>
         </x-ui.page-header>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Admin\DatabaseMaintenanceController;
+use App\Http\Controllers\Admin\KompendiumRomanArchiveDownloadController;
 use App\Http\Controllers\Admin\KompendiumRomanDownloadController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\AdminMessageController;
@@ -455,6 +456,10 @@ Route::middleware(['auth', 'verified', 'redirect.if.anwaerter'])->group(function
         Route::get('admin/romane/{roman}/herunterladen', KompendiumRomanDownloadController::class)
             ->middleware('admin')
             ->name('admin.romane.download');
+
+        Route::get('admin/romane/herunterladen', KompendiumRomanArchiveDownloadController::class)
+            ->middleware('admin')
+            ->name('admin.romane.download-all');
 
         Route::get('admin/suchstatistik', KompendiumSearchAnalyticsDashboard::class)
             ->middleware('admin')

--- a/tests/Feature/KompendiumRomanArchiveDownloadTest.php
+++ b/tests/Feature/KompendiumRomanArchiveDownloadTest.php
@@ -6,6 +6,7 @@ use App\Enums\Role;
 use App\Http\Controllers\Admin\KompendiumRomanArchiveDownloadController;
 use App\Models\KompendiumRoman;
 use App\Models\User;
+use App\Services\KompendiumRomanArchiveException;
 use App\Services\KompendiumRomanArchiveService;
 use App\Services\KompendiumRomanArchiveWriter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -275,7 +276,10 @@ class KompendiumRomanArchiveDownloadTest extends TestCase
             ->once()
             ->withArgs(fn (string $message, array $context): bool => $message === 'Kompendium: ZIP-Export wurde abgebrochen.'
                 && $context['user_id'] === $this->admin->id
-                && $context['fehler'] === 'Das ZIP-Archiv konnte nicht erstellt werden.');
+                && $context['fehler'] === 'Das ZIP-Archiv konnte nicht erstellt werden.'
+                && $context['exception'] instanceof KompendiumRomanArchiveException
+                && $context['exception']->getPrevious() instanceof RuntimeException
+                && $context['exception']->getPrevious()->getMessage() === 'Interner technischer Fehler');
     }
 
     public function test_empty_archive_created_by_writer_is_rejected_and_removed(): void

--- a/tests/Feature/KompendiumRomanArchiveDownloadTest.php
+++ b/tests/Feature/KompendiumRomanArchiveDownloadTest.php
@@ -1,0 +1,345 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Http\Controllers\Admin\KompendiumRomanArchiveDownloadController;
+use App\Models\KompendiumRoman;
+use App\Models\User;
+use App\Services\KompendiumRomanArchiveService;
+use App\Services\KompendiumRomanArchiveWriter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Tests\Concerns\CreatesUserWithRole;
+use Tests\TestCase;
+use ZipArchive;
+
+#[CoversClass(KompendiumRomanArchiveDownloadController::class)]
+#[CoversClass(KompendiumRomanArchiveService::class)]
+class KompendiumRomanArchiveDownloadTest extends TestCase
+{
+    use CreatesUserWithRole;
+    use RefreshDatabase;
+
+    private User $admin;
+
+    /** @var list<string> */
+    private array $archivePaths = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('private');
+        Log::spy();
+        $this->admin = $this->createUserWithRole(Role::Admin);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->archivePaths as $archivePath) {
+            File::delete($archivePath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_admin_can_download_all_novels_grouped_by_readable_series_name(): void
+    {
+        $maddrax = $this->createRoman([
+            'dateiname' => '001 - Der Gott aus dem Eis.txt',
+            'dateipfad' => 'romane/maddrax/001 - Der Gott aus dem Eis.txt',
+            'serie' => 'maddrax',
+            'roman_nr' => 1,
+            'titel' => 'Der Gott aus dem Eis',
+            'status' => 'hochgeladen',
+        ]);
+        $missionMars = $this->createRoman([
+            'dateiname' => '002 - Der rote Planet.txt',
+            'dateipfad' => 'romane/missionmars/002 - Der rote Planet.txt',
+            'serie' => 'missionmars',
+            'roman_nr' => 2,
+            'titel' => 'Der rote Planet',
+            'status' => 'indexiert',
+        ]);
+        $volkDerTiefe = $this->createRoman([
+            'dateiname' => '003 - Rückkehr.txt',
+            'dateipfad' => 'romane/volkdertiefe/003 - Rückkehr.txt',
+            'serie' => 'volkdertiefe',
+            'roman_nr' => 3,
+            'titel' => 'Rückkehr',
+            'status' => 'fehler',
+        ]);
+        $hardcover = $this->createRoman([
+            'dateiname' => '004 - Sonderband.txt',
+            'dateipfad' => 'romane/hardcovers/004 - Sonderband.txt',
+            'serie' => 'hardcovers',
+            'roman_nr' => 4,
+            'titel' => 'Sonderband',
+            'status' => 'indexierung_laeuft',
+        ]);
+
+        Storage::disk('private')->put($maddrax->dateipfad, 'Maddrax-Inhalt');
+        Storage::disk('private')->put($missionMars->dateipfad, 'Mission-Mars-Inhalt');
+        Storage::disk('private')->put($volkDerTiefe->dateipfad, 'Inhalt mit Umlauten: äöüß');
+        Storage::disk('private')->put($hardcover->dateipfad, 'Hardcover-Inhalt');
+
+        $this->travelTo('2026-08-05 14:30:12');
+        $response = $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download-all'));
+
+        $response->assertOk()
+            ->assertDownload('omxfc-kompendium-romane-2026-08-05-143012.zip')
+            ->assertHeader('Content-Type', 'application/zip')
+            ->assertHeader('X-Content-Type-Options', 'nosniff');
+
+        $binaryResponse = $response->baseResponse;
+        $this->assertInstanceOf(BinaryFileResponse::class, $binaryResponse);
+        $this->assertTrue($binaryResponse->shouldDeleteFileAfterSend());
+
+        $archivePath = $binaryResponse->getFile()->getPathname();
+        $this->archivePaths[] = $archivePath;
+
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open($archivePath));
+        $this->assertSame(4, $zip->numFiles);
+        $this->assertSame(
+            'Maddrax-Inhalt',
+            $zip->getFromName('Maddrax - Die dunkle Zukunft der Erde/001 - Der Gott aus dem Eis.txt'),
+        );
+        $this->assertSame(
+            'Mission-Mars-Inhalt',
+            $zip->getFromName('Mission Mars/002 - Der rote Planet.txt'),
+        );
+        $this->assertSame(
+            'Inhalt mit Umlauten: äöüß',
+            $zip->getFromName('Das Volk der Tiefe/003 - Rückkehr.txt'),
+        );
+        $this->assertSame('Hardcover-Inhalt', $zip->getFromName('Hardcovers/004 - Sonderband.txt'));
+        $this->assertTrue($zip->close());
+    }
+
+    #[DataProvider('nonAdminRoles')]
+    public function test_non_admin_cannot_download_archive(Role $role): void
+    {
+        $nonAdmin = $this->createUserWithRole($role);
+
+        $this->actingAs($nonAdmin)
+            ->get(route('kompendium.admin.romane.download-all'))
+            ->assertForbidden();
+    }
+
+    public static function nonAdminRoles(): array
+    {
+        return [
+            'Mitglied' => [Role::Mitglied],
+            'Vorstand' => [Role::Vorstand],
+            'Kassenwart' => [Role::Kassenwart],
+            'Ehrenmitglied' => [Role::Ehrenmitglied],
+        ];
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('kompendium.admin.romane.download-all'))
+            ->assertRedirect(route('login'));
+    }
+
+    public function test_empty_database_aborts_export(): void
+    {
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download-all'))
+            ->assertRedirect(route('kompendium.admin'))
+            ->assertSessionHas('error', 'Es sind keine Romane für den ZIP-Export vorhanden.');
+    }
+
+    public function test_missing_source_file_aborts_entire_export(): void
+    {
+        $available = $this->createRoman();
+        Storage::disk('private')->put($available->dateipfad, 'Vorhanden');
+
+        $this->createRoman([
+            'dateiname' => '002 - Fehlt.txt',
+            'dateipfad' => 'romane/maddrax/002 - Fehlt.txt',
+            'roman_nr' => 2,
+            'titel' => 'Fehlt',
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download-all'))
+            ->assertRedirect(route('kompendium.admin'))
+            ->assertSessionHas('error', 'Die Datei "002 - Fehlt.txt" fehlt. Der Export wurde abgebrochen.');
+
+        $this->assertNoTemporaryArchivesExist();
+    }
+
+    #[DataProvider('unsafeStoredLocations')]
+    public function test_unsafe_stored_location_aborts_export(
+        string $serie,
+        string $dateiname,
+        string $dateipfad,
+    ): void {
+        $roman = $this->createRoman([
+            'serie' => $serie,
+            'dateiname' => $dateiname,
+            'dateipfad' => $dateipfad,
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download-all'))
+            ->assertRedirect(route('kompendium.admin'))
+            ->assertSessionHas(
+                'error',
+                "Die Dateiinformationen für Roman #{$roman->id} sind ungültig. Der Export wurde abgebrochen.",
+            );
+
+        $this->assertNoTemporaryArchivesExist();
+    }
+
+    public static function unsafeStoredLocations(): array
+    {
+        return [
+            'unbekannte Serie' => [
+                'unbekannt',
+                '001 - Geheim.txt',
+                'romane/unbekannt/001 - Geheim.txt',
+            ],
+            'Unterverzeichnis im Dateinamen' => [
+                'maddrax',
+                'archiv/001 - Geheim.txt',
+                'romane/maddrax/archiv/001 - Geheim.txt',
+            ],
+            'Backslash im Dateinamen' => [
+                'maddrax',
+                'archiv\\001 - Geheim.txt',
+                'romane/maddrax/archiv\\001 - Geheim.txt',
+            ],
+            'andere Dateiendung' => [
+                'maddrax',
+                '001 - Geheim.html',
+                'romane/maddrax/001 - Geheim.html',
+            ],
+            'abweichender Dateipfad' => [
+                'maddrax',
+                '001 - Erwartet.txt',
+                'romane/maddrax/001 - Andere Datei.txt',
+            ],
+            'Steuerzeichen' => [
+                'maddrax',
+                "001 - Geheim\n.txt",
+                "romane/maddrax/001 - Geheim\n.txt",
+            ],
+        ];
+    }
+
+    public function test_directory_instead_of_source_file_aborts_export(): void
+    {
+        $roman = $this->createRoman();
+        Storage::disk('private')->makeDirectory($roman->dateipfad);
+
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download-all'))
+            ->assertRedirect(route('kompendium.admin'))
+            ->assertSessionHas(
+                'error',
+                'Die Datei "001 - Der Gott aus dem Eis.txt" kann nicht gelesen werden. Der Export wurde abgebrochen.',
+            );
+
+        $this->assertNoTemporaryArchivesExist();
+    }
+
+    public function test_writer_failure_removes_temporary_archive_and_is_logged(): void
+    {
+        $roman = $this->createRoman();
+        Storage::disk('private')->put($roman->dateipfad, 'Inhalt');
+
+        $this->mock(KompendiumRomanArchiveWriter::class, function ($mock): void {
+            $mock->shouldReceive('write')
+                ->once()
+                ->andThrow(new RuntimeException('Interner technischer Fehler'));
+        });
+
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download-all'))
+            ->assertRedirect(route('kompendium.admin'))
+            ->assertSessionHas('error', 'Das ZIP-Archiv konnte nicht erstellt werden.');
+
+        $this->assertNoTemporaryArchivesExist();
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message, array $context): bool => $message === 'Kompendium: ZIP-Export wurde abgebrochen.'
+                && $context['user_id'] === $this->admin->id
+                && $context['fehler'] === 'Das ZIP-Archiv konnte nicht erstellt werden.');
+    }
+
+    public function test_empty_archive_created_by_writer_is_rejected_and_removed(): void
+    {
+        $roman = $this->createRoman();
+        Storage::disk('private')->put($roman->dateipfad, 'Inhalt');
+
+        $this->mock(KompendiumRomanArchiveWriter::class, function ($mock): void {
+            $mock->shouldReceive('write')->once();
+        });
+
+        $this->actingAs($this->admin)
+            ->get(route('kompendium.admin.romane.download-all'))
+            ->assertRedirect(route('kompendium.admin'))
+            ->assertSessionHas('error', 'Das erstellte ZIP-Archiv ist ungültig.');
+
+        $this->assertNoTemporaryArchivesExist();
+    }
+
+    public function test_admin_dashboard_shows_unfiltered_archive_download_link(): void
+    {
+        $downloadUrl = route('kompendium.admin.romane.download-all');
+
+        $response = $this->actingAs($this->admin)
+            ->get(route('kompendium.admin', [
+                'filterSerie' => 'missionmars',
+                'filterStatus' => 'indexiert',
+                'suchbegriff' => 'Mars',
+            ]));
+
+        $response->assertOk()
+            ->assertSee('data-testid="download-all-novels"', false)
+            ->assertSee('href="'.$downloadUrl.'"', false);
+
+        $this->assertMatchesRegularExpression(
+            '/<a(?=[^>]*data-testid="download-all-novels")(?=[^>]*href="'.preg_quote($downloadUrl, '/').'")(?![^>]*wire:navigate)[^>]*>/',
+            $response->getContent(),
+        );
+    }
+
+    private function createRoman(array $attributes = []): KompendiumRoman
+    {
+        return KompendiumRoman::query()->create(array_merge([
+            'dateiname' => '001 - Der Gott aus dem Eis.txt',
+            'dateipfad' => 'romane/maddrax/001 - Der Gott aus dem Eis.txt',
+            'serie' => 'maddrax',
+            'roman_nr' => 1,
+            'titel' => 'Der Gott aus dem Eis',
+            'hochgeladen_am' => now(),
+            'hochgeladen_von' => $this->admin->id,
+            'status' => 'hochgeladen',
+        ], $attributes));
+    }
+
+    private function assertNoTemporaryArchivesExist(): void
+    {
+        $temporaryDirectory = Storage::disk('private')->path('temp/kompendium-exports');
+
+        if (! is_dir($temporaryDirectory)) {
+            $this->assertDirectoryDoesNotExist($temporaryDirectory);
+
+            return;
+        }
+
+        $this->assertSame([], File::files($temporaryDirectory));
+    }
+}

--- a/tests/Unit/KompendiumRomanArchiveTemporaryFileFactoryTest.php
+++ b/tests/Unit/KompendiumRomanArchiveTemporaryFileFactoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\KompendiumRomanArchiveException;
+use App\Services\KompendiumRomanArchiveTemporaryFileFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(KompendiumRomanArchiveTemporaryFileFactory::class)]
+class KompendiumRomanArchiveTemporaryFileFactoryTest extends TestCase
+{
+    private string $temporaryDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->temporaryDirectory = sys_get_temp_dir()
+            .'/kompendium-archive-factory-'.bin2hex(random_bytes(8));
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->temporaryDirectory)) {
+            foreach (new \FilesystemIterator($this->temporaryDirectory) as $file) {
+                if ($file->isFile()) {
+                    unlink($file->getPathname());
+                }
+            }
+
+            rmdir($this->temporaryDirectory);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_it_atomically_creates_a_private_file_in_the_requested_directory(): void
+    {
+        $path = (new KompendiumRomanArchiveTemporaryFileFactory)->create($this->temporaryDirectory);
+
+        $this->assertFileExists($path);
+        $this->assertSame(realpath($this->temporaryDirectory), realpath(dirname($path)));
+        $this->assertMatchesRegularExpression('/\/romane-[a-f0-9]{32}\.zip$/', $path);
+        $this->assertSame(0600, fileperms($path) & 0777);
+    }
+
+    public function test_it_retries_with_a_new_name_without_overwriting_a_collision(): void
+    {
+        $this->assertTrue(mkdir($this->temporaryDirectory, 0700, true));
+        $collisionPath = $this->temporaryDirectory.'/romane-collision.zip';
+        $expectedPath = $this->temporaryDirectory.'/romane-available.zip';
+        $this->assertNotFalse(file_put_contents($collisionPath, 'bestehende Datei'));
+
+        $factory = $this->factoryWithCandidates([$collisionPath, $expectedPath]);
+
+        $this->assertSame($expectedPath, $factory->create($this->temporaryDirectory));
+        $this->assertSame('bestehende Datei', file_get_contents($collisionPath));
+        $this->assertFileExists($expectedPath);
+    }
+
+    public function test_it_aborts_after_repeated_name_collisions(): void
+    {
+        $this->assertTrue(mkdir($this->temporaryDirectory, 0700, true));
+        $collisionPath = $this->temporaryDirectory.'/romane-collision.zip';
+        $this->assertNotFalse(file_put_contents($collisionPath, 'bestehende Datei'));
+
+        $factory = $this->factoryWithCandidates(array_fill(0, 10, $collisionPath));
+
+        $this->expectException(KompendiumRomanArchiveException::class);
+        $this->expectExceptionMessage('nach mehreren Versuchen nicht angelegt');
+
+        $factory->create($this->temporaryDirectory);
+    }
+
+    public function test_it_reports_a_non_collision_creation_failure_immediately(): void
+    {
+        $factory = $this->factoryWithCandidates([
+            $this->temporaryDirectory.'/fehlendes-unterverzeichnis/romane.zip',
+        ]);
+
+        $this->expectException(KompendiumRomanArchiveException::class);
+        $this->expectExceptionMessage('Das temporäre ZIP-Archiv konnte nicht angelegt werden.');
+
+        $factory->create($this->temporaryDirectory);
+    }
+
+    /**
+     * @param  list<string>  $candidates
+     */
+    private function factoryWithCandidates(array $candidates): KompendiumRomanArchiveTemporaryFileFactory
+    {
+        return new class($candidates) extends KompendiumRomanArchiveTemporaryFileFactory
+        {
+            /**
+             * @param  list<string>  $candidates
+             */
+            public function __construct(private array $candidates) {}
+
+            protected function candidatePath(string $directory): string
+            {
+                return array_shift($this->candidates) ?? parent::candidatePath($directory);
+            }
+        };
+    }
+}

--- a/tests/Unit/KompendiumRomanArchiveWriterTest.php
+++ b/tests/Unit/KompendiumRomanArchiveWriterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\KompendiumRomanArchiveException;
+use App\Services\KompendiumRomanArchiveWriter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+#[CoversClass(KompendiumRomanArchiveWriter::class)]
+class KompendiumRomanArchiveWriterTest extends TestCase
+{
+    /** @var list<string> */
+    private array $temporaryPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryPaths as $path) {
+            if (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_writes_all_entries_with_requested_archive_paths(): void
+    {
+        $firstSource = $this->temporaryFile('Erster Inhalt');
+        $secondSource = $this->temporaryFile('Zweiter Inhalt');
+        $archivePath = $this->temporaryFile();
+
+        (new KompendiumRomanArchiveWriter)->write($archivePath, [
+            [
+                'sourcePath' => $firstSource,
+                'archivePath' => 'Maddrax - Die dunkle Zukunft der Erde/001 - Eins.txt',
+            ],
+            [
+                'sourcePath' => $secondSource,
+                'archivePath' => 'Mission Mars/001 - Zwei.txt',
+            ],
+        ]);
+
+        $zip = new ZipArchive;
+        $this->assertTrue($zip->open($archivePath));
+        $this->assertSame(2, $zip->numFiles);
+        $this->assertSame(
+            'Erster Inhalt',
+            $zip->getFromName('Maddrax - Die dunkle Zukunft der Erde/001 - Eins.txt'),
+        );
+        $this->assertSame('Zweiter Inhalt', $zip->getFromName('Mission Mars/001 - Zwei.txt'));
+        $this->assertTrue($zip->close());
+    }
+
+    public function test_rejects_directory_as_archive_path(): void
+    {
+        $this->expectException(KompendiumRomanArchiveException::class);
+        $this->expectExceptionMessage('Das ZIP-Archiv konnte nicht erstellt werden.');
+
+        (new KompendiumRomanArchiveWriter)->write(sys_get_temp_dir(), []);
+    }
+
+    public function test_rejects_missing_source_file(): void
+    {
+        $archivePath = $this->temporaryFile();
+        $missingSource = sys_get_temp_dir().'/kompendium-source-missing-'.bin2hex(random_bytes(8)).'.txt';
+
+        $this->expectException(KompendiumRomanArchiveException::class);
+        $this->expectExceptionMessage('Eine Roman-Datei konnte nicht zum ZIP-Archiv hinzugefügt werden.');
+
+        (new KompendiumRomanArchiveWriter)->write($archivePath, [[
+            'sourcePath' => $missingSource,
+            'archivePath' => 'Maddrax/001 - Fehlt.txt',
+        ]]);
+    }
+
+    private function temporaryFile(string $contents = ''): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'kompendium-test-');
+        $this->assertNotFalse($path);
+        $this->temporaryPaths[] = $path;
+
+        if ($contents !== '') {
+            $this->assertNotFalse(file_put_contents($path, $contents));
+        }
+
+        return $path;
+    }
+}

--- a/tests/Unit/KompendiumRomanFileValidatorTest.php
+++ b/tests/Unit/KompendiumRomanFileValidatorTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\KompendiumRoman;
+use App\Services\KompendiumRomanFileValidator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(KompendiumRomanFileValidator::class)]
+class KompendiumRomanFileValidatorTest extends TestCase
+{
+    public function test_accepts_expected_txt_path_for_known_series(): void
+    {
+        $roman = new KompendiumRoman([
+            'serie' => 'missionmars',
+            'dateiname' => '001 - Der rote Planet.txt',
+            'dateipfad' => 'romane/missionmars/001 - Der rote Planet.txt',
+        ]);
+
+        $this->assertTrue((new KompendiumRomanFileValidator)->hasValidStoragePath($roman));
+    }
+
+    #[DataProvider('invalidRomanFiles')]
+    public function test_rejects_unsafe_or_inconsistent_file_data(
+        string $serie,
+        string $dateiname,
+        string $dateipfad,
+    ): void {
+        $roman = new KompendiumRoman([
+            'serie' => $serie,
+            'dateiname' => $dateiname,
+            'dateipfad' => $dateipfad,
+        ]);
+
+        $this->assertFalse((new KompendiumRomanFileValidator)->hasValidStoragePath($roman));
+    }
+
+    public static function invalidRomanFiles(): array
+    {
+        return [
+            'unbekannte Serie' => ['unbekannt', '001 - Test.txt', 'romane/unbekannt/001 - Test.txt'],
+            'leerer Dateiname' => ['maddrax', '', 'romane/maddrax/'],
+            'falsche Endung' => ['maddrax', '001 - Test.html', 'romane/maddrax/001 - Test.html'],
+            'Slash' => ['maddrax', 'archiv/001 - Test.txt', 'romane/maddrax/archiv/001 - Test.txt'],
+            'Backslash' => ['maddrax', 'archiv\\001 - Test.txt', 'romane/maddrax/archiv\\001 - Test.txt'],
+            'Steuerzeichen' => ['maddrax', "001 - Test\n.txt", "romane/maddrax/001 - Test\n.txt"],
+            'abweichender Pfad' => ['maddrax', '001 - Test.txt', 'romane/missionmars/001 - Test.txt'],
+            'Traversal im Pfad' => ['maddrax', '001 - Test.txt', 'romane/maddrax/../001 - Test.txt'],
+        ];
+    }
+}

--- a/tests/e2e/kompendium-admin.spec.js
+++ b/tests/e2e/kompendium-admin.spec.js
@@ -164,6 +164,15 @@ test.describe('Kompendium Admin Dashboard', () => {
         await expect(page.getByRole('button', { name: 'Alle indexieren' })).toBeVisible();
         await expect(page.getByRole('button', { name: 'Alle de-indexieren' })).toBeVisible();
     });
+
+    test('shows the unfiltered ZIP download as a regular browser link', async ({ page }) => {
+        await page.goto('/kompendium/admin');
+
+        const downloadLink = page.getByTestId('download-all-novels');
+        await expect(downloadLink).toBeVisible();
+        await expect(downloadLink).toHaveAttribute('href', /\/kompendium\/admin\/romane\/herunterladen$/);
+        await expect(downloadLink).not.toHaveAttribute('wire:navigate', /.*/);
+    });
 });
 
 test.describe('Kompendium Public Page', () => {


### PR DESCRIPTION
This pull request introduces a new feature that enables administrators to download all "Kompendium" novels as a single ZIP archive. It adds a robust ZIP archive creation workflow with input validation, error handling, and temporary file management. To support this, the PR also ensures the PHP `zip` extension is available in all relevant environments and updates the UI to provide a download button for this functionality.

**New "Download All Novels as ZIP" Feature:**

* Added a new controller `KompendiumRomanArchiveDownloadController` that handles the creation and download of a ZIP archive containing all novels, with appropriate error handling and logging.
* Implemented supporting services for archive creation:
  - `KompendiumRomanArchiveService` manages the process, validates files, and handles errors.
  - `KompendiumRomanArchiveWriter` writes the ZIP file using the PHP ZipArchive extension.
  - `KompendiumRomanArchiveTemporaryFileFactory` creates secure temporary files for the archive.
  - `KompendiumRomanArchiveException` provides custom exception handling for archive operations.
  - `KompendiumRomanArchiveFile` is a value object representing the archive file.
* Added a new download button to the admin dashboard UI for triggering the ZIP export.
* Registered the new download route in `routes/web.php`.

**Refactoring and Validation Improvements:**

* Extracted file validation logic into a dedicated `KompendiumRomanFileValidator` service and updated the single-novel download controller to use it. [[1]](diffhunk://#diff-33c0b56e633f5c4733507e555e4043155f1fb00f4a86a14cb7060f21c07c55acL7-R17) [[2]](diffhunk://#diff-33c0b56e633f5c4733507e555e4043155f1fb00f4a86a14cb7060f21c07c55acL26-L44) [[3]](diffhunk://#diff-6a407ae02c47011378653df60a681d52eaf50619e29335c78ee939ead8d32382R1-R27)

**Dependency and Environment Updates:**

* Required the `ext-zip` PHP extension in `composer.json` and ensured it is installed in Dockerfiles and all GitHub Actions workflows for CI. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R29) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R25-R32) [[3]](diffhunk://#diff-62214a4393b520c35832b7e7b52e1f75189487e92dbe4d951333c4e9e0c8a6f0L4-R7) [[4]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3R24) [[5]](diffhunk://#diff-7cdd3ccec44c8ba176bdc3b9ef54c3f56aa210a1a4e2bb5f79d87b1e50314a18R37) [[6]](diffhunk://#diff-3a166e9011edd4edcb0ab3f0648dbf8861de3d7b7d9c426704df48ebf4f88f12R23) [[7]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L22-R22) [[8]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L59-R59) [[9]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L139-R139) [[10]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510R172) [[11]](diffhunk://#diff-ea12f60188cdd90bc99e5d0af2eb91647bbe4a9199176aa1ec5240f65efed510L230-R231) [[12]](diffhunk://#diff-c57924d2da76eb6198dd9af64dada827604e4ef9b27c1d74386be712ccc8416fL24-R24)